### PR TITLE
feat: Adapt to V23 dde dbus interface

### DIFF
--- a/calendar-client/src/dataManage/calendarmanage.cpp
+++ b/calendar-client/src/dataManage/calendarmanage.cpp
@@ -9,9 +9,6 @@
 
 #include <QDBusConnection>
 
-const QString DBus_TimeDate_Name = "com.deepin.daemon.Timedate";
-const QString DBus_TimeDate_Path = "/com/deepin/daemon/Timedate";
-
 CalendarManager *CalendarManager::m_scheduleManager = nullptr;
 CalendarManager *CalendarManager::getInstance()
 {

--- a/calendar-common/CMakeLists.txt
+++ b/calendar-common/CMakeLists.txt
@@ -3,6 +3,7 @@ project(commondata)
 
 find_package(PkgConfig REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core DBus Sql)
+find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED Core)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -29,4 +30,5 @@ target_link_libraries(${PROJECT_NAME}
     Qt${QT_VERSION_MAJOR}::DBus
     Qt${QT_VERSION_MAJOR}::Sql
     kcalendarcore
+    Dtk${DTK_VERSION_MAJOR}::Core
 )

--- a/calendar-common/src/dbustimedate.cpp
+++ b/calendar-common/src/dbustimedate.cpp
@@ -5,14 +5,45 @@
 #include "dbustimedate.h"
 #include "commondef.h"
 
+#include <DSysInfo>
+
 #include <QDBusPendingReply>
 #include <QDBusReply>
 #include <QtDebug>
 #include <QDBusInterface>
 
-#define NETWORK_DBUS_INTEERFACENAME "com.deepin.daemon.Timedate"
-#define NETWORK_DBUS_NAME "com.deepin.daemon.Timedate"
-#define NETWORK_DBUS_PATH "/com/deepin/daemon/Timedate"
+DCORE_USE_NAMESPACE
+
+inline const char *getTimedateService()
+{
+    auto ver = DSysInfo::majorVersion().toInt();
+    if (ver > 20) {
+        return "org.deepin.dde.Timedate1";
+    }
+    return "com.deepin.daemon.Timedate";
+}
+
+inline const char *getTimedatePath()
+{
+    auto ver = DSysInfo::majorVersion().toInt();
+    if (ver > 20) {
+        return "/org/deepin/dde/Timedate1";
+    }
+    return "/com/deepin/daemon/Timedate";
+}
+
+inline const char *getTimedateInterface()
+{
+    auto ver = DSysInfo::majorVersion().toInt();
+    if (ver > 20) {
+        return "org.deepin.dde.Timedate1";
+    }
+    return "com.deepin.daemon.Timedate";
+}
+
+#define NETWORK_DBUS_INTEERFACENAME getTimedateInterface()
+#define NETWORK_DBUS_NAME getTimedateService()
+#define NETWORK_DBUS_PATH getTimedatePath()
 
 DBusTimedate::DBusTimedate(QObject *parent)
     : QDBusAbstractInterface(NETWORK_DBUS_NAME, NETWORK_DBUS_PATH, NETWORK_DBUS_INTEERFACENAME, QDBusConnection::sessionBus(), parent)


### PR DESCRIPTION
As title.

Log: Adapt to V23 dde dbus interface

## Summary by Sourcery

Adapt the calendar modules to support the new V23 DDE Timedate DBus interface by selecting the service, object path, and interface at runtime based on system version and update build dependencies accordingly.

Enhancements:
- Introduce DSysInfo-based logic to dynamically choose the Timedate DBus service, path, and interface for pre-V23 and V23+ systems
- Remove hard-coded Timedate DBus constants and replace them with inline version-aware accessors

Build:
- Add a Dtk Core dependency for DSysInfo support in the common library

Chores:
- Remove obsolete DBus constants in the calendar client code