### PR TITLE
fix: Fix twinkling issues

### DIFF
--- a/calendar-client/src/widget/yearWidget/yearview.cpp
+++ b/calendar-client/src/widget/yearWidget/yearview.cpp
@@ -46,7 +46,6 @@ CYearView::CYearView(QWidget *parent)
     separatorLineLayout->addWidget(m_currentMouth);
     separatorLineLayout->addStretch();
 
-    m_currentMouth->show();
     m_currentMouth->installEventFilter(this);
 
     m_weekWidget = new CWeekWidget(this);


### PR DESCRIPTION
- Remove unnecessary show call for current month widget in year view

Log: Clean up widget initialization in year view.
Bug:
https://pms.uniontech.com/bug-view-335511.html
https://pms.uniontech.com/bug-view-327467.html
https://pms.uniontech.com/bug-view-332573.html

## Summary by Sourcery

Bug Fixes:
- Remove redundant m_currentMouth->show() invocation in CYearView to fix twinkling issues