### PR TITLE
chore: Bump version to 6.5.5

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.4.1
+  version: 6.5.5.1
   kind: app
   description: |
     calendar for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-calendar (6.5.5) unstable; urgency=medium
+
+  * fix: crash caused by repeatedly deleting the
+         same schedule data (Bug: 303095)
+
+ -- renbin <renbin@uniontech.com>  Wed, 16 Apr 2025 15:35:34 +0800
+
 dde-calendar (6.5.4) unstable; urgency=medium
 
   * fix: Fix some UI issues (#228)(Bug: 304001)

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.4.1
+  version: 6.5.5.1
   kind: app
   description: |
     calendar for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.4.1
+  version: 6.5.5.1
   kind: app
   description: |
     calendar for deepin os.


### PR DESCRIPTION
Bump version to 6.5.5

Log: Bump version to 6.5.5

## Summary by Sourcery

Chores:
- Bump application version from 6.5.4.1 to 6.5.5.1 in linglong configuration files for different architectures