### PR TITLE
chore: Update linglong base and runtime

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     calendar for deepin os.
 
-base: org.deepin.base/25.2.0/arm64
-runtime: org.deepin.runtime.dtk/25.2.0/arm64
+base: org.deepin.base/25.2.1/arm64
+runtime: org.deepin.runtime.dtk/25.2.1/arm64
 
 command:
   - dde-calendar

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-calendar (6.5.22) unstable; urgency=medium
+
+  * chore: Update linglong base and runtime
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 17 Sep 2025 13:21:08 +0800
+
 dde-calendar (6.5.21) unstable; urgency=medium
 
   * chore: Update version to 6.5.21

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     calendar for deepin os.
 
-base: org.deepin.base/25.2.0/x86_64
-runtime: org.deepin.runtime.dtk/25.2.0/x86_64
+base: org.deepin.base/25.2.1/x86_64
+runtime: org.deepin.runtime.dtk/25.2.1/x86_64
 
 command:
   - dde-calendar

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     calendar for deepin os.
 
-base: org.deepin.base/25.2.0/loong64
-runtime: org.deepin.runtime.dtk/25.2.0/loong64
+base: org.deepin.base/25.2.1/loong64
+runtime: org.deepin.runtime.dtk/25.2.1/loong64
 
 command:
   - dde-calendar


### PR DESCRIPTION
Update linglong base and runtime

Log: Update linglong base and runtime

## Summary by Sourcery

Bump dde-calendar package version and update linglong packaging to use latest base and runtime dependencies

Enhancements:
- Bump dde-calendar package version to 6.5.22.1
- Update linglong base to org.deepin.base/25.2.1 for arm64, x86_64, and loong64
- Update linglong runtime to org.deepin.runtime.dtk/25.2.1 for arm64, x86_64, and loong64

Documentation:
- Update Debian changelog to reflect new package version