### PR TITLE
chore: Update version to 6.5.21

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     calendar for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-calendar (6.5.21) unstable; urgency=medium
+
+  * chore: Update version to 6.5.21
+  * fix some ui issues.
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 11 Sep 2025 14:13:40 +0800
+
 dde-calendar (6.5.20) unstable; urgency=medium
 
   * chore: Update version to 6.5.17

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     calendar for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     calendar for deepin os.


### PR DESCRIPTION
- update version to 6.5.21

 log: update version to 6.5.21

## Summary by Sourcery

Bump dde-calendar package version to 6.5.21.1

Chores:
- Update version in arm64/linglong.yaml, linglong.yaml, and loong64/linglong.yaml from 6.5.20.1 to 6.5.21.1
- Update Debian changelog for version 6.5.21