### PR TITLE
chore: Update version to 6.5.39

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-calendar (6.5.39) unstable; urgency=medium
+
+  * chore: Update version to 6.5.39
+  * i18n: Translate dde-calendar-service_en_US.ts in fi
+  * i18n: Translate dde-calendar_en_US.ts in pt_BR
+  * i18n: Translate dde-calendar-service_en_US.ts in pt_BR
+  * fix(dbus): add backend fallback for schedule CRUD operations
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 23 Apr 2026 17:25:57 +0800
+
 dde-calendar (6.5.38) unstable; urgency=medium
 
   * fix: resolve high CPU usage and account loading failures

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.38.1
+  version: 6.5.39.1
   kind: app
   description: |
     calendar for deepin os.


### PR DESCRIPTION
- update version to 6.5.39

log: update version to 6.5.39

## Summary by Sourcery

Build:
- Update linglong packaging manifest to version 6.5.39.1.