### PR TITLE
chore: Release 5.13.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+dde-calendar (5.13.0) unstable; urgency=medium
+
+  * feat: add metainfo of dde
+  * Reapply "feat: get general settings from Control Center"
+  * Reapply "chore: update translations"
+  * feat: add docs files
+  * feat: follow system config
+  * chore: update translations
+  * chore: update reuse
+  * chore: typo
+  * feat: auto update holiday data
+  * feat: get system setting from dbus
+  * feat: enable cloud sync
+
+ --myml <wurongjie@deepin.org>  Thu, 07 Mar 2024 13:54:33 +0800
+
 dde-calendar (5.12.1) unstable; urgency=medium
 
   * fix: Unable sync schedule based on cloud sync


### PR DESCRIPTION
在社区版启动云同步
在线定时更新节假日数据
通用设置支持跟随系统配置

Log: