### PR TITLE
Add Keywords in dde-calendar.desktop file.

### DIFF
--- a/assets/dde-calendar.desktop
+++ b/assets/dde-calendar.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Categories=Application;Utility;Calendar;
+Keywords=calendar;date;deepin;dde;
 Comment=Calendar is a date tool.
 Exec=dde-calendar
 GenericName=Calendar


### PR DESCRIPTION
Fixes: desktop-entry-lacks-keywords-entry lintian error.