### PR TITLE
chore: Bump version to 6.5.6

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.5.1
+  version: 6.5.6.1
   kind: app
   description: |
     calendar for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-calendar (6.5.6) unstable; urgency=medium
+
+  * feat: enhance holiday data handling and add 2024/2025 holiday JSON files
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Tue, 22 Apr 2025 15:02:42 +0800
+
 dde-calendar (6.5.5) unstable; urgency=medium
 
   * fix: crash caused by repeatedly deleting the

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.5.1
+  version: 6.5.6.1
   kind: app
   description: |
     calendar for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.5.1
+  version: 6.5.6.1
   kind: app
   description: |
     calendar for deepin os.


### PR DESCRIPTION
Bump version to 6.5.6

Log: Bump version to 6.5.6

## Summary by Sourcery

Chores:
- Update version number in linglong.yaml configuration files for arm64, amd64, and loong64 architectures