### PR TITLE
chore: [tag]New tag v6.5.2

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,12 +7,12 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.1.1
+  version: 6.5.2.1
   kind: app
   description: |
     calendar for deepin os.
 
-base: org.deepin.base/23.1.0/arm64
+base: org.deepin.base/25.0.0/arm64
 runtime: org.deepin.runtime.dtk/25.2.0/arm64
 
 command:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-calendar (6.5.2) unstable; urgency=medium
+
+  * New version 6.5.2
+  * Update linglong base to 25.0.0.
+
+ -- re2zero <yangwu@uniontech.com>  Tue, 11 Feb 2025 16:32:35 +0800
+
 dde-calendar (6.5.1) unstable; urgency=medium
 
   * Update version to 6.5.1

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,12 +7,12 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.1.1
+  version: 6.5.2.1
   kind: app
   description: |
     calendar for deepin os.
 
-base: org.deepin.base/23.1.0
+base: org.deepin.base/25.0.0
 runtime: org.deepin.runtime.dtk/25.2.0
 
 command:

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,12 +7,12 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.1.1
+  version: 6.5.2.1
   kind: app
   description: |
     calendar for deepin os.
 
-base: org.deepin.base/23.1.0/loong64
+base: org.deepin.base/25.0.0/loong64
 runtime: org.deepin.runtime.dtk/25.2.0/loong64
 
 command:


### PR DESCRIPTION
Update the linglong base to 25.0.0 and v6.5.2 release.

Log: v6.5.2 release.