### PR TITLE
chore: Update version to 6.5.16

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.15.1
+  version: 6.5.16.1
   kind: app
   description: |
     calendar for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-calendar (6.5.16) unstable; urgency=medium
+
+  * chore: More logs for common
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 16 Jul 2025 09:28:22 +0800
+
 dde-calendar (6.5.15) unstable; urgency=medium
 
   * chore: Update deepin-manual resources

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.15.1
+  version: 6.5.16.1
   kind: app
   description: |
     calendar for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.15.1
+  version: 6.5.16.1
   kind: app
   description: |
     calendar for deepin os.


### PR DESCRIPTION
- update version to 6.5.16

 log: update version to 6.5.16

## Summary by Sourcery

Bump dde-calendar app version to 6.5.16.1 and update packaging metadata

Chores:
- Update version from 6.5.15.1 to 6.5.16.1 in ARM64, loong64, and default YAML manifests
- Refresh debian/changelog for the new 6.5.16.1 release