### PR TITLE
chore: Update version to 6.5.14

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.13.1
+  version: 6.5.14.1
   kind: app
   description: |
     calendar for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-calendar (6.5.14) unstable; urgency=medium
+
+  * chore: Update deb sources for linglong yaml
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 02 Jul 2025 11:19:32 +0800
+
 dde-calendar (6.5.13) unstable; urgency=medium
 
   * update version 6.5.13. 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.13.1
+  version: 6.5.14.1
   kind: app
   description: |
     calendar for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.13.1
+  version: 6.5.14.1
   kind: app
   description: |
     calendar for deepin os.


### PR DESCRIPTION
Update version to 6.5.14.
Update deb sources for linglong yaml.

Log: Update version to 6.5.14

## Summary by Sourcery

Chores:
- Update dde-calendar version to 6.5.14.1 in ARM64, AMD64, and Loong64 linglong manifests and Debian changelog