### PR TITLE
chore: remove user documentation from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Execute `dde-calendar`
 ## Documentations
 
  - [Development Documentation](https://linuxdeepin.github.io/)
- - [User Documentation](https://wikidev.uniontech.com/index.php?title=%E7%94%BB%E6%9D%BF) 
 
 ## Getting help
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -59,7 +59,6 @@ $ sudo make install
 ## 文档
 
  - [Development Documentation](https://linuxdeepin.github.io/)
- - [用户文档](https://wikidev.uniontech.com/index.php?title=%E7%94%BB%E6%9D%BF)
 
 ## 帮助
 


### PR DESCRIPTION
用户文档的链接无法在外部使用, 并且是错误的地址, 暂时先删除