### PR TITLE
fix(build): require C++14 for calendar client

### DIFF
--- a/src/calendar-client/CMakeLists.txt
+++ b/src/calendar-client/CMakeLists.txt
@@ -20,7 +20,7 @@ set(APP_SERVICE_IN "${APP_RES_DIR}/dbus/com.deepin.Calendar.service.in")
 
 project(${APP_BIN_NAME})
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)


### PR DESCRIPTION
In src/calendar-client/src/widget/calendarmainwindow.cpp, Calendarmainwindow::createViewByIndex uses generic lambda parameters, which require C++14. The client still declares C++11, causing builds with strict standard flags to fail.

## Summary by Sourcery

Build:
- Update the calendar client CMake configuration to use C++14 instead of C++11.