### PR TITLE
feat: Remove caller checks for Huangli dbus interface

### DIFF
--- a/calendar-service/src/dbusservice/dhuangliservice.cpp
+++ b/calendar-service/src/dbusservice/dhuangliservice.cpp
@@ -21,9 +21,6 @@ DHuangliService::DHuangliService(QObject *parent)
 QString DHuangliService::getFestivalMonth(quint32 year, quint32 month)
 {
     DServiceExitControl exitControl;
-    if (!clientWhite(0)) {
-        return QString();
-    }
     QString festivalInfo = m_huangli->getFestivalMonth(year, month);
     return festivalInfo;
 }
@@ -35,9 +32,6 @@ QString DHuangliService::getHuangLiDay(quint32 year, quint32 month, quint32 day)
     if( 0 >= year || 0 >= month || 0 >= day)
         return "";
     DServiceExitControl exitControl;
-    if (!clientWhite(0)) {
-        return QString();
-    }
     QString huangliInfo = m_huangli->getHuangLiDay(year, month, day);
     return huangliInfo;
 }
@@ -46,9 +40,6 @@ QString DHuangliService::getHuangLiDay(quint32 year, quint32 month, quint32 day)
 QString DHuangliService::getHuangLiMonth(quint32 year, quint32 month, bool fill)
 {
     DServiceExitControl exitControl;
-    if (!clientWhite(0)) {
-        return QString();
-    }
     QString huangliInfo = m_huangli->getHuangLiMonth(year, month, fill);
     return huangliInfo;
 }
@@ -57,9 +48,6 @@ QString DHuangliService::getHuangLiMonth(quint32 year, quint32 month, bool fill)
 CaLunarDayInfo DHuangliService::getLunarInfoBySolar(quint32 year, quint32 month, quint32 day)
 {
     DServiceExitControl exitControl;
-    if (!clientWhite(0)) {
-        return CaLunarDayInfo();
-    }
     CaLunarDayInfo huangliInfo = m_huangli->getLunarInfoBySolar(year, month, day);
     return huangliInfo;
 }
@@ -68,9 +56,6 @@ CaLunarDayInfo DHuangliService::getLunarInfoBySolar(quint32 year, quint32 month,
 CaLunarMonthInfo DHuangliService::getLunarMonthCalendar(quint32 year, quint32 month, bool fill)
 {
     DServiceExitControl exitControl;
-    if (!clientWhite(0)) {
-        return CaLunarMonthInfo();
-    }
     CaLunarMonthInfo huangliInfo = m_huangli->getLunarCalendarMonth(year, month, fill);
     return huangliInfo;
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,21 @@
+dde-calendar (5.10.1) unstable; urgency=medium
+
+  * fix: remove illegal gcc option
+    Thanks to rewine
+  * chore(CI): Update obs tag build workflow
+  * feat: avoid use hardcode path
+    Thanks to rewine
+  * fix: use imcomplete class QDesktopWidget
+  * feat: Remove caller checks for Huangli dbus interface
+
+ -- myml <wurongjie@deepin.org>  Mon, 24 Jul 2023 14:30:45 +0800
+
 dde-calendar (5.10.0) unstable; urgency=medium
 
   * chore: deepin system does not support calendar sync
   * chore: correct a typo in CMakeLists.txt
 
- -- myml <wurongjie@deepin.com>  Thu, 6 Apr 2023 11:43:00 +0800
+ -- myml <wurongjie@deepin.org>  Thu, 6 Apr 2023 11:43:00 +0800
 
 
 dde-calendar (5.9.1) unstable; urgency=medium


### PR DESCRIPTION
移除黄历接口对调用者的检查
这些接口没必要限制外部调用
控制中心需要使用黄历接口获取节假日

Log: