### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-calendar.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-calendar.spec
+    - .packit.yaml
+
+upstream_package_name: dde-calendar
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-calendar
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-calendar.spec"

--- a/rpm/deepin-calendar.spec
+++ b/rpm/deepin-calendar.spec
@@ -1,0 +1,54 @@
+%global repo dde-calendar
+
+Name:           deepin-calendar
+Version:        5.7.0.19
+Release:        1%{?dist}
+Summary:        Calendar for Deepin Desktop Environment
+License:        GPLv3+
+URL:            https://github.com/linuxdeepin/dde-calendar
+Source0:        %{url}/archive/%{version}/%{repo}-%{version}.tar.gz
+
+BuildRequires:  cmake
+BuildRequires:  deepin-gettext-tools
+BuildRequires:  desktop-file-utils
+BuildRequires:  qt5-linguist
+BuildRequires:  pkgconfig(dtkwidget) >= 2.0
+BuildRequires:  pkgconfig(dframeworkdbus)
+BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt5DBus)
+BuildRequires:  pkgconfig(Qt5Gui)
+BuildRequires:  pkgconfig(Qt5Widgets)
+BuildRequires:  pkgconfig(Qt5Svg)
+BuildRequires:  pkgconfig(Qt5Multimedia)
+BuildRequires:  pkgconfig(Qt5X11Extras)
+Requires:       hicolor-icon-theme
+
+%description
+Calendar for Deepin Desktop Environment.
+
+%prep
+%autosetup -p1 -n %{repo}-%{version}
+
+%build
+# help find (and prefer) qt5 utilities, e.g. qmake, lrelease
+export PATH=%{_qt5_bindir}:$PATH
+%cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo
+%cmake_build
+
+%install
+%cmake_install
+install -m 644 -D assets/resources/icon/dde-calendar.svg ${RPM_BUILD_ROOT}%{_datadir}/icons/hicolor/scalable/apps/%{repo}.svg
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{repo}.desktop
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/%{repo}
+%{_datadir}/%{repo}/
+%{_datadir}/dbus-1/services/com.deepin.Calendar.service
+%{_datadir}/applications/%{repo}.desktop
+%{_datadir}/icons/hicolor/scalable/apps/%{repo}.svg
+
+%changelog


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log:

Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>