### PR TITLE
fix: dialog window display position error

### DIFF
--- a/calendar-client/src/dialog/schedulectrldlg.cpp
+++ b/calendar-client/src/dialog/schedulectrldlg.cpp
@@ -7,6 +7,7 @@
 #include "scheduledatamanage.h"
 #include "cdynamicicon.h"
 #include "constants.h"
+#include <QTimer>
 
 #include <DMessageBox>
 #include <DPushButton>
@@ -135,8 +136,12 @@ void CScheduleCtrlDlg::changeEvent(QEvent *event)
             button->setText(text_button);
         }
     }
-    setFixedHeight(36 + 48 + height_firstLabel + height_seconLabel + 30);
-    gwi->setFixedHeight(height_firstLabel + height_seconLabel);
+    // 在changeEvent里使用setFixedHeight会导致弹出的确认对话框会显示在左上角
+    // 推测是窗口的问题, 先通过延迟在应用层临时解决
+    QTimer::singleShot(10, this, [this, height_firstLabel, height_seconLabel]{
+        setFixedHeight(36 + 48 + height_firstLabel + height_seconLabel + 30);
+        gwi->setFixedHeight(height_firstLabel + height_seconLabel);
+    });
 }
 
 void CScheduleCtrlDlg::buttonJudge(int id)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-calendar (5.14.3) unstable; urgency=medium
+
+  * fix: dialog window display position error(Issue: https://github.com/linuxdeepin/developer-center/issues/10141)
+
+ -- myml <wurongjie@deepin.org>  Mon, 05 Aug 2024 14:16:16 +0800
+
 dde-calendar (5.14.2) unstable; urgency=medium
 
   * chore: dbus activation adapt to AM(Issue: https://github.com/linuxdeepin/developer-center/issues/9742)


### PR DESCRIPTION
日历在日程右键删除时, 弹出的确认对话框会显示在左上角
目前推测是窗管的问题, 先在应用层的临时解决

Issues: https://github.com/linuxdeepin/developer-center/issues/10141