### PR TITLE
fix: Adjust sidebar icon size and set text format for title label

### DIFF
--- a/calendar-client/src/customWidget/ctitlewidget.cpp
+++ b/calendar-client/src/customWidget/ctitlewidget.cpp
@@ -21,7 +21,7 @@ CTitleWidget::CTitleWidget(QWidget *parent)
     qCDebug(ClientLogger) << "CTitleWidget constructor";
     m_sidebarIcon = new DIconButton(this);
     m_sidebarIcon->setFixedSize(QSize(36, 36));
-    m_sidebarIcon->setIconSize(QSize(19, 15));
+    m_sidebarIcon->setIconSize(QSize(19, 19));
     connect(m_sidebarIcon, &DIconButton::clicked, this, &CTitleWidget::slotSidebarIconClicked);
 
     m_buttonBox = new CButtonBox(this);

--- a/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp
+++ b/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp
@@ -147,6 +147,7 @@ void SidebarTypeItemWidget::initView()
     labelF.setWeight(QFont::Normal);
     m_titleLabel->setFont(labelF);
     m_titleLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    m_titleLabel->setTextFormat(Qt::PlainText);
     m_titleLabel->setText(m_scheduleType->displayName());
     m_titleLabel->setToolTip(m_scheduleType->displayName());
 


### PR DESCRIPTION
- Increased sidebar icon size from 15 to 19 pixels for better visibility.
- Set text format of the title label to plain text for consistent display.

Log: UI improvements for sidebar and title widget. 
Bug: https://pms.uniontech.com/bug-view-319073.html
https://pms.uniontech.com/bug-view-335231.html

## Summary by Sourcery

Adjust UI elements in the calendar client for improved consistency and readability

Bug Fixes:
- Increase sidebar icon size from 19×15 to 19×19 pixels for better visibility
- Enforce plain text formatting on title labels to ensure consistent display