### PR TITLE
fix: Workaround service send bus reply timeout issue

### DIFF
--- a/calendar-service/assets/data/com.dde.calendarserver.calendar.service
+++ b/calendar-service/assets/data/com.dde.calendarserver.calendar.service
@@ -5,7 +5,7 @@ Requires=dbus.socket
 
 [Service]
 Type = simple
-ExecStart = /bin/bash -c "dbus-send --session --print-reply --dest=com.deepin.dataserver.Calendar /com/deepin/dataserver/Calendar/AccountManager com.deepin.dataserver.Calendar.AccountManager.updateRemindJob boolean:false"
+ExecStart = /bin/bash -c "dbus-send --session --dest=com.deepin.dataserver.Calendar /com/deepin/dataserver/Calendar/AccountManager com.deepin.dataserver.Calendar.AccountManager.updateRemindJob boolean:false"
 
 [Install]
 WantedBy=user-session.target


### PR DESCRIPTION
Because of the linglong launch up very slowing when first time, then the timer send dbus to launcher calendar service will timeout(25s). In fact，it does not need to wait reply.

Log: Workaround service send dbus reply timeout issue.
Bug: https://pms.uniontech.com/bug-view-292535.html