### PR TITLE
fix: Implement community edition detection and update privacy URL logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ build
 .cursorindexingignore
 .cursor
 .specstory
+.promptx/
+.spec-workflow/

--- a/calendar-client/src/widget/calendarmainwindow.cpp
+++ b/calendar-client/src/widget/calendarmainwindow.cpp
@@ -982,15 +982,15 @@ void Calendarmainwindow::slotShowPrivacy()
     QString url = "";
     QLocale locale;
     QLocale::Country country = locale.country();
-    bool isCommunityEdition = DSysInfo::isCommunityEdition();
+    bool isCommunity = isCommunityEdition();
     if (country == QLocale::China) {
-        if (isCommunityEdition) {
+        if (isCommunity) {
             url = "https://www.deepin.org/zh/agreement/privacy/";
         } else {
             url = "https://www.uniontech.com/agreement/privacy-cn";
         }
     } else {
-        if (isCommunityEdition) {
+        if (isCommunity) {
             url = "https://www.deepin.org/en/agreement/privacy/";
         } else {
             url = "https://www.uniontech.com/agreement/privacy-en";

--- a/calendar-common/src/units.h
+++ b/calendar-common/src/units.h
@@ -51,7 +51,8 @@ QDateTime dtConvert(const QDateTime &datetime);
 //是否在显示时间范围内1900-2100
 bool withinTimeFrame(const QDate &date);
 
-//TODO:获取系统版本(专业版，社区版等)
+// Check if current system is community edition (Deepin)
+bool isCommunityEdition();
 
 
 #endif // UNITS_H


### PR DESCRIPTION
- Added a new function `isCommunityEdition()` to check if the current system is the community edition of Deepin.
- Updated the privacy URL logic in `Calendarmainwindow` to use the new function for determining the correct URL based on the edition

Log: Enhance system edition detection and improve privacy URL handling.
Bug: https://pms.uniontech.com/bug-view-285647.html