### PR TITLE
fix: Update control center page and item height adjustments

### DIFF
--- a/calendar-client/src/dialog/settingdialog.cpp
+++ b/calendar-client/src/dialog/settingdialog.cpp
@@ -852,7 +852,7 @@ QWidget *CSettingDialog::createControlCenterLink(QObject *obj)
         auto ver = DSysInfo::majorVersion().toInt();
         if (ver > 23) {
             // v25 control center has changed the datetime page.
-            datePage = "system/timeAndLang";
+            datePage = "system/datetime";
             qCDebug(ClientLogger) << "Using v25+ control center page:" << datePage;
         }
         this->m_controlCenterProxy->ShowPage(datePage);

--- a/calendar-client/src/widget/monthWidget/monthscheduleview.cpp
+++ b/calendar-client/src/widget/monthWidget/monthscheduleview.cpp
@@ -71,7 +71,7 @@ void CMonthScheduleView::slotFontChange()
 
     if (m_ItemHeight != h) {
         qCDebug(ClientLogger) << "Font height changed, updating data";
-        m_ItemHeight = h;
+        m_ItemHeight = h + 1;
         updateData();
     }
 }
@@ -254,7 +254,7 @@ void CMonthScheduleView::computePos(int cNum, QDate bgeindate, QDate enddate, QP
     int ecol = (m_beginDate.daysTo(enddate)) % DDEMonthCalendar::AFewDaysOfWeek;
 
     fw = static_cast<int>((ecol - bcol + 1) * ((m_width - m_leftMargin) / 7.0) - 11);
-    fh = m_ItemHeight;
+    fh = m_ItemHeight + 2;
     int x = static_cast<int>(m_leftMargin + bcol * ((m_width - m_leftMargin) / 7.0) + 5);
     //根据UI图调整item坐标
     int y = static_cast<int>(m_topMargin + ((m_height - m_topMargin - m_bottomMargin) / 6.0) * brow + schedule_Item_Y + (cNum - 1) * fh);


### PR DESCRIPTION
- Change the control center date page from "system/timeAndLang" to "system/datetime".
- Adjust item height in month schedule view by increasing it by 1 and 2 respectively.

Log: Update control center page and item height adjustments.