### PR TITLE
feat: keep the json struct of getFestivalMonth

### DIFF
--- a/calendar-client/src/dbus/dbushuanglirequest.cpp
+++ b/calendar-client/src/dbus/dbushuanglirequest.cpp
@@ -41,15 +41,38 @@ bool DbusHuangLiRequest::getFestivalMonth(quint32 year, quint32 month, FestivalI
     // 解析数据
     QJsonArray rootarry = jsonDoc.array();
     for (int i = 0; i < rootarry.size(); i++) {
-        QJsonObject hsubObj = rootarry.at(i).toObject();
-        HolidayInfo dayinfo;
-        if (hsubObj.contains("status")) {
-            dayinfo.status = static_cast<char>(hsubObj.value("status").toInt());
+        QJsonObject subObj = rootarry.at(i).toObject();
+        // 因为是预先定义好的JSON数据格式，所以这里可以这样读取
+        if (subObj.contains("id")) {
+            festivalInfo.ID = subObj.value("id").toString();
         }
-        if (hsubObj.contains("date")) {
-            dayinfo.date = QDate::fromString(hsubObj.value("date").toString(), "yyyy-MM-dd");
+        if (subObj.contains("name")) {
+            festivalInfo.FestivalName = subObj.value("name").toString();
         }
-        festivalInfo.listHoliday.append(dayinfo);
+        if (subObj.contains("description")) {
+            festivalInfo.description = subObj.value("description").toString();
+        }
+        if (subObj.contains("rest")) {
+            festivalInfo.Rest = subObj.value("rest").toString();
+        }
+        if (subObj.contains("month")) {
+            festivalInfo.month = subObj.value("month").toInt();
+        }
+        if (subObj.contains("list")) {
+            QJsonArray sublistArray = subObj.value("list").toArray();
+            for (int j = 0; j < sublistArray.size(); j++) {
+                QJsonObject hsubObj = sublistArray.at(j).toObject();
+                HolidayInfo dayinfo;
+                if (hsubObj.contains("status")) {
+                    dayinfo.status = static_cast<char>(hsubObj.value("status").toInt());
+                }
+                if (hsubObj.contains("date")) {
+                    dayinfo.date = QDate::fromString(hsubObj.value("date").toString(), "yyyy-M-d");
+                }
+                festivalInfo.listHoliday.append(dayinfo);
+            }
+        }
+        festivalInfo.year = static_cast<int>(year);
     }
     return true;
 }

--- a/calendar-common/src/huangliData/lunardatastruct.h
+++ b/calendar-common/src/huangliData/lunardatastruct.h
@@ -16,10 +16,16 @@ typedef struct HuangLi {
 
 typedef struct _tagHolidayInfo {
     QDate date;
-    uint status; // 1: 休 2: 补班
+    char status {};
 } HolidayInfo;
 
 typedef struct _tagFestivalInfo {
+    QString ID {};
+    QString FestivalName {};
+    QString description {};
+    QString Rest {};
+    int month = 0;
+    int year = 0;
     QVector<HolidayInfo> listHoliday {};
 } FestivalInfo;
 

--- a/calendar-service/src/dbusservice/dhuangliservice.cpp
+++ b/calendar-service/src/dbusservice/dhuangliservice.cpp
@@ -18,13 +18,23 @@ DHuangliService::DHuangliService(QObject *parent)
 }
 
 // 获取指定公历月的假日信息
+// !这个接口 dde-daemon 在使用，不能变动!
 QString DHuangliService::getFestivalMonth(quint32 year, quint32 month)
 {
     DServiceExitControl exitControl;
-    auto arr = m_huangli->getFestivalMonth(year, month);
-    QJsonDocument result;
-    result.setArray(arr);
-    return result.toJson(QJsonDocument::Compact);
+    auto list = m_huangli->getFestivalMonth(year, month);
+    // 保持接口返回值兼容
+    QJsonArray result;
+    if (!list.empty()) {
+        QJsonObject obj;
+        obj.insert("id", list.at(0)["date"]);
+        obj.insert("description", "");
+        obj.insert("list", list);
+        result.push_back(obj);
+    }
+    QJsonDocument doc;
+    doc.setArray(result);
+    return doc.toJson(QJsonDocument::Compact);
 }
 
 // 获取指定公历日的黄历信息

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-calendar (5.12.1) unstable; urgency=medium
+
+  * fix: Unable sync schedule based on cloud sync
+  * feat: keep the json struct of getFestivalMonth
+
+ -- myml <wurongjie@deepin.org> Fri, 12 Jan 2024 17:47:37 +0800
+
 dde-calendar (5.12.0) unstable; urgency=medium
 
   * feat: add deepin-log config

--- a/debian/rules
+++ b/debian/rules
@@ -13,5 +13,6 @@ export QT_SELECT := 5
 override_dh_auto_configure:
 	dh_auto_configure -- \
 	  -DCMAKE_BUILD_TYPE=Release \
+	  -DSERVICE_INSTALL_DIR="/usr/lib/deepin-daemon"
 	  -DCMAKE_SAFETYTEST_ARG="CMAKE_SAFETYTEST_ARG_OFF" \
 	  -DAPP_VERSION=$(DEB_VERSION_UPSTREAM) -DVERSION=$(DEB_VERSION_UPSTREAM) LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH)


### PR DESCRIPTION
将 [chore: deepin system does not support calendar sync](https://github.com/linuxdeepin/dde-calendar/pull/146/commits/a297ad6668285a44f7e3471ebe0a033129964761) 合并到主线，这个提交之前是基于 5.10.1 更改的，用于修复专业版上的问题


dde-daemon会使用getFestivalMonth接口的数据配置自动关机, 需要保持接口兼容性，所以恢复了之前接口返回值结构变化