### PR TITLE
fix: Fix title bar icon not sync with system theme

### DIFF
--- a/calendar-client/src/customWidget/cdynamicicon.cpp
+++ b/calendar-client/src/customWidget/cdynamicicon.cpp
@@ -121,7 +121,9 @@ void CDynamicIcon::setIcon()
         qApp->aboutDialog()->setProductIcon(icon);
     }
 
-    m_Titlebar->setIcon(icon);
+    if (m_Titlebar != nullptr) {
+        m_Titlebar->setIcon(icon);
+    }
 }
 
 void CDynamicIcon::setTitlebar(DTitlebar *titlebar)

--- a/calendar-client/src/customWidget/ctitlewidget.cpp
+++ b/calendar-client/src/customWidget/ctitlewidget.cpp
@@ -21,7 +21,7 @@ CTitleWidget::CTitleWidget(QWidget *parent)
     qCDebug(ClientLogger) << "CTitleWidget constructor";
     m_sidebarIcon = new DIconButton(this);
     m_sidebarIcon->setFixedSize(QSize(36, 36));
-    m_sidebarIcon->setIconSize(QSize(19, 19));
+    m_sidebarIcon->setIconSize(QSize(16, 16));
     connect(m_sidebarIcon, &DIconButton::clicked, this, &CTitleWidget::slotSidebarIconClicked);
 
     m_buttonBox = new CButtonBox(this);

--- a/calendar-client/src/widget/calendarmainwindow.cpp
+++ b/calendar-client/src/widget/calendarmainwindow.cpp
@@ -371,18 +371,21 @@ void Calendarmainwindow::initUI()
     //1.5秒更新当前时间
     m_currentDateUpdateTimer->start(1500);
 
-    CDynamicIcon::getInstance()->setTitlebar(this->titlebar());
+    auto titleBar = this->titlebar();
+    // disable dynamic icon titlebar
+    // CDynamicIcon::getInstance()->setTitlebar(titleBar);
     CDynamicIcon::getInstance()->setIcon();
 
     m_titleWidget = new CTitleWidget(this);
     m_titleWidget->setFocusPolicy(Qt::TabFocus);
-    this->titlebar()->setCustomWidget(m_titleWidget);
-    setTabOrder(this->titlebar(), m_titleWidget);
+    titleBar->setCustomWidget(m_titleWidget);
+    setTabOrder(titleBar, m_titleWidget);
     //设置状态栏焦点代理为标题窗口
-    this->titlebar()->setFocusProxy(m_titleWidget);
+    titleBar->setFocusProxy(m_titleWidget);
+    titleBar->setIcon(QIcon::fromTheme("dde-calendar"));
 
-    this->titlebar()->setQuitMenuVisible(true);//先设置后，才可以获取menu内容。因为setQuitMenuVisible接口中进行了action的添加操作
-    QMenu *menuTitleBar = this->titlebar()->menu();
+    titleBar->setQuitMenuVisible(true);//先设置后，才可以获取menu内容。因为setQuitMenuVisible接口中进行了action的添加操作
+    QMenu *menuTitleBar = titleBar->menu();
 
     QAction *pSetting = new QAction(tr("Manage"), menuTitleBar);
     //menuTitleBar->addAction(pSetting);


### PR DESCRIPTION
- Added a null check for the titlebar in CDynamicIcon to prevent potential crashes.
- Refactored titlebar references in Calendarmainwindow for clarity and maintainability.

Log: Fix title bar icon not sync with system theme.
Bug: https://pms.uniontech.com/bug-view-323493.html

## Summary by Sourcery

Synchronize the calendar titlebar icon with the system theme, add safety checks to prevent null-pointer crashes, and clean up titlebar references with an updated sidebar icon size.

Bug Fixes:
- Add null check in CDynamicIcon to avoid crashes when titlebar is null
- Explicitly set the themed calendar icon on the titlebar to restore theme synchronization

Enhancements:
- Refactor Calendarmainwindow to use a local titleBar variable for clarity and disable redundant dynamic icon calls
- Reduce CTitleWidget sidebar icon size to 16×16 and update related tab order setup