### PR TITLE
chore: update version to 6.5.38

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-calendar (6.5.38) unstable; urgency=medium
+
+  * fix: resolve high CPU usage and account loading failures
+  * chore: reorganize project directory structure
+
+ -- Wang Yu <wangyu@uniontech.com>  Tue, 07 Apr 2026 15:03:02 +0800
+
 dde-calendar (6.5.37) unstable; urgency=medium
 
   * fix: prevent icon scaling at high DPI zoom levels

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.37.1
+  version: 6.5.38.1
   kind: app
   description: |
     calendar for deepin os.


### PR DESCRIPTION
- bump version to 6.5.38

Log : bump version to 6.5.38

## Summary by Sourcery

Chores:
- Bump package version from 6.5.37.1 to 6.5.38.1 in linglong configuration.