### PR TITLE
feat: cweekwidget uses locale to replace tr

### DIFF
--- a/calendar-client/src/customWidget/cweekwidget.cpp
+++ b/calendar-client/src/customWidget/cweekwidget.cpp
@@ -7,6 +7,7 @@
 #include "constants.h"
 #include <QLocale>
 #include <QPainter>
+#include <QDate>
 
 CWeekWidget::CWeekWidget(QWidget *parent) : QPushButton(parent)
   , m_firstDay(CalendarManager::getInstance()->getFirstDayOfWeek())
@@ -69,7 +70,10 @@ void CWeekWidget::paintEvent(QPaintEvent *event)
     }
 
     QStringList weekStr;
-    weekStr << tr("Sun") << tr("Mon") << tr("Tue") << tr("Wed") << tr("Thu") << tr("Fri") << tr("Sat");
+    for (auto i : { 7, 1, 2, 3, 4, 5, 6 }) {
+        QString weekDayName = locale.dayName(i, QLocale::NarrowFormat);
+        weekStr << weekDayName;
+    }
 
     //绘制周一到周日
     for (int i = Qt::Monday; i <= Qt::Sunday; ++i) {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+dde-calendar (5.14.9) UNRELEASED; urgency=medium
+
+  [ transifex-integration[bot] ]
+  * i18n: Translate dde-calendar_en_US.ts in ro
+  * i18n: Translate dde-calendar-service_en_US.ts in ro
+  * i18n: Translate dde-calendar_en_US.ts in sq
+  * i18n: Translate dde-calendar-service_en_US.ts in sq
+  * i18n: Translate dde-calendar-service_en_US.ts in zh_CN
+  * i18n: Removing dde-calendar-service_en_US.ts in zh_CN
+
+  [ myml ]
+  * feat: cweekwidget uses locale to replace tr
+
+ -- myml <wurongjie@deepin.org>  Sun, 29 Sep 2024 15:42:47 +0800
+
 dde-calendar (5.14.8) unstable; urgency=medium
 
   * chore: Update linglong build script.


### PR DESCRIPTION
cweekwidget组件使用locale.toString替换tr手动翻译
一来可以使用qt自己的翻译支持的语言更广泛, 且能减少翻译工作量
二来避免翻译人员在不知道显示场景下使用长翻译而不是缩写

Bug: https://pms.uniontech.com/bug-view-271483.html