### PR TITLE
feat: Qt5 to Qt6 Migration

### DIFF
--- a/3rdparty/kcalendarcore/CMakeLists.txt
+++ b/3rdparty/kcalendarcore/CMakeLists.txt
@@ -3,23 +3,14 @@ project(kcalendarcore)
 
 # Find the library
 find_package(PkgConfig REQUIRED)
-find_package(Qt5Gui REQUIRED)
-find_package(Qt5 COMPONENTS
-    Core
-    DBus
-REQUIRED)
-
-#set(LibIcal_MIN_VERSION "3.0")
-#find_package(ical ${LibIcal_MIN_VERSION})
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui DBus)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
-pkg_check_modules(3rd_lib REQUIRED
-        libical
-        )
+pkg_check_modules(3rd_lib REQUIRED libical)
 
-#安全编译参数
+# 安全编译参数
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong -z noexecstack -pie -fPIC -z lazy")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src ${3rd_lib_INCLUDE_DIRS})
@@ -28,9 +19,9 @@ aux_source_directory(src CALENDARCORE_SRCS)
 add_library(${PROJECT_NAME} STATIC ${CALENDARCORE_SRCS})
 
 target_link_libraries(${PROJECT_NAME}
-    Qt5::Core
-    Qt5::DBus
-    Qt5::Gui
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::Gui
     ${3rd_lib_LIBRARIES}
     ${Libical_LIBRARIES}
     icalvcal

--- a/3rdparty/kcalendarcore/src/vcalformat.cpp
+++ b/3rdparty/kcalendarcore/src/vcalformat.cpp
@@ -334,13 +334,18 @@ Todo::Ptr VCalFormat::VTodoToEvent(VObject *vtodo)
                 recurrenceType = Recurrence::rWeekly;
             } else if (tmpStrLen > 1) {
                 recurrenceTypeAbbrLen = 2;
-                if (tmpStr.leftRef(2) == QLatin1String("MP")) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                auto prefix = QStringView(tmpStr).left(2);
+#else
+                auto prefix = tmpStr.leftRef(2);
+#endif
+                if (prefix == QLatin1String("MP")) {
                     recurrenceType = Recurrence::rMonthlyPos;
-                } else if (tmpStr.leftRef(2) == QLatin1String("MD")) {
+                } else if (prefix == QLatin1String("MD")) {
                     recurrenceType = Recurrence::rMonthlyDay;
-                } else if (tmpStr.leftRef(2) == QLatin1String("YM")) {
+                } else if (prefix == QLatin1String("YM")) {
                     recurrenceType = Recurrence::rYearlyMonth;
-                } else if (tmpStr.leftRef(2) == QLatin1String("YD")) {
+                } else if (prefix == QLatin1String("YD")) {
                     recurrenceType = Recurrence::rYearlyDay;
                 }
             }
@@ -350,7 +355,11 @@ Todo::Ptr VCalFormat::VTodoToEvent(VObject *vtodo)
             // Immediately after the type is the frequency
             int index = tmpStr.indexOf(QLatin1Char(' '));
             int last = tmpStr.lastIndexOf(QLatin1Char(' ')) + 1; // find last entry
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            int rFreq = QStringView(tmpStr).mid(recurrenceTypeAbbrLen, (index - 1)).toInt();
+#else
             int rFreq = tmpStr.midRef(recurrenceTypeAbbrLen, (index - 1)).toInt();
+#endif
             ++index; // advance to beginning of stuff after freq
 
             // Read the type-specific settings
@@ -485,7 +494,11 @@ Todo::Ptr VCalFormat::VTodoToEvent(VObject *vtodo)
             if (tmpStr.mid(index, 1) == QLatin1String("#")) {
                 // Nr of occurrences
                 index++;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                int rDuration = QStringView(tmpStr).mid(index, tmpStr.length() - index).toInt();
+#else
                 int rDuration = tmpStr.midRef(index, tmpStr.length() - index).toInt();
+#endif
                 if (rDuration > 0) {
                     anEvent->recurrence()->setDuration(rDuration);
                 }
@@ -769,13 +782,19 @@ Event::Ptr VCalFormat::VEventToEvent(VObject *vevent)
                 recurrenceType = Recurrence::rWeekly;
             } else if (tmpStrLen > 1) {
                 recurrenceTypeAbbrLen = 2;
-                if (tmpStr.leftRef(2) == QLatin1String("MP")) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                auto prefix = QStringView(tmpStr).left(2);
+#else
+                auto prefix = tmpStr.leftRef(2);
+#endif
+
+                if (prefix == QLatin1String("MP")) {
                     recurrenceType = Recurrence::rMonthlyPos;
-                } else if (tmpStr.leftRef(2) == QLatin1String("MD")) {
+                } else if (prefix == QLatin1String("MD")) {
                     recurrenceType = Recurrence::rMonthlyDay;
-                } else if (tmpStr.leftRef(2) == QLatin1String("YM")) {
+                } else if (prefix == QLatin1String("YM")) {
                     recurrenceType = Recurrence::rYearlyMonth;
-                } else if (tmpStr.leftRef(2) == QLatin1String("YD")) {
+                } else if (prefix == QLatin1String("YD")) {
                     recurrenceType = Recurrence::rYearlyDay;
                 }
             }
@@ -785,7 +804,11 @@ Event::Ptr VCalFormat::VEventToEvent(VObject *vevent)
             // Immediately after the type is the frequency
             int index = tmpStr.indexOf(QLatin1Char(' '));
             int last = tmpStr.lastIndexOf(QLatin1Char(' ')) + 1; // find last entry
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            int rFreq = QStringView(tmpStr).mid(recurrenceTypeAbbrLen, (index - 1)).toInt();
+#else
             int rFreq = tmpStr.midRef(recurrenceTypeAbbrLen, (index - 1)).toInt();
+#endif
             ++index; // advance to beginning of stuff after freq
 
             // Read the type-specific settings
@@ -920,7 +943,11 @@ Event::Ptr VCalFormat::VEventToEvent(VObject *vevent)
             if (tmpStr.mid(index, 1) == QLatin1String("#")) {
                 // Nr of occurrences
                 index++;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                int rDuration = QStringView(tmpStr).mid(index, tmpStr.length() - index).toInt();
+#else
                 int rDuration = tmpStr.midRef(index, tmpStr.length() - index).toInt();
+#endif
                 if (rDuration > 0) {
                     anEvent->recurrence()->setDuration(rDuration);
                 }
@@ -1210,16 +1237,26 @@ QDateTime VCalFormat::ISOToQDateTime(const QString &dtStr)
 {
     QDate tmpDate;
     QTime tmpTime;
-    QString tmpStr;
     int year, month, day, hour, minute, second;
 
-    tmpStr = dtStr;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QStringView tmpStr{dtStr};
+    year = tmpStr.left(4).toInt();
+    month = tmpStr.mid(4, 2).toInt();
+    day = tmpStr.mid(6, 2).toInt();
+    hour = tmpStr.mid(9, 2).toInt();
+    minute = tmpStr.mid(11, 2).toInt();
+    second = tmpStr.mid(13, 2).toInt();
+#else
+    QString tmpStr = dtStr;
     year = tmpStr.leftRef(4).toInt();
     month = tmpStr.midRef(4, 2).toInt();
     day = tmpStr.midRef(6, 2).toInt();
     hour = tmpStr.midRef(9, 2).toInt();
     minute = tmpStr.midRef(11, 2).toInt();
     second = tmpStr.midRef(13, 2).toInt();
+#endif
+
     tmpDate.setDate(year, month, day);
     tmpTime.setHMS(hour, minute, second);
 
@@ -1239,9 +1276,16 @@ QDate VCalFormat::ISOToQDate(const QString &dateStr)
 {
     int year, month, day;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QStringView tmpStr{dateStr};
+    year = tmpStr.left(4).toInt();
+    month = tmpStr.mid(4, 2).toInt();
+    day = tmpStr.mid(6, 2).toInt();
+#else
     year = dateStr.leftRef(4).toInt();
     month = dateStr.midRef(4, 2).toInt();
     day = dateStr.midRef(6, 2).toInt();
+#endif
 
     return QDate(year, month, day);
 }
@@ -1280,8 +1324,12 @@ bool VCalFormat::parseTZOffsetISO8601(const QString &s, int &result)
     if (str.size() < (ofs + 2)) {
         return false;
     }
-
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QStringView tmpStr{str};
+    v = tmpStr.mid(ofs, 2).toInt(&ok) * 60;
+#else
     v = str.midRef(ofs, 2).toInt(&ok) * 60;
+#endif
     if (!ok) {
         return false;
     }
@@ -1295,7 +1343,12 @@ bool VCalFormat::parseTZOffsetISO8601(const QString &s, int &result)
             if (str.size() < (ofs + 2)) {
                 return false;
             }
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            v += tmpStr.mid(ofs, 2).toInt(&ok);
+#else
             v += str.midRef(ofs, 2).toInt(&ok);
+#endif
             if (!ok) {
                 return false;
             }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,31 @@
 cmake_minimum_required(VERSION 3.7)
 project(dde-calendar)
 
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-   set(CMAKE_INSTALL_PREFIX /usr)
-endif ()
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX /usr)
+endif()
+
 include(GNUInstallDirs)
 
-#compile flags
-if (CMAKE_BUILD_TYPE MATCHES Debug)
+# check Qt version, support Qt5 default
+find_package(Qt6 QUIET)
+
+if(Qt6_FOUND)
+  set(SUPPORT_QT6 TRUE)
+  set(QT_VERSION_MAJOR 6)
+  set(DTK_VERSION_MAJOR 6)
+else()
+  set(QT_VERSION_MAJOR 5)
+endif()
+
+message(STATUS "--- Enable Qt6: ${ENABLE_Qt6} Current use Qt Version: ${QT_VERSION_MAJOR}")
+
+# compile flags
+if(CMAKE_BUILD_TYPE MATCHES Debug)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra")
-# Enable Qt builtin debug mode
+
+  # Enable Qt builtin debug mode
   add_definitions("-DQT_MESSAGELOGCONTEXT")
 else()
   # -Wl, -O2 Enable linker optimizations
@@ -20,21 +35,23 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O2 -Wl,--gc-sections")
 endif()
 
-#代码覆盖率开关
+# 代码覆盖率开关
 if(CMAKE_COVERAGE_ARG STREQUAL "CMAKE_COVERAGE_ARG_ON")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -fprofile-arcs -ftest-coverage")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -fprofile-arcs -ftest-coverage")
 endif()
 
 macro(SUBDIRLIST result curdir)
-    file(GLOB children RELATIVE ${curdir} ${curdir}/*)
-    set(dirlist "")
-    foreach(child ${children})
-        if(IS_DIRECTORY ${curdir}/${child})
-            LIST(APPEND dirlist ${child})
-        endif()
-    endforeach()
-    set(${result} ${dirlist})
+  file(GLOB children RELATIVE ${curdir} ${curdir}/*)
+  set(dirlist "")
+
+  foreach(child ${children})
+    if(IS_DIRECTORY ${curdir}/${child})
+      LIST(APPEND dirlist ${child})
+    endif()
+  endforeach()
+
+  set(${result} ${dirlist})
 endmacro()
 
 ADD_SUBDIRECTORY(3rdparty/kcalendarcore)
@@ -42,46 +59,54 @@ ADD_SUBDIRECTORY(calendar-common)
 ADD_SUBDIRECTORY(calendar-client)
 ADD_SUBDIRECTORY(calendar-service)
 ADD_SUBDIRECTORY(schedule-plugin)
-#ADD_SUBDIRECTORY(tests)
 
-#前后端都有翻译所以将翻译放到更高层级
-find_package(Qt5LinguistTools REQUIRED)
-#lupdate start
-#此处其实只有当没有自动翻译需要手动翻译.ts文件才有意义可以创建不同语言名称的ts文件，下同
-set(TS_FILES
-    "${CMAKE_CURRENT_SOURCE_DIR}/translations/${PROJECT_NAME}_en_US.ts"
-)
+# FIXME: Unit tests have not been maintained for a long time
+# ADD_SUBDIRECTORY(tests)
+
+# ##### Translation #####
+# There are translations on both the front and back ends, so take the translations to a higher level
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS LinguistTools)
+
+# In fact, it only makes sense to manually translate .ts files without automatic translation,
+# and you can create TS files with different language names, the same below
 find_program(LUPDATE_EXECUTABLE lupdate)
-foreach(_ts_file ${TS_FILES})
-    execute_process(
-        COMMAND ${LUPDATE_EXECUTABLE} -recursive ${CMAKE_CURRENT_SOURCE_DIR}/calendar-client -ts ${_ts_file})
-endforeach()
-
-set(TS_SERVICEFILES
-     "${CMAKE_CURRENT_SOURCE_DIR}/translations/${PROJECT_NAME}-service_en_US.ts"
-)
-foreach(_ts_file ${TS_SERVICEFILES})
-    execute_process(
-        COMMAND ${LUPDATE_EXECUTABLE} -recursive ${CMAKE_CURRENT_SOURCE_DIR}/calendar-service -ts ${_ts_file})
-endforeach()
-#lupdate end
-
-file (GLOB DTNG_TS_FILES translations/*.ts)
-
-#lrelease start
-#发布qm文件
 find_program(LRELEASE_EXECUTABLE lrelease)
-foreach(_ts_file ${DTNG_TS_FILES})
-        execute_process(COMMAND ${LRELEASE_EXECUTABLE}   ${_ts_file})
-endforeach()
-#lrelease end
+set(TS_FILES "${CMAKE_CURRENT_SOURCE_DIR}/translations/${PROJECT_NAME}_en_US.ts")
+set(TS_SERVICEFILES "${CMAKE_CURRENT_SOURCE_DIR}/translations/${PROJECT_NAME}-service_en_US.ts")
 
-qt5_create_translation(DTNG_QM_FILES
+foreach(_ts_file ${TS_FILES})
+  execute_process(
+    COMMAND ${LUPDATE_EXECUTABLE} -recursive ${CMAKE_CURRENT_SOURCE_DIR}/calendar-client -ts ${_ts_file})
+endforeach()
+
+foreach(_ts_file ${TS_SERVICEFILES})
+  execute_process(
+    COMMAND ${LUPDATE_EXECUTABLE} -recursive ${CMAKE_CURRENT_SOURCE_DIR}/calendar-service -ts ${_ts_file})
+endforeach()
+
+file(GLOB DTNG_TS_FILES translations/*.ts)
+
+foreach(_ts_file ${DTNG_TS_FILES})
+  execute_process(COMMAND ${LRELEASE_EXECUTABLE} ${_ts_file})
+endforeach()
+
+# lrelease end
+if(SUPPORT_QT6)
+  qt_create_translation(DTNG_QM_FILES
     ${DTNG_TS_FILES}
     ${DTNG_QM_FILES}
-)
-  
+  )
+else()
+  qt5_create_translation(DTNG_QM_FILES
+    ${DTNG_TS_FILES}
+    ${DTNG_QM_FILES}
+  )
+endif()
+
 file(GLOB APP_QM_FILES "translations/*.qm")
 install(FILES ${APP_QM_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/dde-calendar/translations)
+
+# ##### Translation end #####
+
 # 安装日志搜集工具的配置
 install(FILES "org.deepin.calendar.json" DESTINATION ${CMAKE_INSTALL_DATADIR}/deepin-log-viewer/deepin-log.conf.d/)

--- a/DDav/CMakeLists.txt
+++ b/DDav/CMakeLists.txt
@@ -3,10 +3,7 @@ project(kdav)
 
 # Find the library
 find_package(PkgConfig REQUIRED)
-find_package(Qt5 COMPONENTS
-    Core
-    DBus
-REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core DBus)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -17,7 +14,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong -z noexecstack 
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 aux_source_directory(src KDAV_SRCS)
-link_libraries(${Qt5CORE_LIBRARIES} ${Qt5DBus_LIBRARIES})
+link_libraries(Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::DBus)
 add_library(${PROJECT_NAME} STATIC ${KDAV_SRCS})
 
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,17 @@ _The **master** branch is current development branch, build dependencies may cha
 
 * debhelper-compat (=11)
 * cmake
-* deepin-gettext-tools
-* libdtkgui-dev (>= 5.5.17~)
-* libdtkwidget-dev (>= 5.5.17~)
-* libgtest-dev
-* libqt5svg5-dev
 * pkg-config
-* qtbase5-dev
-* qttools5-dev
-* qttools5-dev-tools
+* deepin-gettext-tools
+* libdtk6gui-dev
+* libdtk6widget-dev
+* qt6-base-dev
+* qt6-tools-dev
+* qt6-tools-dev-tools
+* qt6-svg-dev
+* libgtest-dev
+* libical-dev
+* libgcrypt20-dev
 
 ## Installation
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -10,15 +10,17 @@ _**master**分支是当前开发分支，编译依赖可能在未更新README.md
 
 * debhelper-compat (=11)
 * cmake
-* deepin-gettext-tools
-* libdtkgui-dev (>= 5.5.17~)
-* libdtkwidget-dev (>= 5.5.17~)
-* libgtest-dev
-* libqt5svg5-dev
 * pkg-config
-* qtbase5-dev
-* qttools5-dev
-* qttools5-dev-tools
+* deepin-gettext-tools
+* libdtk6gui-dev
+* libdtk6widget-dev
+* qt6-base-dev
+* qt6-tools-dev
+* qt6-tools-dev-tools
+* qt6-svg-dev
+* libgtest-dev
+* libical-dev
+* libgcrypt20-dev
 
 ## 安装
 

--- a/calendar-client/CMakeLists.txt
+++ b/calendar-client/CMakeLists.txt
@@ -1,11 +1,16 @@
 cmake_minimum_required(VERSION 3.7)
 
-if (NOT DEFINED VERSION)
-    message(WARNING "Not defined version, about dialog version set 5.10.0")
-    set(VERSION 5.10.0)
-endif ()
+if(NOT DEFINED VERSION)
+    if(SUPPORT_QT6)
+        set(VERSION 6.0.0)
+    else()
+        set(VERSION 5.10.0)
+    endif()
 
-#common resource names
+    message(WARNING "Not defined version, about dialog version set ${VERSION}")
+endif()
+
+# common resource names
 set(APP_RES_DIR "assets")
 set(APP_BIN_NAME "dde-calendar")
 set(APP_DESKTOP "${APP_RES_DIR}/dde-calendar.desktop")
@@ -21,38 +26,35 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--as-needed -fPIE")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
 
-
-if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw_64")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw_64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mieee")
-elseif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips64")
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -ftree-vectorize -march=loongson3a -mhard-float -mno-micromips -mno-mips16 -flax-vector-conversions -mloongson-ext2 -mloongson-mmi -Wl,--as-needed")
-endif ()
-
-#compile flags
-if (CMAKE_BUILD_TYPE MATCHES Debug)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra")
-
-  # Enable Qt builtin debug mode
-  add_definitions("-DQT_MESSAGELOGCONTEXT")
-else()
-  # -Wl, -O2 Enable linker optimizations
-  # -Wl, --gc-sections Remove unused code resulting from -fdsta-sections and
-  # -ffunction-sections
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -O2 -Wl,-O1 -Wl,--gc-sections")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O2 -Wl,-O1 -Wl,--gc-sections")
 endif()
 
-#安全编译参数
+# compile flags
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra")
+
+    # Enable Qt builtin debug mode
+    add_definitions("-DQT_MESSAGELOGCONTEXT")
+else()
+    # -Wl, -O2 Enable linker optimizations
+    # -Wl, --gc-sections Remove unused code resulting from -fdsta-sections and
+    # -ffunction-sections
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -O2 -Wl,-O1 -Wl,--gc-sections")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O2 -Wl,-O1 -Wl,--gc-sections")
+endif()
+
+# 安全编译参数
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong -z noexecstack -pie -fPIC -z lazy")
 
 configure_file(${APP_RES_DIR}/environments.h.in environments.h @ONLY)
-
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
-
 SUBDIRLIST(all_src ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-#Include all app own subdirectories
+# Include all app own subdirectories
 foreach(subdir ${all_src})
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/${subdir})
 endforeach()
@@ -60,37 +62,36 @@ endforeach()
 file(GLOB_RECURSE Calendar_SRC ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
 
 find_package(PkgConfig REQUIRED)
-find_package(DtkCore REQUIRED)
-find_package(Qt5Gui REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Svg REQUIRED)
-find_package(Qt5DBus REQUIRED)
-find_package(Qt5Svg REQUIRED)
-find_package(DtkWidget REQUIRED)
-find_package(DtkGui REQUIRED)
-find_package(Qt5Network REQUIRED)
+find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED Core Gui Widget)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets Svg DBus Network)
 
 set_source_files_properties(src/dbus/org.deepin.dde.ControlCenter.xml PROPERTIES CLASSNAME ControlCenterProxy)
-qt5_add_dbus_interface(Calendar_SRC src/dbus/org.deepin.dde.ControlCenter.xml controlCenterProxy)
 
-include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
+if(SUPPORT_QT6)
+    qt_add_dbus_interface(Calendar_SRC src/dbus/org.deepin.dde.ControlCenter.xml controlCenterProxy)
+    include_directories(${Qt6Gui_PRIVATE_INCLUDE_DIRS})
+else()
+    qt5_add_dbus_interface(Calendar_SRC src/dbus/org.deepin.dde.ControlCenter.xml controlCenterProxy)
+    include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
+endif()
+
 # Tell CMake to create the executable
 add_executable(${PROJECT_NAME} ${Calendar_SRC} ${APP_QRC})
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${DtkWidget_INCLUDE_DIRS} ${OBJECT_BINARY_DIR} ../calendar-common/src)
+target_include_directories(${PROJECT_NAME} PUBLIC ${OBJECT_BINARY_DIR} ../calendar-common/src)
 target_link_libraries(${PROJECT_NAME}
-    ${DtkWidget_LIBRARIES}
-    ${DtkCore_LIBRARIES}
-    ${DtkGui_LIBRARIES}
-    ${Qt5Widgets_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5DBus_LIBRARIES}
-    ${Qt5Network_LIBRARIES}
     commondata
+    Dtk${DTK_VERSION_MAJOR}::Core
+    Dtk${DTK_VERSION_MAJOR}::Gui
+    Dtk${DTK_VERSION_MAJOR}::Widget
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::Svg
+    Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::Network
 )
 
-#修改dbus服务文件
-set (EXEC_DDE_CALENDAR "${CMAKE_INSTALL_FULL_BINDIR}/${APP_BIN_NAME}" CACHE STRING "Command to execute dde-calendar")
+# 修改dbus服务文件
+set(EXEC_DDE_CALENDAR "${CMAKE_INSTALL_FULL_BINDIR}/${APP_BIN_NAME}" CACHE STRING "Command to execute dde-calendar")
 
 configure_file(${APP_SERVICE_IN} ${CMAKE_CURRENT_BINARY_DIR}/dbus/com.deepin.Calendar.service @ONLY)
 
@@ -98,7 +99,7 @@ configure_file(${APP_SERVICE_IN} ${CMAKE_CURRENT_BINARY_DIR}/dbus/com.deepin.Cal
 install(TARGETS dde-calendar DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(DIRECTORY ${APP_RES_DIR}/dde-calendar
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/deepin-manual/manual-assets/application/)
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/deepin-manual/manual-assets/application/)
 install(FILES ${APP_DESKTOP} DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dbus/com.deepin.Calendar.service DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/services)
 install(FILES assets/org.deepin.calendar.metainfo.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)

--- a/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp
+++ b/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp
@@ -50,8 +50,8 @@ void CColorPickerWidget::setColorHexLineEdit()
     //确认按钮初始置灰
     m_enterBtn->setDisabled(true);
     //输入框输入限制
-    QRegExp reg("^[0-9A-Fa-f]{6}$");
-    QValidator *validator = new QRegExpValidator(reg, m_colHexLineEdit->lineEdit());
+    QRegularExpression reg("^[0-9A-Fa-f]{6}$");
+    QValidator *validator = new QRegularExpressionValidator(reg, m_colHexLineEdit->lineEdit());
     m_colHexLineEdit->lineEdit()->setValidator(validator);
     setFocusProxy(m_colHexLineEdit);
 }
@@ -80,7 +80,7 @@ void CColorPickerWidget::initUI()
     m_wordLabel->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
     m_colHexLineEdit->setClearButtonEnabled(false); //不显示清空按钮
     QHBoxLayout *inputLayout = new QHBoxLayout;
-    inputLayout->setMargin(0);
+    inputLayout->setContentsMargins(0, 0, 0, 0);
     inputLayout->setSpacing(6);
     inputLayout->addWidget(m_wordLabel);
     inputLayout->addWidget(m_colHexLineEdit, 1);
@@ -92,7 +92,7 @@ void CColorPickerWidget::initUI()
     m_enterBtn->setText(tr("Save", "button"));
     m_enterBtn->setFixedSize(140, 36);
     QHBoxLayout *btnLayout = new QHBoxLayout;
-    btnLayout->setMargin(0);
+    btnLayout->setContentsMargins(0, 0, 0, 0);
     btnLayout->setSpacing(5);
     btnLayout->addWidget(m_cancelBtn);
     DVerticalLine *line = new DVerticalLine(this);
@@ -133,12 +133,14 @@ void CColorPickerWidget::slotHexLineEditChange(const QString &text)
 {
     QString lowerText = text.toLower();
     if (lowerText == text) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QRegularExpression rx("^[0-9a-f]{6}$");
+        m_enterBtn->setDisabled(!rx.match(lowerText).hasMatch());
+#else
         QRegExp rx("^[0-9a-f]{6}$");
-        if (rx.indexIn(lowerText) == -1) {
-            m_enterBtn->setDisabled(true);
-        } else {
-            m_enterBtn->setDisabled(false);
-        }
+        m_enterBtn->setDisabled(rx.indexIn(lowerText) == -1);
+#endif
+
     } else {
         m_colHexLineEdit->setText(lowerText);
     }

--- a/calendar-client/src/customWidget/colorseletorwidget.cpp
+++ b/calendar-client/src/customWidget/colorseletorwidget.cpp
@@ -162,9 +162,9 @@ void ColorSeletorWidget::initView()
     hLayout->addWidget(addColorBut);
     hLayout->addStretch(1);
 
-    m_colorLayout->setMargin(0);
+    m_colorLayout->setContentsMargins(0, 0, 0, 0);
     m_colorLayout->setSpacing(3);
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->setSpacing(3);
 
     this->setLayout(hLayout);

--- a/calendar-client/src/customWidget/cpushbutton.cpp
+++ b/calendar-client/src/customWidget/cpushbutton.cpp
@@ -21,7 +21,7 @@ CPushButton::CPushButton(QWidget *parent) : QWidget(parent)
 
     m_textLabel->setFixedSize(200,34);
     layoutAddType->setSpacing(0);
-    layoutAddType->setMargin(0);
+    layoutAddType->setContentsMargins(0, 0, 0, 0);
     layoutAddType->setAlignment(Qt::AlignLeft);
     m_iconButton = new DIconButton(this);
     m_iconButton->setFocusPolicy(Qt::NoFocus);

--- a/calendar-client/src/customWidget/customframe.cpp
+++ b/calendar-client/src/customWidget/customframe.cpp
@@ -149,7 +149,7 @@ void CustomFrame::paintEvent(QPaintEvent *e)
 
     if (!m_text.isEmpty()) {
         painter.save();
-        painter.setRenderHints(QPainter::HighQualityAntialiasing);
+        painter.setRenderHints(QPainter::Antialiasing);
         painter.setFont(m_font);
         painter.setPen(m_tnormalColor);
         painter.drawText(fillRect, m_textflag, m_text);

--- a/calendar-client/src/customWidget/labelwidget.cpp
+++ b/calendar-client/src/customWidget/labelwidget.cpp
@@ -25,7 +25,7 @@ void LabelWidget::paintEvent(QPaintEvent *ev)
         //有焦点，绘制焦点
         QStyleOptionFocusRect option;
         option.initFrom(this);
-        option.backgroundColor = palette().color(QPalette::Background);
+        option.backgroundColor = palette().color(QPalette::Window);
         style()->drawPrimitive(QStyle::PE_FrameFocusRect, &option, &painter, this);
     }
     QLabel::paintEvent(ev);

--- a/calendar-client/src/customWidget/monthbrefwidget.cpp
+++ b/calendar-client/src/customWidget/monthbrefwidget.cpp
@@ -22,7 +22,7 @@ MonthBrefWidget::MonthBrefWidget(QWidget *parent)
 {
     QGridLayout *gridLayout = new QGridLayout(this);
     gridLayout->setSpacing(0);
-    gridLayout->setMargin(0);
+    gridLayout->setContentsMargins(0, 0, 0, 0);
 
     for (int i = 0; i < DDEYearCalendar::RectSizeOfEveryMonth; ++i) {
         CMonthDayRectWidget *item = new CMonthDayRectWidget(m_globalData, this);
@@ -340,7 +340,11 @@ void CMonthDayRectWidget::paintEvent(QPaintEvent *event)
  * 鼠标进入事件
  * @param event
  */
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+void CMonthDayRectWidget::enterEvent(QEnterEvent *event)
+#else
 void CMonthDayRectWidget::enterEvent(QEvent *event)
+#endif
 {
     m_hovered = true;
     QWidget::enterEvent(event);

--- a/calendar-client/src/customWidget/monthbrefwidget.h
+++ b/calendar-client/src/customWidget/monthbrefwidget.h
@@ -145,7 +145,11 @@ protected:
     //绘制日期以及当天状态
     void paintEvent(QPaintEvent *event) override;
     //鼠标进入事件
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    void enterEvent(QEnterEvent *event) override;
+#else
     void enterEvent(QEvent *event) override;
+#endif
     //离开事件，设置当前选中的日期为空
     void leaveEvent(QEvent *event) override;
 

--- a/calendar-client/src/customWidget/scheduleview.cpp
+++ b/calendar-client/src/customWidget/scheduleview.cpp
@@ -20,7 +20,9 @@
 #include <QShortcut>
 #include <QVBoxLayout>
 #include <QApplication>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QDesktopWidget>
+#endif
 
 DGUI_USE_NAMESPACE
 
@@ -400,7 +402,7 @@ void CScheduleView::initUI()
 {
     m_layout = new QVBoxLayout;
     m_layout->setSpacing(0);
-    m_layout->setMargin(0);
+    m_layout->setContentsMargins(0, 0, 0, 0);
     m_alldaylist = new CAllDayEventWeekView(this, m_viewPos);
     m_layout->addWidget(m_alldaylist);
     m_layout->addSpacing(1);
@@ -483,10 +485,17 @@ void CScheduleView::slotScheduleShow(const bool isShow, const DSchedule::Ptr &ou
         //根据日程类型获取颜色
         CSchedulesColor gdColor = CScheduleDataManage::getScheduleDataManage()->getScheduleColorByType(
             out->scheduleTypeID());
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QScreen *screen = QGuiApplication::primaryScreen();
+        QRect screenGeometry = screen->geometry();
+#else
         QDesktopWidget *w = QApplication::desktop();
+        QRect screenGeometry = w->screenGeometry();
+#endif
         m_ScheduleRemindWidget->setData(out, gdColor);
 
-        if ((pos22.x() + m_ScheduleRemindWidget->width() + 15) > w->width()) {
+        if ((pos22.x() + m_ScheduleRemindWidget->width() + 15) > screenGeometry.width()) {
             m_ScheduleRemindWidget->setDirection(DArrowRectangle::ArrowRight);
             m_ScheduleRemindWidget->show(pos22.x() - 15, pos22.y());
         } else {

--- a/calendar-client/src/customWidget/timeedit.cpp
+++ b/calendar-client/src/customWidget/timeedit.cpp
@@ -4,7 +4,6 @@
 
 #include "timeedit.h"
 
-#include <QRegExpValidator>
 #include <QEvent>
 #include <QFocusEvent>
 #include <QPainter>
@@ -234,7 +233,7 @@ void CTimeEdit::paintEvent(QPaintEvent *e)
         QPainter painter(this);
         QStyleOptionFocusRect option;
         option.initFrom(this);
-        option.backgroundColor = palette().color(QPalette::Background);
+        option.backgroundColor = palette().color(QPalette::Window);
         style()->drawPrimitive(QStyle::PE_FrameFocusRect, &option, &painter, this);
     }
 }

--- a/calendar-client/src/dataManage/accountitem.cpp
+++ b/calendar-client/src/dataManage/accountitem.cpp
@@ -315,8 +315,8 @@ void AccountItem::deleteSchedulesByTypeID(const QString &typeID, CallbackFunc ca
 
 void AccountItem::querySchedulesWithParameter(const int year, CallbackFunc callback)
 {
-    QDateTime start = QDateTime(QDate(year, 1, 1));
-    QDateTime end = QDateTime(QDate(year, 12, 31));
+    QDateTime start(QDate(year, 1, 1), QTime(0, 0, 0));
+    QDateTime end(QDate(year, 12, 31), QTime(23, 59, 59));
     querySchedulesWithParameter(start, end, callback);
 }
 

--- a/calendar-client/src/dbus/dbusaccountmanagerrequest.cpp
+++ b/calendar-client/src/dbus/dbusaccountmanagerrequest.cpp
@@ -110,7 +110,7 @@ void DbusAccountManagerRequest::getAccountList()
  */
 void DbusAccountManagerRequest::downloadByAccountID(const QString &accountID)
 {
-    asyncCall("downloadByAccountID", QVariant(accountID));
+    asyncCall("downloadByAccountID", {QVariant(accountID)});
 }
 
 /**

--- a/calendar-client/src/dbus/dbusaccountrequest.cpp
+++ b/calendar-client/src/dbus/dbusaccountrequest.cpp
@@ -81,7 +81,7 @@ void DbusAccountRequest::getScheduleTypeList()
  */
 void DbusAccountRequest::getScheduleTypeByID(const QString &typeID)
 {
-    asyncCall("getScheduleTypeByID", QVariant(typeID));
+    asyncCall("getScheduleTypeByID", {QVariant(typeID)});
 }
 
 /**
@@ -93,7 +93,7 @@ void DbusAccountRequest::createScheduleType(const DScheduleType::Ptr &typeInfo)
 {
     QString jsonStr;
     DScheduleType::toJsonString(typeInfo, jsonStr);
-    asyncCall("createScheduleType", QVariant(jsonStr));
+    asyncCall("createScheduleType", {QVariant(jsonStr)});
 }
 
 /**
@@ -105,7 +105,7 @@ void DbusAccountRequest::updateScheduleType(const DScheduleType::Ptr &typeInfo)
 {
     QString jsonStr;
     DScheduleType::toJsonString(typeInfo, jsonStr);
-    asyncCall("updateScheduleType", QVariant(jsonStr));
+    asyncCall("updateScheduleType", {QVariant(jsonStr)});
 }
 
 /**
@@ -118,7 +118,7 @@ void DbusAccountRequest::updateScheduleTypeShowState(const DScheduleType::Ptr &t
     QString jsonStr;
     DScheduleType::toJsonString(typeInfo, jsonStr);
     QString callName = "updateScheduleTypeShowState";
-    asyncCall("updateScheduleType", callName, QVariant(jsonStr));
+    asyncCall("updateScheduleType", callName, {QVariant(jsonStr)});
 }
 
 /**
@@ -129,7 +129,7 @@ void DbusAccountRequest::updateScheduleTypeShowState(const DScheduleType::Ptr &t
 void DbusAccountRequest::deleteScheduleTypeByID(const QString &typeID)
 {
     QList<QVariant> argumentList;
-    asyncCall("deleteScheduleTypeByID", QVariant(typeID));
+    asyncCall("deleteScheduleTypeByID", {QVariant(typeID)});
 }
 
 /**
@@ -152,7 +152,7 @@ void DbusAccountRequest::createSchedule(const DSchedule::Ptr &scheduleInfo)
 {
     QString jsonStr;
     DSchedule::toJsonString(scheduleInfo, jsonStr);
-    asyncCall("createSchedule", QVariant(jsonStr));
+    asyncCall("createSchedule", {QVariant(jsonStr)});
 }
 
 /**
@@ -164,7 +164,7 @@ void DbusAccountRequest::updateSchedule(const DSchedule::Ptr &scheduleInfo)
 {
     QString jsonStr;
     DSchedule::toJsonString(scheduleInfo, jsonStr);
-    asyncCall("updateSchedule", QVariant(jsonStr));
+    asyncCall("updateSchedule", {QVariant(jsonStr)});
 }
 
 DSchedule::Ptr DbusAccountRequest::getScheduleByScheduleID(const QString &scheduleID)
@@ -194,7 +194,7 @@ DSchedule::Ptr DbusAccountRequest::getScheduleByScheduleID(const QString &schedu
 void DbusAccountRequest::deleteScheduleByScheduleID(const QString &scheduleID)
 {
     QList<QVariant> argumentList;
-    asyncCall("deleteScheduleByScheduleID", QVariant(scheduleID));
+    asyncCall("deleteScheduleByScheduleID", {QVariant(scheduleID)});
 }
 
 /**
@@ -205,7 +205,7 @@ void DbusAccountRequest::deleteScheduleByScheduleID(const QString &scheduleID)
 void DbusAccountRequest::deleteSchedulesByScheduleTypeID(const QString &typeID)
 {
     QList<QVariant> argumentList;
-    asyncCall("deleteSchedulesByScheduleTypeID", QVariant(typeID));
+    asyncCall("deleteSchedulesByScheduleTypeID", {QVariant(typeID)});
 }
 
 /**
@@ -222,12 +222,12 @@ void DbusAccountRequest::querySchedulesWithParameter(const DScheduleQueryPar::Pt
         m_priParams = params;
     }
     QString jsonStr = DScheduleQueryPar::toJsonString(params);
-    asyncCall("querySchedulesWithParameter", callName, QVariant(jsonStr));
+    asyncCall("querySchedulesWithParameter", callName, {QVariant(jsonStr)});
 }
 
 bool DbusAccountRequest::querySchedulesByExternal(const DScheduleQueryPar::Ptr &params, QString &json)
 {
-    QDBusPendingReply<QString> reply = call("querySchedulesWithParameter", QVariant(params));
+    QDBusPendingReply<QString> reply = call("querySchedulesWithParameter", QVariant::fromValue(params));
     if (reply.isError()) {
         qCWarning(ClientLogger) << reply.error().message();
         return false;
@@ -355,10 +355,10 @@ void DbusAccountRequest::onPropertiesChanged(const QString &, const QVariantMap 
 
 void DbusAccountRequest::importSchedule(QString icsFilePath, QString typeID, bool cleanExists)
 {
-    asyncCall("importSchedule", QVariant(icsFilePath), QVariant(typeID), QVariant(cleanExists));
+    asyncCall("importSchedule", {QVariant(icsFilePath), QVariant(typeID), QVariant(cleanExists)});
 }
 
 void DbusAccountRequest::exportSchedule(QString icsFilePath, QString typeID)
 {
-    asyncCall("exportSchedule", QVariant(icsFilePath), QVariant(typeID));
+    asyncCall("exportSchedule", {QVariant(icsFilePath), QVariant(typeID)});
 }

--- a/calendar-client/src/dbus/dbuscalendar_adaptor.h
+++ b/calendar-client/src/dbus/dbuscalendar_adaptor.h
@@ -12,7 +12,6 @@ class QByteArray;
 template<class T> class QList;
 template<class Key, class Value> class QMap;
 class QString;
-class QStringList;
 class QVariant;
 QT_END_NAMESPACE
 

--- a/calendar-client/src/dbus/dbushuanglirequest.cpp
+++ b/calendar-client/src/dbus/dbushuanglirequest.cpp
@@ -137,7 +137,7 @@ bool DbusHuangLiRequest::getHuangLiMonth(quint32 year,
  */
 void DbusHuangLiRequest::getLunarInfoBySolar(quint32 year, quint32 month, quint32 day)
 {
-    asyncCall("getLunarInfoBySolar", QVariant(year), QVariant(month), QVariant(day));
+    asyncCall("getLunarInfoBySolar", {QVariant(year), QVariant(month), QVariant(day)});
 }
 
 /**
@@ -149,7 +149,7 @@ void DbusHuangLiRequest::getLunarInfoBySolar(quint32 year, quint32 month, quint3
  */
 void DbusHuangLiRequest::getLunarMonthCalendar(quint32 year, quint32 month, bool fill)
 {
-    asyncCall("getLunarMonthCalendar", QVariant(year), QVariant(month), QVariant(fill));
+    asyncCall("getLunarMonthCalendar", {QVariant(year), QVariant(month), QVariant(fill)});
 }
 
 void DbusHuangLiRequest::slotCallFinished(CDBusPendingCallWatcher *call)

--- a/calendar-client/src/dbus/dbusrequestbase.cpp
+++ b/calendar-client/src/dbus/dbusrequestbase.cpp
@@ -32,7 +32,7 @@ void DbusRequestBase::setCallbackFunc(CallbackFunc func)
  */
 void DbusRequestBase::asyncCall(const QString &method, const QList<QVariant> &args)
 {
-    QDBusPendingCall async = QDBusAbstractInterface::asyncCall(method, args);
+    QDBusPendingCall async = QDBusAbstractInterface::asyncCallWithArgumentList(method, args);
     CDBusPendingCallWatcher *watcher = new CDBusPendingCallWatcher(async, method, this);
     //将回调函数放进CallWatcher中，随CallWatcher调用结果返回
     watcher->setCallbackFunc(m_callbackFunc);
@@ -41,30 +41,9 @@ void DbusRequestBase::asyncCall(const QString &method, const QList<QVariant> &ar
     connect(watcher, &CDBusPendingCallWatcher::signalCallFinished, this, &DbusRequestBase::slotCallFinished);
 }
 
-/**
- * @brief DbusRequestBase::asyncCall
- * 异步访问dbus接口
- * @param method    dbus方法名
- * @param args  参数
- */
-void DbusRequestBase::asyncCall(const QString &method,
-                                const QVariant &arg1, const QVariant &arg2, const QVariant &arg3, const QVariant &arg4,
-                                const QVariant &arg5, const QVariant &arg6, const QVariant &arg7, const QVariant &arg8)
+void DbusRequestBase::asyncCall(const QString &method, const QString &callName, const QList<QVariant> &args)
 {
-    asyncCall(method, method, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
-}
-
-/**
- * @brief DbusRequestBase::asyncCall
- * 异步访问dbus接口
- * @param method    dbus方法名
- * @param args  参数
- */
-void DbusRequestBase::asyncCall(const QString &method, const QString &callName,
-                                const QVariant &arg1, const QVariant &arg2, const QVariant &arg3, const QVariant &arg4,
-                                const QVariant &arg5, const QVariant &arg6, const QVariant &arg7, const QVariant &arg8)
-{
-    QDBusPendingCall async = QDBusAbstractInterface::asyncCall(method, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+    QDBusPendingCall async = QDBusAbstractInterface::asyncCallWithArgumentList(method, args);
     CDBusPendingCallWatcher *watcher = new CDBusPendingCallWatcher(async, callName, this);
     //将回调函数放进CallWatcher中，随CallWatcher调用结果返回
     watcher->setCallbackFunc(m_callbackFunc);

--- a/calendar-client/src/dbus/dbusrequestbase.h
+++ b/calendar-client/src/dbus/dbusrequestbase.h
@@ -33,25 +33,8 @@ public slots:
 
 protected:
     //异步调用，包装异步调用事件
-    void asyncCall(const QString &method, const QList<QVariant> &args);
-    void asyncCall(const QString &method,
-                   const QVariant &arg1 = QVariant(),
-                   const QVariant &arg2 = QVariant(),
-                   const QVariant &arg3 = QVariant(),
-                   const QVariant &arg4 = QVariant(),
-                   const QVariant &arg5 = QVariant(),
-                   const QVariant &arg6 = QVariant(),
-                   const QVariant &arg7 = QVariant(),
-                   const QVariant &arg8 = QVariant());
-    void asyncCall(const QString &method, const QString &callName,
-                   const QVariant &arg1 = QVariant(),
-                   const QVariant &arg2 = QVariant(),
-                   const QVariant &arg3 = QVariant(),
-                   const QVariant &arg4 = QVariant(),
-                   const QVariant &arg5 = QVariant(),
-                   const QVariant &arg6 = QVariant(),
-                   const QVariant &arg7 = QVariant(),
-                   const QVariant &arg8 = QVariant());
+    void asyncCall(const QString &method, const QList<QVariant> &args = {});
+    void asyncCall(const QString &method, const QString &callName, const QList<QVariant> &args = {});
 
 private:
     CallbackFunc m_callbackFunc = nullptr; //回调函数

--- a/calendar-client/src/dbus/exportedinterface.cpp
+++ b/calendar-client/src/dbus/exportedinterface.cpp
@@ -59,7 +59,7 @@ QVariant ExportedInterface::invoke(const QString &action, const QString &paramet
         //口查询日程
         if (gLocalAccountItem && gLocalAccountItem->querySchedulesByExternal(para.ADTitleName, para.ADStartTime, para.ADEndTime, out)) {
             //删除查询到的日程
-            QMap<QDate, DSchedule::List>::const_iterator _iterator = nullptr;
+            QMap<QDate, DSchedule::List>::const_iterator _iterator;
             for (_iterator = out.constBegin(); _iterator != out.constEnd(); ++_iterator) {
                 for (int i = 0 ; i < _iterator.value().size(); ++i) {
                     _scheduleOperation.deleteOnlyInfo(_iterator.value().at(i));

--- a/calendar-client/src/dialog/myscheduleview.cpp
+++ b/calendar-client/src/dialog/myscheduleview.cpp
@@ -268,7 +268,7 @@ void CMyScheduleView::initUI()
     m_Title->move(137, 0);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
-    mainLayout->setMargin(0);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->setSpacing(0);
 
     area = new QScrollArea(this);
@@ -276,7 +276,7 @@ void CMyScheduleView::initUI()
     area->setFocusPolicy(Qt::FocusPolicy::NoFocus);
     area->setFrameShape(QFrame::NoFrame);
     area->setFixedWidth(363);
-    area->setBackgroundRole(QPalette::Background);
+    area->setBackgroundRole(QPalette::Window);
     area->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
     area->setWidgetResizable(true);
     area->setAlignment(Qt::AlignCenter);
@@ -324,7 +324,7 @@ void CMyScheduleView::initUI()
     //获取widget的调色板
     DPalette centerWidgetPalette = centerWidget->palette();
     //设置背景色为透明
-    centerWidgetPalette.setColor(DPalette::Background, Qt::transparent);
+    centerWidgetPalette.setColor(DPalette::Window, Qt::transparent);
     centerWidget->setPalette(centerWidgetPalette);
     //添加窗口为剧中对齐
     addContent(centerWidget, Qt::AlignCenter);

--- a/calendar-client/src/dialog/schedulectrldlg.cpp
+++ b/calendar-client/src/dialog/schedulectrldlg.cpp
@@ -36,7 +36,7 @@ void CScheduleCtrlDlg::initUI()
     setIcon(t_icon);
 
     m_mainBoxLayout = new QVBoxLayout();
-    m_mainBoxLayout->setMargin(0);
+    m_mainBoxLayout->setContentsMargins(0, 0, 0, 0);
     m_mainBoxLayout->setSpacing(0);
 
     m_firstLabel = new QLabel();
@@ -67,10 +67,10 @@ void CScheduleCtrlDlg::initUI()
     DPalette anipa = gwi->palette();
     QColor color = "#F8F8F8";
     color.setAlphaF(0.0);
-    anipa.setColor(DPalette::Background, color);
+    anipa.setColor(DPalette::Window, color);
     gwi->setAutoFillBackground(true);
     gwi->setPalette(anipa);
-    gwi->setBackgroundRole(DPalette::Background);
+    gwi->setBackgroundRole(DPalette::Window);
     addContent(gwi, Qt::AlignCenter);
 }
 

--- a/calendar-client/src/dialog/scheduledlg.cpp
+++ b/calendar-client/src/dialog/scheduledlg.cpp
@@ -804,13 +804,13 @@ void CScheduleDlg::initUI()
     mlabelF.setWeight(QFont::Medium);
 
     QVBoxLayout *maintlayout = new QVBoxLayout;
-    maintlayout->setMargin(0);
+    maintlayout->setContentsMargins(0, 0, 0, 0);
     maintlayout->setSpacing(10);
     //帐户
     {
         QHBoxLayout *hlayout = new QHBoxLayout;
         hlayout->setSpacing(0);
-        hlayout->setMargin(0);
+        hlayout->setContentsMargins(0, 0, 0, 0);
 
         DLabel *aLabel = new DLabel(tr("Calendar account:"));
         aLabel->setToolTip(tr("Calendar account"));
@@ -838,7 +838,7 @@ void CScheduleDlg::initUI()
         //使用网格布局
         QGridLayout *typelayout = new QGridLayout;
         typelayout->setSpacing(0);
-        typelayout->setMargin(0);
+        typelayout->setContentsMargins(0, 0, 0, 0);
         m_typeLabel = new QLabel();
         m_typeLabel->setToolTip(tr("Type"));
         DFontSizeManager::instance()->bind(m_typeLabel, DFontSizeManager::T6);
@@ -873,7 +873,7 @@ void CScheduleDlg::initUI()
     {
         QHBoxLayout *contentLabellayout = new QHBoxLayout;
         contentLabellayout->setSpacing(0);
-        contentLabellayout->setMargin(0);
+        contentLabellayout->setContentsMargins(0, 0, 0, 0);
 
         m_contentLabel = new QLabel(this);
         DFontSizeManager::instance()->bind(m_contentLabel, DFontSizeManager::T6);
@@ -910,7 +910,7 @@ void CScheduleDlg::initUI()
     {
         QHBoxLayout *alldayLabellayout = new QHBoxLayout;
         alldayLabellayout->setSpacing(0);
-        alldayLabellayout->setMargin(0);
+        alldayLabellayout->setContentsMargins(0, 0, 0, 0);
         m_adllDayLabel = new QLabel(this);
         m_adllDayLabel->setToolTip(tr("All Day"));
         DFontSizeManager::instance()->bind(m_adllDayLabel, DFontSizeManager::T6);
@@ -958,7 +958,7 @@ void CScheduleDlg::initUI()
 
         QHBoxLayout *tLayout = new QHBoxLayout;
         tLayout->setSpacing(8);
-        tLayout->setMargin(0);
+        tLayout->setContentsMargins(0, 0, 0, 0);
         tLayout->addWidget(tLabel);
         tLayout->addWidget(m_solarRadioBtn);
         tLayout->addWidget(m_lunarRadioBtn);
@@ -976,7 +976,7 @@ void CScheduleDlg::initUI()
     {
         QHBoxLayout *beginLabellayout = new QHBoxLayout;
         beginLabellayout->setSpacing(0);
-        beginLabellayout->setMargin(0);
+        beginLabellayout->setContentsMargins(0, 0, 0, 0);
         m_beginTimeLabel = new QLabel(this);
         m_beginTimeLabel->setToolTip(tr("Starts"));
         DFontSizeManager::instance()->bind(m_beginTimeLabel, DFontSizeManager::T6);
@@ -1017,7 +1017,7 @@ void CScheduleDlg::initUI()
     {
         QHBoxLayout *enQLabellayout = new QHBoxLayout;
         enQLabellayout->setSpacing(0);
-        enQLabellayout->setMargin(0);
+        enQLabellayout->setContentsMargins(0, 0, 0, 0);
         m_endTimeLabel = new QLabel(this);
         m_endTimeLabel->setToolTip(tr("Ends"));
         DFontSizeManager::instance()->bind(m_endTimeLabel, DFontSizeManager::T6);
@@ -1058,7 +1058,7 @@ void CScheduleDlg::initUI()
     {
         QHBoxLayout *rminQLabellayout = new QHBoxLayout;
         rminQLabellayout->setSpacing(0);
-        rminQLabellayout->setMargin(0);
+        rminQLabellayout->setContentsMargins(0, 0, 0, 0);
         m_remindSetLabel = new QLabel();
         DFontSizeManager::instance()->bind(m_remindSetLabel, DFontSizeManager::T6);
         QFontMetrics fontWidth_remindSetLabel(mlabelF);
@@ -1089,7 +1089,7 @@ void CScheduleDlg::initUI()
     {
         QHBoxLayout *repeatLabellayout = new QHBoxLayout;
         repeatLabellayout->setSpacing(0);
-        repeatLabellayout->setMargin(0);
+        repeatLabellayout->setContentsMargins(0, 0, 0, 0);
         m_beginrepeatLabel = new QLabel();
         m_beginrepeatLabel->setToolTip(tr("Repeat"));
         DFontSizeManager::instance()->bind(m_beginrepeatLabel, DFontSizeManager::T6);
@@ -1124,7 +1124,7 @@ void CScheduleDlg::initUI()
     {
         QHBoxLayout *endrepeatLabellayout = new QHBoxLayout;
         endrepeatLabellayout->setSpacing(0);
-        endrepeatLabellayout->setMargin(0);
+        endrepeatLabellayout->setContentsMargins(0, 0, 0, 0);
         m_endrepeatLabel = new QLabel();
         DFontSizeManager::instance()->bind(m_endrepeatLabel, DFontSizeManager::T6);
         QFontMetrics fontWidth_endrepeatLabel(mlabelF);
@@ -1149,7 +1149,7 @@ void CScheduleDlg::initUI()
 
         QHBoxLayout *endrepeattimeslayout = new QHBoxLayout;
         endrepeattimeslayout->setSpacing(0);
-        endrepeattimeslayout->setMargin(0);
+        endrepeattimeslayout->setContentsMargins(0, 0, 0, 0);
         endrepeattimeslayout->setContentsMargins(0, 0, 0, 0);
         m_endrepeattimes = new DLineEdit(this);
         //设置对象名称和辅助显示名称
@@ -1158,8 +1158,8 @@ void CScheduleDlg::initUI()
         m_endrepeattimes->setFixedSize(71, item_Fixed_Height);
         m_endrepeattimes->setText(QString::number(10));
         m_endrepeattimes->setClearButtonEnabled(false);
-        QRegExp rx("^[1-9]\\d{0,2}$");
-        QValidator *validator = new QRegExpValidator(rx, this);
+        QRegularExpression rx("^[1-9]\\d{0,2}$");
+        QValidator *validator = new QRegularExpressionValidator(rx, this);
         m_endrepeattimes->lineEdit()->setValidator(validator);
         m_endrepeattimesLabel = new QLabel(tr("time(s)"));
         m_endrepeattimesLabel->setToolTip(tr("time(s)"));

--- a/calendar-client/src/dialog/settingdialog.cpp
+++ b/calendar-client/src/dialog/settingdialog.cpp
@@ -220,7 +220,7 @@ void CSettingDialog::initView()
             }
             if (wid->accessibleName().contains("DefaultWidgetAtContentRow")) {
                 //DefaultWidgetAtContentRow是设置对话框右边每一个option条目对应widget的accessibleName的前缀，所以如果后续有更多条目，需要做修改
-                wid->layout()->setMargin(0);
+                wid->layout()->setContentsMargins(0, 0, 0, 0);
             }
         }
     }

--- a/calendar-client/src/dialog/timejumpdialog.cpp
+++ b/calendar-client/src/dialog/timejumpdialog.cpp
@@ -34,7 +34,7 @@ void TimeJumpDialog::initView()
     m_jumpButton->setFixedSize(82, 36);
 
     QHBoxLayout *hLayout = new QHBoxLayout(this);
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->setSpacing(10);
 
     hLayout->addWidget(m_yearEdit);

--- a/calendar-client/src/main.cpp
+++ b/calendar-client/src/main.cpp
@@ -15,7 +15,6 @@
 #include <DApplication>
 #include <DLog>
 #include <DGuiApplicationHelper>
-#include <DApplicationSettings>
 
 #include <QDBusConnection>
 

--- a/calendar-client/src/widget/calendarmainwindow.cpp
+++ b/calendar-client/src/widget/calendarmainwindow.cpp
@@ -40,8 +40,10 @@
 #include <DSettingsWidgetFactory>
 #include <DBackgroundGroup>
 #include <DMessageManager>
-
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QDesktopWidget>
+#endif
+
 #include <QJsonDocument>
 #include <QJsonParseError>
 #include <QJsonObject>
@@ -269,28 +271,28 @@ void Calendarmainwindow::slotTheme(int type)
 
     if (type == 1) {
         DPalette anipa = m_contentBackground->palette();
-        anipa.setColor(DPalette::Background, "#F8F8F8");
+        anipa.setColor(DPalette::Window, "#F8F8F8");
         m_contentBackground->setPalette(anipa);
-        m_contentBackground->setBackgroundRole(DPalette::Background);
+        m_contentBackground->setBackgroundRole(DPalette::Window);
 
         DPalette tframepa = m_transparentFrame->palette();
         QColor tColor = "#FFFFFF";
         tColor.setAlphaF(0.3);
-        tframepa.setColor(DPalette::Background, tColor);
+        tframepa.setColor(DPalette::Window, tColor);
         m_transparentFrame->setPalette(tframepa);
-        m_transparentFrame->setBackgroundRole(DPalette::Background);
+        m_transparentFrame->setBackgroundRole(DPalette::Window);
     } else {
         DPalette anipa = m_contentBackground->palette();
-        anipa.setColor(DPalette::Background, "#252525");
+        anipa.setColor(DPalette::Window, "#252525");
         m_contentBackground->setPalette(anipa);
-        m_contentBackground->setBackgroundRole(DPalette::Background);
+        m_contentBackground->setBackgroundRole(DPalette::Window);
 
         DPalette tframepa = m_transparentFrame->palette();
         QColor tColor = "#000000";
         tColor.setAlphaF(0.3);
-        tframepa.setColor(DPalette::Background, tColor);
+        tframepa.setColor(DPalette::Window, tColor);
         m_transparentFrame->setPalette(tframepa);
-        m_transparentFrame->setBackgroundRole(DPalette::Background);
+        m_transparentFrame->setBackgroundRole(DPalette::Window);
     }
     CScheduleDataManage::getScheduleDataManage()->setTheMe(type);
     m_yearwindow->setTheMe(type);
@@ -398,7 +400,7 @@ void Calendarmainwindow::initUI()
     m_contentBackground->setObjectName("ScheduleSearchWidgetBackgroundFrame");
     m_contentBackground->setContentsMargins(0, 0, 0, 0);
     DPalette anipa = m_contentBackground->palette();
-    anipa.setColor(DPalette::Background, "#F8F8F8");
+    anipa.setColor(DPalette::Window, "#F8F8F8");
     m_contentBackground->setAutoFillBackground(true);
     m_contentBackground->setPalette(anipa);
 
@@ -408,7 +410,7 @@ void Calendarmainwindow::initUI()
     m_scheduleSearchView->setAccessibleDescription("Window showing search results");
 
     QVBoxLayout *ssLayout = new QVBoxLayout;
-    ssLayout->setMargin(0);
+    ssLayout->setContentsMargins(0, 0, 0, 0);
     ssLayout->setSpacing(0);
     ssLayout->addWidget(m_scheduleSearchView, 1);
     m_contentBackground->setLayout(ssLayout);
@@ -793,7 +795,11 @@ void Calendarmainwindow::slotDeleteitem()
 void Calendarmainwindow::slotSetMaxSize()
 {
     //获取屏幕大小
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QSize deskSize = QGuiApplication::primaryScreen()->size();
+#else
     QSize deskSize = QApplication::desktop()->size();
+#endif
     //设置最大尺寸为屏幕尺寸
     setMaximumSize(deskSize);
     if (TabletConfig::isTablet()) {

--- a/calendar-client/src/widget/dayWidget/dayhuangliview.cpp
+++ b/calendar-client/src/widget/dayWidget/dayhuangliview.cpp
@@ -18,7 +18,7 @@
 CDayHuangLiLabel::CDayHuangLiLabel(QWidget *parent)
     : DLabel(parent)
 {
-    setMargin(0);
+    setContentsMargins(0, 0, 0, 0);
 }
 
 void CDayHuangLiLabel::setbackgroundColor(QColor backgroundColor)
@@ -55,7 +55,7 @@ void CDayHuangLiLabel::paintEvent(QPaintEvent *e)
 
     QPainter painter(this);
     QRect fillRect = QRect(0, 0, labelwidth, labelheight);
-    painter.setRenderHints(QPainter::HighQualityAntialiasing);
+    painter.setRenderHints(QPainter::Antialiasing);
     painter.setBrush(QBrush(m_backgroundColor));
     painter.setPen(Qt::NoPen);
     painter.drawRoundedRect(fillRect, 12, 12);
@@ -68,7 +68,7 @@ void CDayHuangLiLabel::paintEvent(QPaintEvent *e)
     pixmap.setDevicePixelRatio(devicePixelRatioF());
     painter.save();
     painter.setRenderHint(QPainter::Antialiasing);
-    painter.setRenderHint(QPainter::HighQualityAntialiasing);
+    painter.setRenderHint(QPainter::Antialiasing);
     painter.setRenderHint(QPainter::SmoothPixmapTransform);
     painter.drawPixmap(QRect(m_leftMagin, m_topMagin + 1, 22, 22), pixmap);
     painter.restore();

--- a/calendar-client/src/widget/dayWidget/daymonthview.cpp
+++ b/calendar-client/src/widget/dayWidget/daymonthview.cpp
@@ -71,9 +71,9 @@ void CDayMonthView::setTheMe(int type)
     if (type == 0 || type == 1) {
         DPalette aniPa = this->palette();
         QColor tbColor = "#FFFFFF";
-        aniPa.setColor(DPalette::Background, tbColor);
+        aniPa.setColor(DPalette::Window, tbColor);
         setPalette(aniPa);
-        setBackgroundRole(DPalette::Background);
+        setBackgroundRole(DPalette::Window);
         setBColor(tbColor);
 
         QColor todayhover = "#000000";
@@ -119,9 +119,9 @@ void CDayMonthView::setTheMe(int type)
     } else if (type == 2) {
         DPalette aniPa = this->palette();
         QColor tbColor = "#282828";
-        aniPa.setColor(DPalette::Background, tbColor);
+        aniPa.setColor(DPalette::Window, tbColor);
         setPalette(aniPa);
-        setBackgroundRole(DPalette::Background);
+        setBackgroundRole(DPalette::Window);
         setBColor(tbColor);
 
         DPalette prevPalette = m_prevButton->palette();
@@ -197,7 +197,7 @@ void CDayMonthView::initUI()
     m_nextButton->setFixedSize(36, 36);
 
     QHBoxLayout *titleLayout = new QHBoxLayout;
-    titleLayout->setMargin(0);
+    titleLayout->setContentsMargins(0, 0, 0, 0);
     titleLayout->setSpacing(0);
     titleLayout->setContentsMargins(0, 0, 0, 3);
     //add separator line
@@ -216,7 +216,7 @@ void CDayMonthView::initUI()
 
     //上半部分
     m_upLayout = new QVBoxLayout;
-    m_upLayout->setMargin(0);
+    m_upLayout->setContentsMargins(0, 0, 0, 0);
     m_upLayout->setSpacing(0);
     m_upLayout->setContentsMargins(22, 9, 0, 7);
     m_upLayout->addLayout(titleLayout);
@@ -229,7 +229,7 @@ void CDayMonthView::initUI()
 
     //中间部分
     QVBoxLayout *midLayout = new QVBoxLayout;
-    midLayout->setMargin(0);
+    midLayout->setContentsMargins(0, 0, 0, 0);
     midLayout->setSpacing(0);
     midLayout->setContentsMargins(0, 0, 0, 20);
     m_currentDay = new CustomFrame(this);
@@ -291,7 +291,7 @@ void CDayMonthView::initUI()
     m_jiDownLayout->addWidget(m_jiLabel, 1);
 
     m_hhLayout = new QVBoxLayout;
-    m_hhLayout->setMargin(0);
+    m_hhLayout->setContentsMargins(0, 0, 0, 0);
     m_hhLayout->setSpacing(0);
     m_hhLayout->addLayout(m_upLayout, 6);
     m_hhLayout->addLayout(midLayout);
@@ -424,7 +424,7 @@ CDayMonthWidget::CDayMonthWidget(QWidget *parent)
     , m_isFocus(false)
 {
     m_gridLayout = new QGridLayout;
-    m_gridLayout->setMargin(0);
+    m_gridLayout->setContentsMargins(0, 0, 0, 0);
     m_gridLayout->setSpacing(0);
     m_dayNumFont.setPixelSize(DDECalendar::FontSizeTwelve);
     for (int r = 0; r < 6; ++r) {

--- a/calendar-client/src/widget/dayWidget/daymonthview.h
+++ b/calendar-client/src/widget/dayWidget/daymonthview.h
@@ -9,7 +9,6 @@
 #include "cweekwidget.h"
 
 #include <DWidget>
-#include <DImageButton>
 #include <DPushButton>
 #include <DFrame>
 #include <DIconButton>

--- a/calendar-client/src/widget/dayWidget/daywindow.cpp
+++ b/calendar-client/src/widget/dayWidget/daywindow.cpp
@@ -216,7 +216,7 @@ void CDayWindow::setLunarVisible(bool state)
 void CDayWindow::initUI()
 {
     QHBoxLayout *titleLayout = new QHBoxLayout;
-    titleLayout->setMargin(0);
+    titleLayout->setContentsMargins(0, 0, 0, 0);
     titleLayout->setSpacing(0);
     titleLayout->setContentsMargins(10, 9, 0, 3);
 
@@ -254,7 +254,7 @@ void CDayWindow::initUI()
     titleLayout->addStretch();
 
     QVBoxLayout *leftLayout = new QVBoxLayout;
-    leftLayout->setMargin(0);
+    leftLayout->setContentsMargins(0, 0, 0, 0);
     leftLayout->setSpacing(0);
     m_scheduleView = new CScheduleView(this, ScheduleViewPos::DayPos);
     m_scheduleView->setviewMargin(72, 109, 20, 0);
@@ -268,7 +268,7 @@ void CDayWindow::initUI()
     m_daymonthView = new CDayMonthView(this);
 
     QHBoxLayout *leftMainLayout = new QHBoxLayout;
-    leftMainLayout->setMargin(0);
+    leftMainLayout->setContentsMargins(0, 0, 0, 0);
     leftMainLayout->setSpacing(1);
     leftMainLayout->setContentsMargins(0, 0, 0, 0);
     leftMainLayout->addLayout(leftLayout);
@@ -285,7 +285,7 @@ void CDayWindow::initUI()
     m_leftground->setBColor("#FFFFFF");
 
     m_mainLayout = new QHBoxLayout;
-    m_mainLayout->setMargin(0);
+    m_mainLayout->setContentsMargins(0, 0, 0, 0);
     m_mainLayout->setSpacing(0);
     m_mainLayout->addWidget(m_leftground);
 

--- a/calendar-client/src/widget/monthWidget/monthdayview.cpp
+++ b/calendar-client/src/widget/monthWidget/monthdayview.cpp
@@ -24,7 +24,7 @@ CMonthDayView::CMonthDayView(QWidget *parent)
     , m_touchGesture(this)
 {
     QHBoxLayout *hBoxLayout = new QHBoxLayout;
-    hBoxLayout->setMargin(0);
+    hBoxLayout->setContentsMargins(0, 0, 0, 0);
     hBoxLayout->setSpacing(0);
     hBoxLayout->setContentsMargins(10, 0, 10, 0);
     m_monthWidget = new CMonthWidget(this);
@@ -68,9 +68,9 @@ void CMonthDayView::setTheMe(int type)
         frameColor.setAlphaF(0.05);
     }
     DPalette aniPa = palette();
-    aniPa.setColor(DPalette::Background, frameColor);
+    aniPa.setColor(DPalette::Window, frameColor);
     setPalette(aniPa);
-    setBackgroundRole(DPalette::Background);
+    setBackgroundRole(DPalette::Window);
     CMonthRect::setTheMe(type);
 }
 
@@ -415,7 +415,7 @@ void CMonthRect::paintItem(QPainter *painter, const QRectF &rect, bool drawFocus
             painter->setBrush(Qt::NoBrush);
             painter->drawEllipse(focusRect);
         }
-        painter->setRenderHint(QPainter::HighQualityAntialiasing);
+        painter->setRenderHint(QPainter::Antialiasing);
         painter->setPen(m_currentDayTextColor);
         painter->setFont(m_dayNumFont);
         painter->drawText(rect, Qt::AlignCenter, dayNum);

--- a/calendar-client/src/widget/monthWidget/monthview.cpp
+++ b/calendar-client/src/widget/monthWidget/monthview.cpp
@@ -15,7 +15,6 @@
 #include <QTime>
 #include <QApplication>
 #include <QMouseEvent>
-#include <QDesktopWidget>
 
 DGUI_USE_NAMESPACE
 
@@ -42,7 +41,7 @@ CMonthView::CMonthView(QWidget *parent) : DWidget(parent)
     connect(m_monthGraphicsView, &CMonthGraphicsview::signalGotoDayView, this, &CMonthView::signalsViewSelectDate);
     //新建最终布局
     m_mainLayout = new QVBoxLayout;
-    m_mainLayout->setMargin(0);
+    m_mainLayout->setContentsMargins(0, 0, 0, 0);
     m_mainLayout->setSpacing(0);
     m_mainLayout->addWidget(m_weekIndicator);
     m_mainLayout->addWidget(m_monthGraphicsView);

--- a/calendar-client/src/widget/monthWidget/monthwindow.cpp
+++ b/calendar-client/src/widget/monthWidget/monthwindow.cpp
@@ -63,9 +63,9 @@ void CMonthWindow::setTheMe(int type)
         m_YearLunarLabel->setForegroundRole(DPalette::WindowText);
 
         DPalette gpa = m_gridWidget->palette();
-        gpa.setColor(DPalette::Background, "#F8F8F8");
+        gpa.setColor(DPalette::Window, "#F8F8F8");
         m_gridWidget->setPalette(gpa);
-        m_gridWidget->setBackgroundRole(DPalette::Background);
+        m_gridWidget->setBackgroundRole(DPalette::Window);
     } else if (type == 2) {
 
 
@@ -79,9 +79,9 @@ void CMonthWindow::setTheMe(int type)
         m_YearLunarLabel->setForegroundRole(DPalette::WindowText);
 
         DPalette gpa = m_gridWidget->palette();
-        gpa.setColor(DPalette::Background, "#252525");
+        gpa.setColor(DPalette::Window, "#252525");
         m_gridWidget->setPalette(gpa);
-        m_gridWidget->setBackgroundRole(DPalette::Background);
+        m_gridWidget->setBackgroundRole(DPalette::Window);
     }
     m_monthDayView->setTheMe(type);
     m_monthView->setTheMe(type);
@@ -256,14 +256,14 @@ void CMonthWindow::initUI()
     m_monthDayView = new CMonthDayView(this);
 
     QHBoxLayout *yeartitleLayout = new QHBoxLayout;
-    yeartitleLayout->setMargin(0);
+    yeartitleLayout->setContentsMargins(0, 0, 0, 0);
     yeartitleLayout->setSpacing(0);
     yeartitleLayout->addSpacing(10);
     yeartitleLayout->addWidget(m_YearLabel);
     yeartitleLayout->addWidget(m_dialogIconButton);
 
     QHBoxLayout *yeartitleLayout1 = new QHBoxLayout;
-    yeartitleLayout1->setMargin(0);
+    yeartitleLayout1->setContentsMargins(0, 0, 0, 0);
     yeartitleLayout1->setSpacing(0);
 
     yeartitleLayout1->addWidget(m_YearLunarLabel);
@@ -280,13 +280,13 @@ void CMonthWindow::initUI()
     m_monthView->setAccessibleName("monthViewWidget");
     m_monthView->setCurrentDate(getCurrendDateTime().date());
     QVBoxLayout *mhLayout = new QVBoxLayout;
-    mhLayout->setMargin(0);
+    mhLayout->setContentsMargins(0, 0, 0, 0);
     mhLayout->setSpacing(0);
     mhLayout->addWidget(m_monthView);
 
     QVBoxLayout *hhLayout = new QVBoxLayout;
     hhLayout->setSpacing(0);
-    hhLayout->setMargin(0);
+    hhLayout->setContentsMargins(0, 0, 0, 0);
 
     //头部控件统一高度为 M_YTopHeight
     QWidget *top = new QWidget(this);
@@ -301,12 +301,12 @@ void CMonthWindow::initUI()
     hhLayout->addWidget(m_gridWidget);
 
     m_tMainLayout = new QHBoxLayout;
-    m_tMainLayout->setMargin(0);
+    m_tMainLayout->setContentsMargins(0, 0, 0, 0);
     m_tMainLayout->setSpacing(0);
     m_tMainLayout->addLayout(hhLayout);
 
     QVBoxLayout *ssLayout = new QVBoxLayout;
-    ssLayout->setMargin(0);
+    ssLayout->setContentsMargins(0, 0, 0, 0);
     ssLayout->setSpacing(0);
     m_tMainLayout->addLayout(ssLayout);
 

--- a/calendar-client/src/widget/schedulesearchview.cpp
+++ b/calendar-client/src/widget/schedulesearchview.cpp
@@ -370,8 +370,11 @@ void CScheduleSearchItem::mouseReleaseEvent(QMouseEvent *event)
     }
     DLabel::mouseReleaseEvent(event);
 }
-
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+void CScheduleSearchItem::enterEvent(QEnterEvent *event)
+#else
 void CScheduleSearchItem::enterEvent(QEvent *event)
+#endif
 {
     DLabel::enterEvent(event);
     m_mouseStatus = M_HOVER;
@@ -645,7 +648,7 @@ void CScheduleSearchView::updateDateShow()
         gwi->setText(tr("No search results"));
         gwi->setFixedSize(m_maxWidth - 20, 450);
         listItem->setSizeHint(QSize(m_maxWidth - 20, 450)); //每次改变Item的高度
-        listItem->setFlags(Qt::ItemIsTristate);
+        listItem->setFlags(Qt::ItemIsAutoTristate);
         m_gradientItemList->addItem(listItem);
         m_gradientItemList->setItemWidget(listItem, gwi);
         m_labellist.append(gwi);
@@ -691,7 +694,7 @@ void CScheduleSearchView::createItemWidget(DSchedule::Ptr info, QDate date, int 
 
     QListWidgetItem *listItem = new QListWidgetItem;
     listItem->setSizeHint(QSize(m_maxWidth - 15, 36)); //每次改变Item的高度
-    listItem->setFlags(Qt::ItemIsTristate);
+    listItem->setFlags(Qt::ItemIsAutoTristate);
     m_gradientItemList->addItem(listItem);
     m_gradientItemList->setItemWidget(listItem, gwi);
     m_labellist.append(gwi);
@@ -717,7 +720,7 @@ QListWidgetItem *CScheduleSearchView::createItemWidget(QDate date)
             &CScheduleSearchView::signalScheduleHide);
     QListWidgetItem *listItem = new QListWidgetItem;
     listItem->setSizeHint(QSize(m_maxWidth - 15, 36)); //每次改变Item的高度
-    listItem->setFlags(Qt::ItemIsTristate);
+    listItem->setFlags(Qt::ItemIsAutoTristate);
     m_gradientItemList->addItem(listItem);
     m_gradientItemList->setItemWidget(listItem, gwi);
     m_labellist.append(gwi);

--- a/calendar-client/src/widget/schedulesearchview.h
+++ b/calendar-client/src/widget/schedulesearchview.h
@@ -132,7 +132,11 @@ protected:
     void mouseDoubleClickEvent(QMouseEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    void enterEvent(QEnterEvent *event) override;
+#else
     void enterEvent(QEvent *event) override;
+#endif
     void leaveEvent(QEvent *event) override;
     bool eventFilter(QObject *o, QEvent *e) override;
     void focusInEvent(QFocusEvent *e) override;

--- a/calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp
+++ b/calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp
@@ -42,7 +42,7 @@ void SidebarCalendarWidget::initView()
     m_previousPage->setFocusPolicy(Qt::NoFocus);
 
     QHBoxLayout *headLayout = new QHBoxLayout();
-    headLayout->setMargin(0);
+    headLayout->setContentsMargins(0, 0, 0, 0);
     headLayout->setAlignment(Qt::AlignCenter);
     headLayout->addWidget(m_previousPage);
     headLayout->addWidget(m_dateLabel);
@@ -58,7 +58,7 @@ void SidebarCalendarWidget::initView()
 
     m_keyWidget = new QWidget(this);
     m_keyLayout = new QGridLayout();
-    m_keyLayout->setMargin(0);
+    m_keyLayout->setContentsMargins(0, 0, 0, 0);
     m_keyLayout->setSpacing(0);
     m_keyWidget->setLayout(m_keyLayout);
     //循坏实例化6*7个日期按键
@@ -71,7 +71,7 @@ void SidebarCalendarWidget::initView()
     }
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
-    mainLayout->setMargin(0);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
     this->setLayout(mainLayout);
     mainLayout->addSpacing(6);
     mainLayout->addWidget(m_headWidget);

--- a/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp
+++ b/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp
@@ -165,7 +165,7 @@ SidebarAccountItemWidget::SidebarAccountItemWidget(AccountItem::Ptr ptr, QWidget
 void SidebarAccountItemWidget::initView()
 {
     QHBoxLayout *hLayout = new QHBoxLayout(this);
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->setSpacing(0);
     m_headIconButton = new DIconButton(this);
     m_headIconButton->setFlat(true);

--- a/calendar-client/src/widget/sidebarWidget/sidebarview.cpp
+++ b/calendar-client/src/widget/sidebarWidget/sidebarview.cpp
@@ -32,7 +32,7 @@ void SidebarView::initView()
 
     // 设置底色透明，否则展开/收起出现背景色
     QPalette pal = m_treeWidget->palette();
-    pal.setBrush(QPalette::Background, QBrush(QColor(255, 255, 255, 0)));
+    pal.setBrush(QPalette::Window, QBrush(QColor(255, 255, 255, 0)));
     m_treeWidget->setPalette(pal);
 
     m_treeWidget->setItemDelegate(delegate);

--- a/calendar-client/src/widget/weekWidget/weekheadview.cpp
+++ b/calendar-client/src/widget/weekWidget/weekheadview.cpp
@@ -35,7 +35,7 @@ CWeekHeadView::CWeekHeadView(QWidget *parent)
 
     // cells grid
     QHBoxLayout *hBoxLayout = new QHBoxLayout;
-    hBoxLayout->setMargin(0);
+    hBoxLayout->setContentsMargins(0, 0, 0, 0);
     hBoxLayout->setSpacing(0);
 
     m_monthLabel = new CustomFrame(this);

--- a/calendar-client/src/widget/weekWidget/weekview.cpp
+++ b/calendar-client/src/widget/weekWidget/weekview.cpp
@@ -28,7 +28,7 @@ CWeekView::CWeekView(const GetWeekNumOfYear &getWeekNumOfYear, QWidget *parent)
     , m_weekNumWidget(nullptr)
 {
     QHBoxLayout *hBoxLayout = new QHBoxLayout;
-    hBoxLayout->setMargin(0);
+    hBoxLayout->setContentsMargins(0, 0, 0, 0);
     hBoxLayout->setSpacing(0);
 
     //上一周按钮
@@ -149,7 +149,7 @@ CWeekNumWidget::CWeekNumWidget(const GetWeekNumOfYear &getWeekNumOfYear, QWidget
 
     QHBoxLayout *hBoxLayout = new QHBoxLayout;
     hBoxLayout->setSpacing(0);
-    hBoxLayout->setMargin(0);
+    hBoxLayout->setContentsMargins(0, 0, 0, 0);
     //显示周数的widget
     for (int c = 0; c != DDEWeekCalendar::NumWeeksDisplayed; ++c) {
         QWidget *cell = new QWidget;

--- a/calendar-client/src/widget/weekWidget/weekwindow.cpp
+++ b/calendar-client/src/widget/weekWidget/weekwindow.cpp
@@ -98,14 +98,14 @@ void CWeekWindow::initUI()
     m_YearLunarLabel->setPalette(YearLpa);
 
     QHBoxLayout *yeartitleLayout = new QHBoxLayout;
-    yeartitleLayout->setMargin(0);
+    yeartitleLayout->setContentsMargins(0, 0, 0, 0);
     yeartitleLayout->setSpacing(0);
     yeartitleLayout->addSpacing(10);
     yeartitleLayout->addWidget(m_YearLabel);
     yeartitleLayout->addWidget(m_dialogIconButton);
 
     QHBoxLayout *yeartitleLayout1 = new QHBoxLayout;
-    yeartitleLayout1->setMargin(0);
+    yeartitleLayout1->setContentsMargins(0, 0, 0, 0);
     yeartitleLayout1->setSpacing(0);
     yeartitleLayout1->addWidget(m_YearLunarLabel);
     yeartitleLayout->addSpacing(6);
@@ -119,7 +119,7 @@ void CWeekWindow::initUI()
     m_todayframe->setFixedHeight(DDEYearCalendar::Y_MLabelHeight);
     m_todayframe->setboreder(1);
     QHBoxLayout *todaylayout = new QHBoxLayout;
-    todaylayout->setMargin(0);
+    todaylayout->setContentsMargins(0, 0, 0, 0);
     todaylayout->setSpacing(0);
     //将显示周数的view加入布局
     todaylayout->addWidget(m_weekview);
@@ -138,12 +138,12 @@ void CWeekWindow::initUI()
     m_scheduleView->setRange(763, 1032, QDate(2019, 8, 12), QDate(2019, 8, 18));
 
     m_mainHLayout = new QVBoxLayout;
-    m_mainHLayout->setMargin(0);
+    m_mainHLayout->setContentsMargins(0, 0, 0, 0);
     m_mainHLayout->setSpacing(0);
     m_mainHLayout->addWidget(m_weekHeadView, 1);
     m_mainHLayout->addWidget(m_scheduleView, 9);
     QVBoxLayout *hhLayout = new QVBoxLayout;
-    hhLayout->setMargin(0);
+    hhLayout->setContentsMargins(0, 0, 0, 0);
     hhLayout->setSpacing(0);
     //头部控件统一高度为 M_YTopHeight
     QWidget *top = new QWidget(this);
@@ -153,7 +153,7 @@ void CWeekWindow::initUI()
     hhLayout->addLayout(m_mainHLayout);
 
     m_tMainLayout = new QHBoxLayout;
-    m_tMainLayout->setMargin(0);
+    m_tMainLayout->setContentsMargins(0, 0, 0, 0);
     m_tMainLayout->setSpacing(0);
     m_tMainLayout->addLayout(hhLayout);
 

--- a/calendar-client/src/widget/yearWidget/yearview.cpp
+++ b/calendar-client/src/widget/yearWidget/yearview.cpp
@@ -38,7 +38,7 @@ CYearView::CYearView(QWidget *parent)
     m_currentMouth->setTextFont(m_momthFont);
 
     QHBoxLayout *separatorLineLayout = new QHBoxLayout;
-    separatorLineLayout->setMargin(0);
+    separatorLineLayout->setContentsMargins(0, 0, 0, 0);
     separatorLineLayout->setSpacing(0);
     separatorLineLayout->setContentsMargins(0, 0, 0, 0);
     separatorLineLayout->addWidget(m_currentMouth);
@@ -64,7 +64,7 @@ CYearView::CYearView(QWidget *parent)
     m_hhLayout->addLayout(separatorLineLayout);
     m_hhLayout->addWidget(m_weekWidget, 1);
     m_hhLayout->addWidget(m_monthView, 6);
-    m_hhLayout->setMargin(0);
+    m_hhLayout->setContentsMargins(0, 0, 0, 0);
     m_hhLayout->setSpacing(0);
     m_hhLayout->setContentsMargins(13, 10, 10, 10);
     setLayout(m_hhLayout);
@@ -224,7 +224,7 @@ void CYearView::paintEvent(QPaintEvent *e)
         //有焦点，绘制焦点
         QStyleOptionFocusRect option;
         option.initFrom(this);
-        option.backgroundColor = palette().color(QPalette::Background);
+        option.backgroundColor = palette().color(QPalette::Window);
         style()->drawPrimitive(QStyle::PE_FrameFocusRect, &option, &painter, this);
     }
 }

--- a/calendar-client/src/widget/yearWidget/yearwindow.cpp
+++ b/calendar-client/src/widget/yearWidget/yearwindow.cpp
@@ -16,7 +16,6 @@
 #include <QMenuBar>
 #include <QMouseEvent>
 #include <QApplication>
-#include <QDesktopWidget>
 
 DGUI_USE_NAMESPACE
 CYearWindow::CYearWindow(QWidget *parent)
@@ -306,14 +305,14 @@ void CYearWindow::initUI()
     m_yearLunarDayLabel->setAlignment(Qt::AlignRight);
 
     QHBoxLayout *yeartitleLayout = new QHBoxLayout;
-    yeartitleLayout->setMargin(0);
+    yeartitleLayout->setContentsMargins(0, 0, 0, 0);
     yeartitleLayout->setSpacing(0);
     yeartitleLayout->addSpacing(10);
     yeartitleLayout->addWidget(m_yearLabel);
     yeartitleLayout->addWidget(m_dialogIconButton);
 
     QHBoxLayout *yeartitleLayout1 = new QHBoxLayout;
-    yeartitleLayout1->setMargin(0);
+    yeartitleLayout1->setContentsMargins(0, 0, 0, 0);
     yeartitleLayout1->setSpacing(0);
     yeartitleLayout1->addWidget(m_yearLunarLabel);
     yeartitleLayout1->addStretch();
@@ -326,7 +325,7 @@ void CYearWindow::initUI()
     m_todayFrame->setFixedHeight(DDEYearCalendar::Y_MLabelHeight);
     m_todayFrame->setboreder(1);
     QHBoxLayout *todaylayout = new QHBoxLayout;
-    todaylayout->setMargin(0);
+    todaylayout->setContentsMargins(0, 0, 0, 0);
     todaylayout->setSpacing(0);
     //设置tab选中顺序
     setTabOrder(m_prevButton, m_today);
@@ -356,13 +355,13 @@ void CYearWindow::initUI()
 
     m_yearWidget = qobject_cast<YearFrame *>(m_StackedWidget->widget(0));
     QVBoxLayout *hhLayout = new QVBoxLayout;
-    hhLayout->setMargin(0);
+    hhLayout->setContentsMargins(0, 0, 0, 0);
     hhLayout->setSpacing(0);
     hhLayout->setContentsMargins(0, 0, 0, 0);
     hhLayout->addWidget(m_StackedWidget);
 
     m_tMainLayout = new QVBoxLayout;
-    m_tMainLayout->setMargin(0);
+    m_tMainLayout->setContentsMargins(0, 0, 0, 0);
     m_tMainLayout->setSpacing(0);
     m_tMainLayout->setContentsMargins(0, 0, 0, 0);
     m_tMainLayout->addLayout(hhLayout);
@@ -396,10 +395,10 @@ void CYearWindow::setTheMe(int type)
     if (type == 0 || type == 1) {
         DPalette todayPa = m_today->palette();
         todayPa.setColor(DPalette::WindowText, QColor("#000000"));
-        todayPa.setColor(DPalette::Background, Qt::white);
+        todayPa.setColor(DPalette::Window, Qt::white);
         m_today->setPalette(todayPa);
         m_today->setForegroundRole(DPalette::WindowText);
-        m_today->setBackgroundRole(DPalette::Background);
+        m_today->setBackgroundRole(DPalette::Window);
 
         m_todayFrame->setBColor(Qt::white);
 
@@ -420,10 +419,10 @@ void CYearWindow::setTheMe(int type)
         todayPa.setColor(DPalette::WindowText, QColor("#C0C6D4"));
         QColor tbColor = "#414141";
         tbColor.setAlphaF(0.0);
-        todayPa.setColor(DPalette::Background, tbColor);
+        todayPa.setColor(DPalette::Window, tbColor);
         m_today->setPalette(todayPa);
         m_today->setForegroundRole(DPalette::WindowText);
-        m_today->setBackgroundRole(DPalette::Background);
+        m_today->setBackgroundRole(DPalette::Window);
         QColor tbColor2 = "#414141";
         tbColor2.setAlphaF(0.3);
         m_todayFrame->setBColor(tbColor2);
@@ -705,7 +704,7 @@ YearFrame::YearFrame(DWidget *parent)
     : QWidget(parent)
 {
     QGridLayout *gridLayout = new QGridLayout;
-    gridLayout->setMargin(0);
+    gridLayout->setContentsMargins(0, 0, 0, 0);
     gridLayout->setSpacing(8);
 
     for (int i = 0; i < 3; i++) {
@@ -742,13 +741,13 @@ YearFrame::YearFrame(DWidget *parent)
     m_YearLunarLabel->setPalette(LunaPa);
 
     QHBoxLayout *yeartitleLayout = new QHBoxLayout;
-    yeartitleLayout->setMargin(0);
+    yeartitleLayout->setContentsMargins(0, 0, 0, 0);
     yeartitleLayout->setSpacing(0);
     yeartitleLayout->setContentsMargins(11, 12, 8, 10);
     yeartitleLayout->addWidget(m_YearLabel);
 
     QHBoxLayout *yeartitleLayout1 = new QHBoxLayout;
-    yeartitleLayout1->setMargin(0);
+    yeartitleLayout1->setContentsMargins(0, 0, 0, 0);
     yeartitleLayout1->setSpacing(0);
     yeartitleLayout1->setContentsMargins(4, 9, 0, 7);
     yeartitleLayout1->addWidget(m_YearLunarLabel);
@@ -761,7 +760,7 @@ YearFrame::YearFrame(DWidget *parent)
     m_topWidget->setLayout(yeartitleLayout);
     m_topWidget->setFixedHeight(DDEMonthCalendar::M_YTopHeight);
     QVBoxLayout *hhLayout = new QVBoxLayout;
-    hhLayout->setMargin(0);
+    hhLayout->setContentsMargins(0, 0, 0, 0);
     hhLayout->setSpacing(0);
     hhLayout->addWidget(m_topWidget);
     hhLayout->addLayout(gridLayout);
@@ -836,9 +835,9 @@ void YearFrame::setTheMe(int type)
 {
     if (type == 0 || type == 1) {
         DPalette gpa = palette();
-        gpa.setColor(DPalette::Background, "#F8F8F8");
+        gpa.setColor(DPalette::Window, "#F8F8F8");
         setPalette(gpa);
-        setBackgroundRole(DPalette::Background);
+        setBackgroundRole(DPalette::Window);
 
         DPalette pa = m_YearLabel->palette();
         pa.setColor(DPalette::WindowText, QColor("#3B3B3B"));
@@ -851,9 +850,9 @@ void YearFrame::setTheMe(int type)
         m_YearLunarLabel->setForegroundRole(DPalette::WindowText);
     } else if (type == 2) {
         DPalette gpa = palette();
-        gpa.setColor(DPalette::Background, "#252525");
+        gpa.setColor(DPalette::Window, "#252525");
         setPalette(gpa);
-        setBackgroundRole(DPalette::Background);
+        setBackgroundRole(DPalette::Window);
 
         DPalette pa = m_YearLabel->palette();
         pa.setColor(DPalette::WindowText, QColor("#C0C6D4"));

--- a/calendar-common/CMakeLists.txt
+++ b/calendar-common/CMakeLists.txt
@@ -1,19 +1,14 @@
 cmake_minimum_required(VERSION 3.7)
 project(commondata)
 
-# Find the library
 find_package(PkgConfig REQUIRED)
-find_package(Qt5 COMPONENTS
-    Core
-    DBus
-    Sql
-REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core DBus Sql)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-#安全编译参数
+# 安全编译参数
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong -z noexecstack -pie -fPIC -z lazy")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -21,7 +16,6 @@ aux_source_directory(src BASESTRUCT_SRCS)
 aux_source_directory(src/huangliData BASESTRUCT_SRCS_HUANGLI)
 aux_source_directory(src/lunarandfestival BASESTRUCT_SRCS_NONGLI)
 aux_source_directory(src/pinyin BASESTRUCT_SRCS_PINYIN)
-link_libraries(${Qt5CORE_LIBRARIES} ${Qt5DBus_LIBRARIES})
 
 add_library(${PROJECT_NAME} STATIC ${BASESTRUCT_SRCS}
     ${BASESTRUCT_SRCS_HUANGLI}
@@ -31,10 +25,8 @@ add_library(${PROJECT_NAME} STATIC ${BASESTRUCT_SRCS}
 target_include_directories(${PROJECT_NAME} PUBLIC ../3rdparty/kcalendarcore/src)
 
 target_link_libraries(${PROJECT_NAME}
-    Qt5::Core
-    Qt5::DBus
-    Qt5::Sql
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::Sql
     kcalendarcore
-    )
-
-
+)

--- a/calendar-common/src/dschedulequerypar.h
+++ b/calendar-common/src/dschedulequerypar.h
@@ -63,4 +63,7 @@ private:
     QDateTime m_dtEnd; //查询的截止时间
 };
 
+Q_DECLARE_METATYPE(DScheduleQueryPar)
+Q_DECLARE_METATYPE(DScheduleQueryPar::Ptr)
+
 #endif // DSCHEDULEQUERYPAR_H

--- a/calendar-common/src/pinyin/pinyinsearch.cpp
+++ b/calendar-common/src/pinyin/pinyinsearch.cpp
@@ -47,8 +47,13 @@ pinyinsearch *pinyinsearch::getPinPinSearch()
  */
 bool pinyinsearch::CanQueryByPinyin(QString str)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QRegularExpression regexp("^[a-zA-Z]+$");
+    return regexp.match(str).hasMatch();
+#else
     QRegExp regexp("^[a-zA-Z]+$");
     return regexp.exactMatch(str);
+#endif
 }
 
 /**

--- a/calendar-service/CMakeLists.txt
+++ b/calendar-service/CMakeLists.txt
@@ -5,73 +5,68 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-#安全编译参数
+# 安全编译参数
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong -z noexecstack -pie -fPIC -z lazy")
 
 set(APP_RES_DIR "assets")
-set( SERVER_SERVICE_IN "${APP_RES_DIR}/data/com.deepin.dataserver.Calendar.service.in")
-set( APP_SERVICE_IN "${APP_RES_DIR}/data/dde-calendar.service.in")
-set( SERVER_SYSTEMD_SERVICE "${APP_RES_DIR}/data/com.dde.calendarserver.calendar.service")
+set(SERVER_SERVICE_IN "${APP_RES_DIR}/data/com.deepin.dataserver.Calendar.service.in")
+set(APP_SERVICE_IN "${APP_RES_DIR}/data/dde-calendar.service.in")
+set(SERVER_SYSTEMD_SERVICE "${APP_RES_DIR}/data/com.dde.calendarserver.calendar.service")
 set(APP_SYSTEMD_TIMER "${APP_RES_DIR}/data/com.dde.calendarserver.calendar.timer")
 set(AUTOSTART_DESKTOP "${APP_RES_DIR}/dde-calendar-service.desktop")
 set(HUANGLIDB "${APP_RES_DIR}/data/huangli.db")
 set(APP_QRC "${APP_RES_DIR}/resources.qrc")
 
-
 # Find the library
 find_package(PkgConfig REQUIRED)
-find_package(DtkCore REQUIRED)
-find_package(Qt5 COMPONENTS
-    Core
-    DBus
-    Sql
-REQUIRED)
-
-set(LINK_LIBS
-    Qt5::Core
-    Qt5::DBus
-    Qt5::Sql
-    ${DtkCore_LIBRARIES}
-    commondata
-    -lpthread
-)
+find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core DBus Sql)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 SUBDIRLIST(all_src ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-#Include all app own subdirectories
+# Include all app own subdirectories
 foreach(subdir ${all_src})
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/${subdir})
 endforeach()
+
 file(GLOB_RECURSE CALENDARSERVICE_SRCS ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
-#添加资源文件
-QT5_ADD_RESOURCES(CALENDARSERVICE_SRCS ${APP_QRC})
 
+# 添加资源文件
+if(SUPPORT_QT6)
+    QT_ADD_RESOURCES(CALENDARSERVICE_SRCS ${APP_QRC})
+else()
+    QT5_ADD_RESOURCES(CALENDARSERVICE_SRCS ${APP_QRC})
+endif()
 
-#后端程序自动退出宏控制
-if (NOT (CMAKE_BUILD_TYPE MATCHES Debug))
-  add_definitions(-DCALENDAR_SERVICE_AUTO_EXIT)
+# 后端程序自动退出宏控制
+if(NOT(CMAKE_BUILD_TYPE MATCHES Debug))
+    add_definitions(-DCALENDAR_SERVICE_AUTO_EXIT)
 endif()
 
 add_executable(${PROJECT_NAME} ${CALENDARSERVICE_SRCS})
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${DtkWidget_INCLUDE_DIRS} ${OBJECT_BINARY_DIR} ../calendar-common/src)
+target_include_directories(${PROJECT_NAME} PUBLIC ${OBJECT_BINARY_DIR} ../calendar-common/src)
 
 target_link_libraries(${PROJECT_NAME}
-    ${LINK_LIBS}
-    )
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::Sql
+    Dtk${DTK_VERSION_MAJOR}::Core
+    commondata
+    -lpthread
+)
 
-set (SERVICE_INSTALL_DIR "${CMAKE_INSTALL_FULL_LIBEXECDIR}/deepin-daemon" CACHE STRING "Install dir for dde-calendar-service")
+set(SERVICE_INSTALL_DIR "${CMAKE_INSTALL_FULL_LIBEXECDIR}/deepin-daemon" CACHE STRING "Install dir for dde-calendar-service")
 
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE
     CALENDAR_SERVICE_PATH="${SERVICE_INSTALL_DIR}"
 )
 
-
-#修改dbus服务文件
-set (EXEC_DDE_CALENDAR_SERVICE "${SERVICE_INSTALL_DIR}/dde-calendar-service" CACHE STRING "Command to execute dde-calendar-service")
+# 修改dbus服务文件
+set(EXEC_DDE_CALENDAR_SERVICE "${SERVICE_INSTALL_DIR}/dde-calendar-service" CACHE STRING "Command to execute dde-calendar-service")
 
 configure_file(${SERVER_SERVICE_IN} ${CMAKE_CURRENT_BINARY_DIR}/dbus/com.deepin.dataserver.Calendar.service @ONLY)
 configure_file(${APP_SERVICE_IN} ${CMAKE_CURRENT_BINARY_DIR}/assets/dde-calendar.service @ONLY)

--- a/calendar-service/src/alarmManager/dalarmmanager.cpp
+++ b/calendar-service/src/alarmManager/dalarmmanager.cpp
@@ -256,7 +256,11 @@ QString DAlarmManager::getBodyTimePart(const QDateTime &nowtime, const QDateTime
     if (allday) {
         //全天日程，只展示日期，即date
         //日程开始时间距离现在超过两天
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        strmsg.append(jobtime.date().toString(QLocale().dateFormat(QLocale::ShortFormat)));
+#else
         strmsg.append(jobtime.date().toString(Qt::LocalDate));
+#endif
         if (diff == 0) {
             //日程开始时间是今天
             strmsg = tr("Today");

--- a/calendar-service/src/dbusservice/dservicebase.cpp
+++ b/calendar-service/src/dbusservice/dservicebase.cpp
@@ -7,6 +7,7 @@
 #include <QtDBus/QDBusConnection>
 #include <QtDBus/QDBusConnectionInterface>
 #include <QFile>
+#include <QRegularExpression>
 #include <QtDebug>
 
 DServiceBase::DServiceBase(const QString &path, const QString &interface, QObject *parent)
@@ -32,7 +33,7 @@ QString DServiceBase::getClientName()
     QString name;
     QFile file(QString("/proc/%1/status").arg(pid));
     if (file.open(QFile::ReadOnly)) {
-        name = QString(file.readLine()).section(QRegExp("([\\t ]*:[\\t ]*|\\n)"), 1, 1);
+        name = QString(file.readLine()).section(QRegularExpression("([\\t ]*:[\\t ]*|\\n)"), 1, 1);
         file.close();
     }
     return name;

--- a/debian/control
+++ b/debian/control
@@ -5,18 +5,17 @@ Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends:
  debhelper-compat (=11),
  cmake,
- deepin-gettext-tools,
- libdtkgui-dev (>= 5.5.17~),
- libdtkwidget-dev (>= 5.5.17~),
- libgtest-dev,
- libqt5svg5-dev,
  pkg-config,
- qtbase5-dev,
- qttools5-dev,
- qttools5-dev-tools,
+# deepin
  deepin-gettext-tools,
+ libdtk6gui-dev,
+ libdtk6widget-dev,
+# qt
+ qt6-base-dev,
+ qt6-tools-dev,
+ qt6-tools-dev-tools,
+ qt6-svg-dev,
  libgtest-dev,
- qttools5-dev,
  libical-dev,
  libgcrypt20-dev
 Standards-Version: 4.3.0
@@ -27,7 +26,7 @@ Rules-Requires-Root: no
 Package: dde-calendar
 Architecture: linux-any
 Depends:
- dde-qt5integration,
+ dde-qt6integration,
  dde-api,
  ${misc:Depends},
  ${shlibs:Depends},

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
 
-export QT_SELECT := 5
+export QT_SELECT := 6
 
 %:
 	dh $@

--- a/schedule-plugin/CMakeLists.txt
+++ b/schedule-plugin/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.7)
 
-if (NOT DEFINED VERSION)
+if(NOT DEFINED VERSION)
     set(VERSION 1.2.2)
-endif ()
+endif()
 
-#common resource names
+# common resource names
 set(APP_RES_DIR "assets")
 set(APP_BIN_NAME "uosschedulex-plugin")
 set(APP_QRC "${APP_RES_DIR}/resources.qrc")
@@ -17,37 +17,41 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw_64")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw_64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mieee")
-endif ()
-add_definitions("-DSCHEDULEPLUGIN_LIBRARY")
-add_definitions("-DQT_DEPRECATED_WARNINGS")
-#compile flags
-if (CMAKE_BUILD_TYPE MATCHES Debug)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra")
-
-  # Enable Qt builtin debug mode
-  add_definitions("-DQT_MESSAGELOGCONTEXT")
-else()
-  # -Wl, -O2 Enable linker optimizations
-  # -Wl, --gc-sections Remove unused code resulting from -fdsta-sections and
-  # -ffunction-sections
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -O2 -Wl,-O1 -Wl,--gc-sections")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O2 -Wl,-O1 -Wl,--gc-sections")
 endif()
 
-#安全编译参数
+add_definitions("-DSCHEDULEPLUGIN_LIBRARY")
+add_definitions("-DQT_DEPRECATED_WARNINGS")
+
+# compile flags
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra")
+
+    # Enable Qt builtin debug mode
+    add_definitions("-DQT_MESSAGELOGCONTEXT")
+else()
+    # -Wl, -O2 Enable linker optimizations
+    # -Wl, --gc-sections Remove unused code resulting from -fdsta-sections and
+    # -ffunction-sections
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -O2 -Wl,-O1 -Wl,--gc-sections")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O2 -Wl,-O1 -Wl,--gc-sections")
+endif()
+
+# 安全编译参数
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong -z noexecstack -pie -fPIC -z lazy")
 
 macro(SUBDIRLIST result curdir)
     file(GLOB children RELATIVE ${curdir} ${curdir}/*)
     set(dirlist "")
+
     foreach(child ${children})
         if(IS_DIRECTORY ${curdir}/${child})
             LIST(APPEND dirlist ${child})
         endif()
     endforeach()
+
     set(${result} ${dirlist})
 endmacro()
 
@@ -55,7 +59,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 SUBDIRLIST(all_src ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-#Include all app own subdirectories
+# Include all app own subdirectories
 foreach(subdir ${all_src})
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/${subdir})
 endforeach()
@@ -63,22 +67,24 @@ endforeach()
 file(GLOB_RECURSE Schedule_Plugin_SRC ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
 
 find_package(PkgConfig REQUIRED)
-find_package(DtkWidget REQUIRED)
-find_package(Qt5Svg REQUIRED)
-find_package(Qt5DBus REQUIRED)
+find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Widget)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Svg DBus)
 
-
-include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
+if(SUPPORT_QT6)
+    include_directories(${Qt6Gui_PRIVATE_INCLUDE_DIRS})
+else()
+    include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
+endif()
 
 # Tell CMake to create the lib
 add_library(${PROJECT_NAME} SHARED ${Schedule_Plugin_SRC} ${APP_QRC} src/interface/service.h)
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${DtkWidget_INCLUDE_DIRS} ${OBJECT_BINARY_DIR} ../calendar-common/src)
+target_include_directories(${PROJECT_NAME} PUBLIC ${OBJECT_BINARY_DIR} ../calendar-common/src)
 
 target_link_libraries(${PROJECT_NAME}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5DBus_LIBRARIES}
-    ${DtkWidget_LIBRARIES}
+    Qt${QT_VERSION_MAJOR}::Svg
+    Qt${QT_VERSION_MAJOR}::DBus
+    Dtk${DTK_VERSION_MAJOR}::Widget
     commondata
 )
 

--- a/schedule-plugin/src/data/jsondata.cpp
+++ b/schedule-plugin/src/data/jsondata.cpp
@@ -152,6 +152,24 @@ void JsonData::repeatJsonResolve(const QJsonObject &jsobj)
         return;
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QRegularExpression rxlen("([W,M])([0-9]{0,2})");
+    QVector<int> repeatnum {};
+    repeatnum.clear();
+    QRegularExpressionMatchIterator it = rxlen.globalMatch(repeatValue);
+    while (it.hasNext()) {
+        QRegularExpressionMatch match = it.next();
+        if (match.captured(1).contains("M")) {
+            setRepeatStatus(EVEM);
+        }
+        if (match.captured(1).contains("W")) {
+            setRepeatStatus(EVEW);
+        }
+        if (match.captured(0).size() > 0 && match.captured(2) != "") {
+            repeatnum.append(match.captured(2).toInt());
+        }
+    }
+#else
     QRegExp rxlen("([W,M])([0-9]{0,2})");
     int pos = 0;
     QVector<int> repeatnum {};
@@ -168,6 +186,7 @@ void JsonData::repeatJsonResolve(const QJsonObject &jsobj)
         }
         pos += rxlen.matchedLength();
     }
+#endif
     setRepeatNum(repeatnum);
 }
 

--- a/schedule-plugin/src/dbus/dbusaccountmanagerrequest.cpp
+++ b/schedule-plugin/src/dbus/dbusaccountmanagerrequest.cpp
@@ -69,7 +69,7 @@ void DbusAccountManagerRequest::setCalendarGeneralSettings(DCalendarGeneralSetti
 {
     QString jsonStr;
     DCalendarGeneralSettings::toJsonString(ptr, jsonStr);
-    asyncCall("setCalendarGeneralSettings", QVariant(jsonStr));
+    asyncCall("setCalendarGeneralSettings", {QVariant(jsonStr)});
 }
 
 void DbusAccountManagerRequest::clientIsShow(bool isShow)

--- a/schedule-plugin/src/dbus/dbusaccountrequest.cpp
+++ b/schedule-plugin/src/dbus/dbusaccountrequest.cpp
@@ -25,7 +25,7 @@ void DbusAccountRequest::updateAccountInfo(const DAccount::Ptr &account)
 {
     QString jsonStr;
     DAccount::toJsonString(account, jsonStr);
-    asyncCall("updateAccountInfo", QVariant(jsonStr));
+    asyncCall("updateAccountInfo", {QVariant(jsonStr)});
 }
 
 /**
@@ -55,7 +55,7 @@ DScheduleType::List DbusAccountRequest::getScheduleTypeList()
  */
 void DbusAccountRequest::getScheduleTypeByID(const QString &typeID)
 {
-    asyncCall("getScheduleTypeByID", QVariant(typeID));
+    asyncCall("getScheduleTypeByID", {QVariant(typeID)});
 }
 
 /**
@@ -67,7 +67,7 @@ void DbusAccountRequest::createScheduleType(const DScheduleType::Ptr &typeInfo)
 {
     QString jsonStr;
     DScheduleType::toJsonString(typeInfo, jsonStr);
-    asyncCall("createScheduleType", QVariant(jsonStr));
+    asyncCall("createScheduleType", {QVariant(jsonStr)});
 }
 
 /**
@@ -79,7 +79,7 @@ void DbusAccountRequest::updateScheduleType(const DScheduleType::Ptr &typeInfo)
 {
     QString jsonStr;
     DScheduleType::toJsonString(typeInfo, jsonStr);
-    asyncCall("updateScheduleType", QVariant(jsonStr));
+    asyncCall("updateScheduleType", {QVariant(jsonStr)});
 }
 
 /**
@@ -90,7 +90,7 @@ void DbusAccountRequest::updateScheduleType(const DScheduleType::Ptr &typeInfo)
 void DbusAccountRequest::deleteScheduleTypeByID(const QString &typeID)
 {
     QList<QVariant> argumentList;
-    asyncCall("deleteScheduleTypeByID", QVariant(typeID));
+    asyncCall("deleteScheduleTypeByID", {QVariant(typeID)});
 }
 
 /**
@@ -100,7 +100,7 @@ void DbusAccountRequest::deleteScheduleTypeByID(const QString &typeID)
  */
 void DbusAccountRequest::scheduleTypeByUsed(const QString &typeID)
 {
-    asyncCall("scheduleTypeByUsed", QVariant(typeID));
+    asyncCall("scheduleTypeByUsed", {QVariant(typeID)});
 }
 
 /**
@@ -135,7 +135,7 @@ void DbusAccountRequest::updateSchedule(const DSchedule::Ptr &scheduleInfo)
 {
     QString jsonStr;
     DSchedule::toJsonString(scheduleInfo, jsonStr);
-    asyncCall("updateSchedule", QVariant(jsonStr));
+    asyncCall("updateSchedule", {QVariant(jsonStr)});
 }
 
 DSchedule::Ptr DbusAccountRequest::getScheduleByID(const QString &scheduleID)
@@ -165,7 +165,7 @@ DSchedule::Ptr DbusAccountRequest::getScheduleByID(const QString &scheduleID)
 void DbusAccountRequest::deleteScheduleByScheduleID(const QString &scheduleID)
 {
     QList<QVariant> argumentList;
-    asyncCall("deleteScheduleByScheduleID", QVariant(scheduleID));
+    asyncCall("deleteScheduleByScheduleID", {QVariant(scheduleID)});
 }
 
 /**
@@ -176,7 +176,7 @@ void DbusAccountRequest::deleteScheduleByScheduleID(const QString &scheduleID)
 void DbusAccountRequest::deleteSchedulesByScheduleTypeID(const QString &typeID)
 {
     QList<QVariant> argumentList;
-    asyncCall("deleteSchedulesByScheduleTypeID", QVariant(typeID));
+    asyncCall("deleteSchedulesByScheduleTypeID", {QVariant(typeID)});
 }
 
 /**

--- a/schedule-plugin/src/dbus/dbushuanglirequest.cpp
+++ b/schedule-plugin/src/dbus/dbushuanglirequest.cpp
@@ -19,7 +19,7 @@ DbusHuangLiRequest::DbusHuangLiRequest(QObject *parent)
  */
 void DbusHuangLiRequest::getFestivalMonth(quint32 year, quint32 month)
 {
-    asyncCall("getFestivalMonth", QVariant(year), QVariant(month));
+    asyncCall("getFestivalMonth", {QVariant(year), QVariant(month)});
 }
 
 /**
@@ -31,7 +31,7 @@ void DbusHuangLiRequest::getFestivalMonth(quint32 year, quint32 month)
  */
 void DbusHuangLiRequest::getHuangLiDay(quint32 year, quint32 month, quint32 day)
 {
-    asyncCall("getHuangLiDay", QVariant(year), QVariant(month), QVariant(day));
+    asyncCall("getHuangLiDay", {QVariant(year), QVariant(month), QVariant(day)});
 }
 
 /**
@@ -43,7 +43,7 @@ void DbusHuangLiRequest::getHuangLiDay(quint32 year, quint32 month, quint32 day)
  */
 void DbusHuangLiRequest::getHuangLiMonth(quint32 year, quint32 month, bool fill)
 {
-    asyncCall("getHuangLiMonth", QVariant(year), QVariant(month), QVariant(fill));
+    asyncCall("getHuangLiMonth", {QVariant(year), QVariant(month), QVariant(fill)});
 }
 
 /**
@@ -55,7 +55,7 @@ void DbusHuangLiRequest::getHuangLiMonth(quint32 year, quint32 month, bool fill)
  */
 void DbusHuangLiRequest::getLunarInfoBySolar(quint32 year, quint32 month, quint32 day)
 {
-    asyncCall("getLunarInfoBySolar", QVariant(year), QVariant(month), QVariant(day));
+    asyncCall("getLunarInfoBySolar", {QVariant(year), QVariant(month), QVariant(day)});
 }
 
 /**
@@ -67,7 +67,7 @@ void DbusHuangLiRequest::getLunarInfoBySolar(quint32 year, quint32 month, quint3
  */
 void DbusHuangLiRequest::getLunarMonthCalendar(quint32 year, quint32 month, bool fill)
 {
-    asyncCall("getLunarMonthCalendar", QVariant(year), QVariant(month), QVariant(fill));
+    asyncCall("getLunarMonthCalendar", {QVariant(year), QVariant(month), QVariant(fill)});
 }
 
 void DbusHuangLiRequest::slotCallFinished(CDBusPendingCallWatcher *call)

--- a/schedule-plugin/src/dbus/dbusrequestbase.cpp
+++ b/schedule-plugin/src/dbus/dbusrequestbase.cpp
@@ -29,7 +29,7 @@ void DbusRequestBase::setCallbackFunc(CallbackFunc func)
  */
 void DbusRequestBase::asyncCall(const QString &method, const QList<QVariant> &args)
 {
-    QDBusPendingCall async = QDBusAbstractInterface::asyncCall(method, args);
+    QDBusPendingCall async = QDBusAbstractInterface::asyncCallWithArgumentList(method, args);
     CDBusPendingCallWatcher *watcher = new CDBusPendingCallWatcher(async, method, this);
     //将回调函数放进CallWatcher中，随CallWatcher调用结果返回
     watcher->setCallbackFunc(m_callbackFunc);
@@ -38,30 +38,9 @@ void DbusRequestBase::asyncCall(const QString &method, const QList<QVariant> &ar
     connect(watcher, &CDBusPendingCallWatcher::signalCallFinished, this, &DbusRequestBase::slotCallFinished);
 }
 
-/**
- * @brief DbusRequestBase::asyncCall
- * 异步访问dbus接口
- * @param method    dbus方法名
- * @param args  参数
- */
-void DbusRequestBase::asyncCall(const QString &method,
-                                const QVariant &arg1, const QVariant &arg2, const QVariant &arg3, const QVariant &arg4,
-                                const QVariant &arg5, const QVariant &arg6, const QVariant &arg7, const QVariant &arg8)
+void DbusRequestBase::asyncCall(const QString &method, QString callName, const QList<QVariant> &args)
 {
-    asyncCall(method, method, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
-}
-
-/**
- * @brief DbusRequestBase::asyncCall
- * 异步访问dbus接口
- * @param method    dbus方法名
- * @param args  参数
- */
-void DbusRequestBase::asyncCall(const QString &method, QString callName,
-                                const QVariant &arg1, const QVariant &arg2, const QVariant &arg3, const QVariant &arg4,
-                                const QVariant &arg5, const QVariant &arg6, const QVariant &arg7, const QVariant &arg8)
-{
-    QDBusPendingCall async = QDBusAbstractInterface::asyncCall(method, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+    QDBusPendingCall async = QDBusAbstractInterface::asyncCallWithArgumentList(method, args);
     CDBusPendingCallWatcher *watcher = new CDBusPendingCallWatcher(async, callName, this);
     //将回调函数放进CallWatcher中，随CallWatcher调用结果返回
     watcher->setCallbackFunc(m_callbackFunc);

--- a/schedule-plugin/src/dbus/dbusrequestbase.h
+++ b/schedule-plugin/src/dbus/dbusrequestbase.h
@@ -33,25 +33,8 @@ public slots:
 
 protected:
     //异步调用，包装异步调用事件
-    void asyncCall(const QString &method, const QList<QVariant> &args);
-    void asyncCall(const QString &method,
-                   const QVariant &arg1 = QVariant(),
-                   const QVariant &arg2 = QVariant(),
-                   const QVariant &arg3 = QVariant(),
-                   const QVariant &arg4 = QVariant(),
-                   const QVariant &arg5 = QVariant(),
-                   const QVariant &arg6 = QVariant(),
-                   const QVariant &arg7 = QVariant(),
-                   const QVariant &arg8 = QVariant());
-    void asyncCall(const QString &method, QString callName,
-                   const QVariant &arg1 = QVariant(),
-                   const QVariant &arg2 = QVariant(),
-                   const QVariant &arg3 = QVariant(),
-                   const QVariant &arg4 = QVariant(),
-                   const QVariant &arg5 = QVariant(),
-                   const QVariant &arg6 = QVariant(),
-                   const QVariant &arg7 = QVariant(),
-                   const QVariant &arg8 = QVariant());
+    void asyncCall(const QString &method, const QList<QVariant> &args = {});
+    void asyncCall(const QString &method, QString callName, const QList<QVariant> &args = {});
 
 private:
     CallbackFunc m_callbackFunc = nullptr; //回调函数

--- a/schedule-plugin/src/widget/buttonwidget.cpp
+++ b/schedule-plugin/src/widget/buttonwidget.cpp
@@ -13,7 +13,6 @@ buttonwidget::buttonwidget(QWidget *parent)
     , buttonLayout(new QHBoxLayout())
     , clickedButtonIndex(0)
 {
-    buttonLayout->setMargin(0);
     buttonLayout->setContentsMargins(BTWidget::BUTTON_LAYOUT_LEFT_MARGIN,
                                      BTWidget::BUTTON_LAYOUT_TOP_MARGIN,
                                      BTWidget::BUTTON_LAYOUT_RIGHT_MARGIN,

--- a/tests/dde-calendar-client-test/CMakeLists.txt
+++ b/tests/dde-calendar-client-test/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
-#common resource names
+
+# common resource names
 project(dde-calendar-client-test)
 
 ADD_COMPILE_OPTIONS(-fno-access-control)
@@ -7,21 +8,16 @@ ADD_COMPILE_OPTIONS(-fno-access-control)
 set(APP_CLIENT_DIR "${CMAKE_SOURCE_DIR}/calendar-client")
 set(APP_COMMON_DIR "${CMAKE_SOURCE_DIR}/calendar-common")
 set(APP_3PARTY_DIR "${CMAKE_SOURCE_DIR}/3rdparty/kcalendarcore")
-#set(APP_RES_DIR "${APP_CLIENT_DIR}/assets")
-#set(APP_QRC "${APP_RES_DIR}/resources.qrc")
+
+# set(APP_RES_DIR "${APP_CLIENT_DIR}/assets")
+# set(APP_QRC "${APP_RES_DIR}/resources.qrc")
 set(APP_BIN_NAME "dde-calendar-test")
 set(PROJECT_NAME_TEST ${APP_BIN_NAME})
 
 find_package(PkgConfig REQUIRED)
-find_package(DtkCore REQUIRED)
-find_package(Qt5Gui REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5DBus REQUIRED)
-find_package(Qt5Svg REQUIRED)
-find_package(DtkWidget REQUIRED)
-find_package(DtkGui REQUIRED)
+find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widget)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED Gui Widgets DBus Svg Test)
 find_package(GTest REQUIRED)
-find_package(Qt5Test REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -39,23 +35,29 @@ SUBDIRLIST(all_src ${APP_COMMON_DIR}/src)
 include_directories(${APP_3PARTY_DIR}/src)
 SUBDIRLIST(all_src ${APP_3PARTY_DIR}/src)
 
-#Include all app own subdirectories
+# Include all app own subdirectories
 foreach(subdir ${all_src})
     include_directories(${APP_CLIENT_DIR}/src/${subdir})
     include_directories(${APP_COMMON_DIR}/src/${subdir})
     include_directories(${APP_COMMON_DIR}/src/${subdir})
 endforeach()
 
+if(SUPPORT_QT6)
+    include_directories(${Qt6Gui_PRIVATE_INCLUDE_DIRS})
+else()
+    include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
+endif()
+
 file(GLOB_RECURSE Calendar_CLIENTSRC ${APP_CLIENT_DIR}/src/*.cpp)
 file(GLOB_RECURSE Calendar_COMMONSRC ${APP_COMMON_DIR}/src/*.cpp)
 file(GLOB_RECURSE Calendar_3PARTYSRC ${APP_3PARTY_DIR}/src/*.cpp)
-include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 list(REMOVE_ITEM Calendar_CLIENTSRC ${APP_CLIENT_DIR}/src/main.cpp)
 list(REMOVE_ITEM Calendar_COMMONSRC ${APP_COMMON_DIR}/src/main.cpp)
 list(REMOVE_ITEM Calendar_3PARTYSRC ${APP_3PARTY_DIR}/src/main.cpp)
 
-#test SRC
+# test SRC
 SUBDIRLIST(TEST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
 foreach(subdir ${TEST_SRC})
     include_directories(${subdir})
 endforeach()
@@ -69,18 +71,18 @@ include(asan)
 # Tell CMake to create the executable
 add_executable(${APP_BIN_NAME} ${Calendar_TEST_SRC} ${Calendar_CLIENTSRC} ${Calendar_COMMONSRC} ${Calendar_3PARTYSRC} ${APP_QRC})
 
-target_include_directories(${APP_BIN_NAME} PUBLIC ${DtkWidget_INCLUDE_DIRS} ${OBJECT_BINARY_DIR})
+target_include_directories(${APP_BIN_NAME} PUBLIC ${OBJECT_BINARY_DIR})
 
 target_link_libraries(${APP_BIN_NAME}
-    ${DtkWidget_LIBRARIES}
-    ${DtkCore_LIBRARIES}
-    ${DtkGui_LIBRARIES}
-    ${Qt5Widgets_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5DBus_LIBRARIES}
+    Dtk${DTK_VERSION_MAJOR}::Core
+    Dtk${DTK_VERSION_MAJOR}::Gui
+    Dtk${DTK_VERSION_MAJOR}::Widget
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::Svg
+    Qt${QT_VERSION_MAJOR}::Test
     ${GTEST_LIBRARIES}
     ${GTEST_MAIN_LIBRARIES}
-    Qt5::Test
     pthread
     basestruct
 )

--- a/tests/dde-calendar-service-test/CMakeLists.txt
+++ b/tests/dde-calendar-service-test/CMakeLists.txt
@@ -14,27 +14,22 @@ set(APP_QRC "${APP_SERVICE_RES_DIR}/resources.qrc")
 
 # Find the library
 find_package(PkgConfig REQUIRED)
-find_package(DtkCore REQUIRED)
-find_package(Qt5 COMPONENTS
-    Core
-    DBus
-    Sql
-REQUIRED)
-find_package(Qt5Test REQUIRED)
+find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core DBus Sql Test)
 find_package(GTest REQUIRED)
 
 set(LINK_LIBS
-    Qt5::Core
-    Qt5::DBus
-    Qt5::Sql
-    ${DtkCore_LIBRARIES}
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::Sql
+    Dtk${DTK_VERSION_MAJOR}::Core
 )
 
 include_directories(${APP_SERVICE_DIR}/src)
 
 SUBDIRLIST(all_src ${APP_SERVICE_DIR}/src)
 
-#Include all app own subdirectories
+# Include all app own subdirectories
 foreach(subdir ${all_src})
     include_directories(${APP_SERVICE_DIR}/src/${subdir})
 endforeach()
@@ -43,8 +38,9 @@ file(GLOB_RECURSE CALENDARSERVICE_SRCS ${APP_SERVICE_DIR}/src/*.cpp)
 include_directories(../../calendar-basicstruct/)
 list(REMOVE_ITEM CALENDARSERVICE_SRCS ${APP_SERVICE_DIR}/src/main.cpp)
 
-#test src
+# test src
 SUBDIRLIST(TEST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
 foreach(subdir ${TEST_SRC})
     include_directories(${subdir})
 endforeach()
@@ -60,7 +56,7 @@ include(asan)
 
 add_executable(${APP_BIN_NAME} ${Calendar_Service_TEST_SRC} ${CALENDARSERVICE_SRCS} ${APP_QRC})
 
-target_link_libraries(${APP_BIN_NAME} 
+target_link_libraries(${APP_BIN_NAME}
     ${LINK_LIBS}
     ${GTEST_LIBRARIES}
     ${GTEST_MAIN_LIBRARIES}


### PR DESCRIPTION
1. Build System: Update CMake configs and dependencies for Qt6
2. API Updates: Replace deprecated APIs (e.g.: QRegExp QDesktopWidget)
3. DBus: Refactor async calls to use QVariant list
4. UI: Modernize widget layouts and color handling
5. Dependencies: Update to Qt6/DTK6 series packages

Log: Qt5 to Qt6 Migration