### PR TITLE
fix: avoid hardcoded exec path

### DIFF
--- a/calendar-service/src/csystemdtimercontrol.cpp
+++ b/calendar-service/src/csystemdtimercontrol.cpp
@@ -111,7 +111,7 @@ void CSystemdTimerControl::createPath()
 QString CSystemdTimerControl::execLinuxCommand(const QString &command)
 {
     QProcess process;
-    process.start("/bin/bash",QStringList()<<"-c"<<command);
+    process.start("bash",QStringList()<<"-c"<<command);
     process.waitForFinished();
     QString strResult = process.readAllStandardOutput();
     return strResult;
@@ -128,7 +128,7 @@ void CSystemdTimerControl::createService(const QString &name, const SystemDInfo 
     content += "[Unit]\n";
     content += "Description = schedule reminder task.\n";
     content += "[Service]\n";
-    content += QString("ExecStart = /bin/bash -c \"%1\"\n").arg(remindCMD);
+    content += QString("ExecStart = bash -c \"%1\"\n").arg(remindCMD);
     createFile(fileName,content);
 }
 

--- a/calendar-service/src/jobremindmanager.cpp
+++ b/calendar-service/src/jobremindmanager.cpp
@@ -76,7 +76,7 @@ void JobRemindManager::RemindJob(const Job &job)
                               .arg(job.RecurID);
             auto argMake = [&](int operationNum, const QString &text, const QString &transText) {
                 actionlist << text << transText;
-                hints.insert("x-deepin-action-" + text, QString("/bin/bash,-c,%1 int32:%2").arg(cmd).arg(operationNum));
+                hints.insert("x-deepin-action-" + text, QString("bash,-c,%1 int32:%2").arg(cmd).arg(operationNum));
             };
 
             QDateTime tm = QDateTime::currentDateTime();


### PR DESCRIPTION
Replace /bin/bash with bash in calendar-service/src/csystemdtimercontrol.cpp and calendar-service/src/jobremindmanager.cpp

Related: linuxdeepin/developer-center#3374

The commit message should be fixed now, please review the PR and merge if there are no outstanding issues.