### PR TITLE
fix(view): fix schedule label misalignment in week/day view

### DIFF
--- a/src/calendar-client/src/customWidget/scheduleview.cpp
+++ b/src/calendar-client/src/customWidget/scheduleview.cpp
@@ -21,9 +21,6 @@
 #include <QShortcut>
 #include <QVBoxLayout>
 #include <QApplication>
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-#include <QDesktopWidget>
-#endif
 
 DGUI_USE_NAMESPACE
 
@@ -539,23 +536,19 @@ void CScheduleView::slotScheduleShow(const bool isShow, const DSchedule::Ptr &ou
         CSchedulesColor gdColor = CScheduleDataManage::getScheduleDataManage()->getScheduleColorByType(
             out->scheduleTypeID());
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        QScreen *screen = QGuiApplication::primaryScreen();
-        QRect screenGeometry = screen->geometry();
-#else
-        QDesktopWidget *w = QApplication::desktop();
-        QRect screenGeometry = w->screenGeometry();
-#endif
         m_ScheduleRemindWidget->setData(out, gdColor);
+        // pos22: 全局屏幕坐标; rPos: 转换后的控件逻辑坐标
+        const auto rPos = this->mapFromGlobal(pos22);
+        const int offsetPx = 15; // 逻辑像素偏移，与 rPos 同一坐标系
 
-        if ((pos22.x() + m_ScheduleRemindWidget->width() + 15) > screenGeometry.width()) {
+        if ((rPos.x() + m_ScheduleRemindWidget->width() + offsetPx) > this->window()->width()) {
             qCDebug(ClientLogger) << "Positioning widget to the right";
             m_ScheduleRemindWidget->setDirection(DArrowRectangle::ArrowRight);
-            m_ScheduleRemindWidget->show(pos22.x() - 15, pos22.y());
+            m_ScheduleRemindWidget->show(rPos.x() - offsetPx, rPos.y());
         } else {
             qCDebug(ClientLogger) << "Positioning widget to the left";
             m_ScheduleRemindWidget->setDirection(DArrowRectangle::ArrowLeft);
-            m_ScheduleRemindWidget->show(pos22.x() + 15, pos22.y());
+            m_ScheduleRemindWidget->show(rPos.x() + offsetPx, rPos.y());
         }
     } else {
         // qCDebug(ClientLogger) << "Hiding schedule widget";


### PR DESCRIPTION
Convert global screen coordinates to widget-relative coordinates using mapFromGlobal() and account for device pixel ratio when calculating label offset. Remove unused QDesktopWidget include.

修复周/日视图下日程标签位置错位的问题，通过mapFromGlobal
将全局坐标转为控件相对坐标，并考虑屏幕缩放比计算偏移量。

Log: 修复周/日视图日程标签位置错位
PMS: BUG-356301
Influence: 修复后周/日视图下日程标签在窗口最大化及不同缩放比下正确显示在日程旁边。

## Summary by Sourcery

Fix positioning of schedule reminder labels in week/day views to correctly align beside schedules across window sizes and display scaling.

Bug Fixes:
- Correct schedule label alignment in week/day views by basing popup positioning on widget-relative coordinates and display scaling.

Enhancements:
- Simplify screen handling by removing legacy QDesktopWidget usage and relying on widget and window geometry.