### PR TITLE
优化和查缺补漏

### DIFF
--- a/infoview.cpp
+++ b/infoview.cpp
@@ -183,9 +183,8 @@ void InfoView::increaseMonth(bool increase)
         m_yearSpinner->setValue(year);
     }
 
-    if (month != m_monthSpinner->value()) {
-        m_monthSpinner->setValue(month);
-    }
+    // fix by jscl: must be run
+    m_monthSpinner->setValue(month);
 }
 
 void InfoView::setTodayButtonVisible(bool visible) const

--- a/spinner.cpp
+++ b/spinner.cpp
@@ -66,6 +66,11 @@ int Spinner::value() const
 
 void Spinner::setValue(int value)
 {
+    // fix by jscl: when the year is 1900, and the month is January.
+    // click preBtn, the year will be 1899, 1899 < m_min(m_min=1900)
+    if (value <= m_min)
+        value = m_min;
+
     if (value != m_value) {
         m_value = value;
         m_label->setText(QString::number(m_value));

--- a/spinner.cpp
+++ b/spinner.cpp
@@ -79,28 +79,38 @@ void Spinner::setValue(int value)
 
 void Spinner::setPrevButtonDisabled(bool disabled) const
 {
-    m_prevButton->setDisabled(disabled);
-    if (disabled) {
-        m_prevButton->setHoverPic(":/resources/icon/previous_disabled.png");
-        m_prevButton->setNormalPic(":/resources/icon/previous_disabled.png");
-        m_prevButton->setPressPic(":/resources/icon/previous_disabled.png");
-    } else {
-        m_prevButton->setHoverPic(":/resources/icon/previous_hover.png");
-        m_prevButton->setNormalPic(":/resources/icon/previous_normal.png");
-        m_prevButton->setPressPic(":/resources/icon/previous_press.png");
+    // fix by jscl:do not load png everytime
+    if (m_preBtnState != disabled) {
+        m_prevButton->setDisabled(disabled);
+        if (disabled) {
+            m_prevButton->setHoverPic(":/resources/icon/previous_disabled.png");
+            m_prevButton->setNormalPic(":/resources/icon/previous_disabled.png");
+            m_prevButton->setPressPic(":/resources/icon/previous_disabled.png");
+        } else {
+            m_prevButton->setHoverPic(":/resources/icon/previous_hover.png");
+            m_prevButton->setNormalPic(":/resources/icon/previous_normal.png");
+            m_prevButton->setPressPic(":/resources/icon/previous_press.png");
+        }
+
+        m_preBtnState = disabled;
     }
 }
 
 void Spinner::setNextButtonDisabled(bool disabled) const
 {
-    m_nextButton->setDisabled(disabled);
-    if (disabled) {
-        m_nextButton->setHoverPic(":/resources/icon/next_disabled.png");
-        m_nextButton->setNormalPic(":/resources/icon/next_disabled.png");
-        m_nextButton->setPressPic(":/resources/icon/next_disabled.png");
-    } else {
-        m_nextButton->setHoverPic(":/resources/icon/next_hover.png");
-        m_nextButton->setNormalPic(":/resources/icon/next_normal.png");
-        m_nextButton->setPressPic(":/resources/icon/next_press.png");
+    // fix by jscl:do not load png everytime
+    if (m_nextBtnState != disabled) {
+        m_nextButton->setDisabled(disabled);
+        if (disabled) {
+            m_nextButton->setHoverPic(":/resources/icon/next_disabled.png");
+            m_nextButton->setNormalPic(":/resources/icon/next_disabled.png");
+            m_nextButton->setPressPic(":/resources/icon/next_disabled.png");
+        } else {
+            m_nextButton->setHoverPic(":/resources/icon/next_hover.png");
+            m_nextButton->setNormalPic(":/resources/icon/next_normal.png");
+            m_nextButton->setPressPic(":/resources/icon/next_press.png");
+        }
+
+        m_nextBtnState = disabled;
     }
 }

--- a/spinner.h
+++ b/spinner.h
@@ -52,6 +52,10 @@ private:
     int m_min = INT_MIN;
     int m_max = INT_MAX;
 
+    // add by jscl:do not load png everytime
+    bool m_preBtnState = true;
+    bool m_nextBtnState = true;
+
     void setPrevButtonDisabled(bool disabled) const;
     void setNextButtonDisabled(bool disabled) const;
 };


### PR DESCRIPTION
1.不需要每次都重新设置加载的图片，而且，disabled只有年在1900年是才会出现。
2.当时间是1900年1月时，再次点击上一个月，则变成1899年12月了。加了m_min判断后，时间会变成1900年12月，也不算是完美吧。

3.也是最重要的问题，我没有搭建起来环境，所以，程序没有编译和运行过，不好意思了！不过修改的都是简单的地方，应该没有错误。

4.还有一个问题，我不知怎么改好，告诉你问题吧，第一次进入后，不会显示当前日期的节日，点击其他日期后，再点击回到今日，节日才会出来。我怀疑是calendarwindow.cpp中的m_calendarView->setCurrentDate(QDate::currentDate());中的问题，我发现setCurrentDate中用到了没初始化的m_days[i]，可能这就是原因。
