### PR TITLE
chore: Bump version to 6.5.11

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.10.1
+  version: 6.5.11.1
   kind: app
   description: |
     calendar for deepin os.

--- a/calendar-client/assets/dde-calendar/calendar/en_US/calendar.md
+++ b/calendar-client/assets/dde-calendar/calendar/en_US/calendar.md
@@ -1,4 +1,4 @@
-# Calendar | dde-calendar
+# Calendar|dde-calendar|
 
 ## Overview
 

--- a/calendar-client/assets/dde-calendar/calendar/zh_HK/calendar.md
+++ b/calendar-client/assets/dde-calendar/calendar/zh_HK/calendar.md
@@ -1,4 +1,4 @@
-# 日曆 | dde-calendar
+# 日曆|dde-calendar|
 
 ## 概述
 

--- a/calendar-client/assets/dde-calendar/calendar/zh_TW/calendar.md
+++ b/calendar-client/assets/dde-calendar/calendar/zh_TW/calendar.md
@@ -1,4 +1,4 @@
-# 日曆 | dde-calendar
+# 日曆|dde-calendar|
 
 ## 概述
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-calendar (6.5.11) unstable; urgency=medium
+
+  * chore: New version 6.5.11.
+
+ -- re2zero <yangwu@uniontech.com>  Tue, 24 Jun 2025 17:23:45 +0800
+
 dde-calendar (6.5.10) unstable; urgency=medium
 
   * chore: New version 6.5.10.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.10.1
+  version: 6.5.11.1
   kind: app
   description: |
     calendar for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.10.1
+  version: 6.5.11.1
   kind: app
   description: |
     calendar for deepin os.


### PR DESCRIPTION
Update version number in configuration files to 6.5.11 for all architectures.

Log: Bump version to 6.5.11

## Summary by Sourcery

Bump the dde-calendar package version to 6.5.11 across all architectures and refine Markdown headers by removing spaces around the pipe in localized documentation.

Documentation:
- Remove spaces around the pipe in English, HK Chinese, and TW Chinese calendar documentation headers for consistent formatting.

Chores:
- Update package version to 6.5.11 in ARM64, LOONG64, and default packaging YAML manifests.
- Revise Debian changelog to reflect the new version bump.