### PR TITLE
chore: Update linglong base

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -12,8 +12,8 @@ package:
   description: |
     calendar for deepin os.
 
-base: org.deepin.base/25.0.0/arm64
-runtime: org.deepin.runtime.dtk/23.2.0/arm64
+base: org.deepin.base/25.2.0/arm64
+runtime: org.deepin.runtime.dtk/25.2.0/arm64
 
 command:
   - dde-calendar

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -12,8 +12,8 @@ package:
   description: |
     calendar for deepin os.
 
-base: org.deepin.base/25.0.0
-runtime: org.deepin.runtime.dtk/23.2.0
+base: org.deepin.base/25.2.0/x86_64
+runtime: org.deepin.runtime.dtk/25.2.0/x86_64
 
 command:
   - dde-calendar

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -12,8 +12,8 @@ package:
   description: |
     calendar for deepin os.
 
-base: org.deepin.base/25.0.0/loong64
-runtime: org.deepin.runtime.dtk/23.2.0/loong64
+base: org.deepin.base/25.2.0/loong64
+runtime: org.deepin.runtime.dtk/25.2.0/loong64
 
 command:
   - dde-calendar


### PR DESCRIPTION
Update linglong base and runtime to 25.2.0

Log: Update linglong base and runtime.