### PR TITLE
feat: update changelog and version

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.9.1
+  version: 6.5.10.1
   kind: app
   description: |
     calendar for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-calendar (6.5.10) unstable; urgency=medium
+
+  * chore: New version 6.5.10.
+
+ -- xiepengfei <xiepengfei@uniontech.com>  Mon, 23 Jun 2025 12:07:47 +0800
+
 dde-calendar (6.5.9) unstable; urgency=medium
 
   * chore: Update dman's resources

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.9.1
+  version: 6.5.10.1
   kind: app
   description: |
     calendar for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.9.1
+  version: 6.5.10.1
   kind: app
   description: |
     calendar for deepin os.


### PR DESCRIPTION
Update changelog and version

## Summary by Sourcery

Bump dde-calendar package version to 6.5.10.1 in YAML manifests and update the Debian changelog

Chores:
- Update package version from 6.5.9.1 to 6.5.10.1 in arm64, loong64, and generic linglong.yaml files
- Refresh Debian changelog with the new version entry