### PR TITLE
fix: changelog 6.5.8

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.7.1
+  version: 6.5.8.1
   kind: app
   description: |
     calendar for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-calendar (6.5.8) unstable; urgency=medium
+
+  * fix cloud synchronization (bug 311911).
+
+ -- muyuankai <muyuankai@uniontech.com>  Tue, 13 May 2025 16:26:10 +0800
+
 dde-calendar (6.5.7) unstable; urgency=medium
 
   * crash fix (bug 303095 313675).

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.7.1
+  version: 6.5.8.1
   kind: app
   description: |
     calendar for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.7.1
+  version: 6.5.8.1
   kind: app
   description: |
     calendar for deepin os.


### PR DESCRIPTION
changelog 6.5.8

Log: changelog 6.5.8

## Summary by Sourcery

Bump dde-calendar package version to 6.5.8.1 across manifests and update the changelog

Chores:
- Update version in arm64, loong64, and generic linglong.yaml manifests from 6.5.7.1 to 6.5.8.1
- Add corresponding debian/changelog entry for version 6.5.8.1