### PR TITLE
feat: Unable to set timer reminder in Linglong environment

### DIFF
--- a/calendar-service/src/csystemdtimercontrol.cpp
+++ b/calendar-service/src/csystemdtimercontrol.cpp
@@ -6,6 +6,7 @@
 
 #include "commondef.h"
 #include "units.h"
+#include <qloggingcategory.h>
 
 #include <QDir>
 #include <QStandardPaths>
@@ -231,8 +232,14 @@ void CSystemdTimerControl::stopUploadTask()
 void CSystemdTimerControl::createPath()
 {
     m_systemdPath = getHomeConfigPath().append("/systemd/user/");
+    // 如果位于玲珑环境, 更改systemd path路径
+    QString linglongAppID = qgetenv("LINGLONG_APPID");
+    if (!linglongAppID.isEmpty()) {
+        m_systemdPath = "/run/host/rootfs" + m_systemdPath;
+        qCInfo(ServiceLogger) << "In Linglong environment, change the systemd path to " << m_systemdPath;
+    }
     QDir dir;
-    //如果该路径不存在，则创建该文件夹
+    // 如果该路径不存在，则创建该文件夹
     if (!dir.exists(m_systemdPath)) {
         dir.mkpath(m_systemdPath);
     }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-calendar (5.14.4) unstable; urgency=medium
+
+  * feat: Unable to set timer reminder in Linglong environment
+
+ -- myml <wurongjie@deepin.org>  Thu, 08 Aug 2024 11:29:59 +0800
+
 dde-calendar (5.14.3) unstable; urgency=medium
 
   * fix: dialog window display position error(Issue: https://github.com/linuxdeepin/developer-center/issues/10141)


### PR DESCRIPTION
玲珑环境会将家目录config进行隔离, 无法在此创建systemd服务
检测玲珑环境并修正config路径位置

Log: