### PR TITLE
fix(client): align schedule tooltip text styles with themes

### DIFF
--- a/src/calendar-client/src/customWidget/scheduleRemindWidget.cpp
+++ b/src/calendar-client/src/customWidget/scheduleRemindWidget.cpp
@@ -99,17 +99,15 @@ void CenterWidget::setTheMe(const int type)
 {
     qCDebug(ClientLogger) << "CenterWidget::setTheMe with type:" << type;
     if (type == 2) {
-        qCDebug(ClientLogger) << "Setting dark theme colors";
-        timeColor = QColor("#C0C6D4");
-        timeColor.setAlphaF(0.7);
-        textColor = QColor("#C0C6D4");
-        textColor.setAlphaF(1);
+        timeColor = QColor("#FFFFFF");
+        timeColor.setAlphaF(0.6);
+        textColor = QColor("#FFFFFF");
+        textColor.setAlphaF(0.7);
     } else {
-        qCDebug(ClientLogger) << "Setting light theme colors";
-        timeColor = QColor("#414D68");
-        timeColor.setAlphaF(0.7);
-        textColor = QColor("#414D68");
-        textColor.setAlphaF(1);
+        timeColor = QColor("#000000");
+        timeColor.setAlphaF(0.6);
+        textColor = QColor("#000000");
+        textColor.setAlphaF(0.7);
     }
     update();
 }
@@ -178,6 +176,7 @@ void CenterWidget::paintEvent(QPaintEvent *e)
     int x = 40 - 13;
     QFont timeFont;
     timeFont.setPixelSize(DDECalendar::FontSizeTwelve);
+    timeFont.setWeight(QFont::Normal);
     QPainter painter(this);
     //draw time
     QPen pen;

--- a/src/calendar-client/src/widget/schedulesearchview.cpp
+++ b/src/calendar-client/src/widget/schedulesearchview.cpp
@@ -108,10 +108,10 @@ void CScheduleSearchItem::setTheMe(int type)
 
         m_hovercolor.background = "#FFFFFF";
         m_hovercolor.background.setAlphaF(0.2);
-        m_hovercolor.timeColor = "#6D7C88";
-        m_hovercolor.timeColor.setAlphaF(1);
-        m_hovercolor.textColor = "#C0C6D4";
-        m_hovercolor.textColor.setAlphaF(1);
+        m_hovercolor.timeColor = "#FFFFFF";
+        m_hovercolor.timeColor.setAlphaF(0.6);
+        m_hovercolor.textColor = "#FFFFFF";
+        m_hovercolor.textColor.setAlphaF(0.7);
     } else {
         qCDebug(ClientLogger) << "Applying light theme";
         m_presscolor.background = CScheduleDataManage::getScheduleDataManage()->getSystemActiveColor();
@@ -123,10 +123,10 @@ void CScheduleSearchItem::setTheMe(int type)
 
         m_hovercolor.background = "#000000";
         m_hovercolor.background.setAlphaF(0.2);
-        m_hovercolor.timeColor = "#526A7F";
-        m_hovercolor.timeColor.setAlphaF(1);
-        m_hovercolor.textColor = "#414D68";
-        m_hovercolor.textColor.setAlphaF(1);
+        m_hovercolor.timeColor = "#000000";
+        m_hovercolor.timeColor.setAlphaF(0.6);
+        m_hovercolor.textColor = "#000000";
+        m_hovercolor.textColor.setAlphaF(0.7);
     }
 }
 
@@ -517,16 +517,20 @@ void CScheduleSearchView::setTheMe(int type)
         qCDebug(ClientLogger) << "Applying light theme";
         m_bBackgroundcolor = "#000000";
         m_bBackgroundcolor.setAlphaF(0.03);
-        m_btimecolor = "#526A7F";
-        m_btTextColor = "#414D68";
+        m_btimecolor = "#000000";
+        m_btimecolor.setAlphaF(0.6);
+        m_btTextColor = "#000000";
+        m_btTextColor.setAlphaF(0.7);
         m_lBackgroundcolor = Qt::white;
         m_lTextColor = "#001A2E";
     } else if (type == 2) {
         qCDebug(ClientLogger) << "Applying dark theme";
         m_bBackgroundcolor = "#FFFFFF";
         m_bBackgroundcolor.setAlphaF(0.05);
-        m_btimecolor = "#6D7C88";
-        m_btTextColor = "#C0C6D4";
+        m_btimecolor = "#FFFFFF";
+        m_btimecolor.setAlphaF(0.6);
+        m_btTextColor = "#FFFFFF";
+        m_btTextColor.setAlphaF(0.7);
         m_lBackgroundcolor = "#FFFFFF";
         m_lBackgroundcolor.setAlphaF(0.0);
         m_lTextColor = "#C0C6D4";
@@ -729,9 +733,11 @@ void CScheduleSearchView::createItemWidget(DSchedule::Ptr info, QDate date, int 
     font.setWeight(QFont::Normal);
     gwi->setBackgroundColor(m_bBackgroundcolor);
     gwi->setText(m_btTextColor, font);
-    font.setPixelSize(DDECalendar::FontSizeTwelve);
+    QFont timeFont = font;
+    timeFont.setPixelSize(DDECalendar::FontSizeTwelve);
+    timeFont.setWeight(QFont::Light);
 
-    gwi->setTimeC(m_btimecolor, font);
+    gwi->setTimeC(m_btimecolor, timeFont);
     gwi->setFixedSize(m_maxWidth - 15, 35);
     gwi->setData(gd, date);
     gwi->setRoundtype(rtype);

--- a/src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp
+++ b/src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp
@@ -23,6 +23,8 @@ CYearScheduleView::CYearScheduleView(QWidget *parent)
     qCDebug(ClientLogger) << "CYearScheduleView constructed";
     m_textfont.setWeight(QFont::Medium);
     m_textfont.setPixelSize(DDECalendar::FontSizeTwelve);
+    m_timefont = m_textfont;
+    m_timefont.setWeight(QFont::Normal);
 }
 
 CYearScheduleView::~CYearScheduleView()
@@ -153,14 +155,16 @@ void CYearScheduleView::setTheMe(int type)
     // qCDebug(ClientLogger) << "Setting theme to type:" << type;
     if (type == 0 || type == 1) {
         // qCDebug(ClientLogger) << "Setting theme to light";
-        m_btimecolor = "#414D68";
-        m_btimecolor.setAlphaF(0.7);
-        m_btTextColor = "#414D68";
+        m_btimecolor = "#000000";
+        m_btimecolor.setAlphaF(0.6);
+        m_btTextColor = "#000000";
+        m_btTextColor.setAlphaF(0.7);
     } else if (type == 2) {
         // qCDebug(ClientLogger) << "Setting theme to dark";
-        m_btimecolor = "#C0C6D4";
-        m_btimecolor.setAlphaF(0.7);
-        m_btTextColor = "#C0C6D4";
+        m_btimecolor = "#FFFFFF";
+        m_btimecolor.setAlphaF(0.6);
+        m_btTextColor = "#FFFFFF";
+        m_btTextColor.setAlphaF(0.7);
     }
 }
 
@@ -304,7 +308,7 @@ void CYearScheduleView::paintItem(QPainter &painter, DSchedule::Ptr info, int in
             //右边时间
             painter.save();
             painter.setPen(m_btimecolor);
-            painter.setFont(m_textfont);
+            painter.setFont(m_timefont);
             if (info->allDay()) {
                 str = tr("All Day");
             } else {

--- a/src/calendar-client/src/widget/yearWidget/yearscheduleview.h
+++ b/src/calendar-client/src/widget/yearWidget/yearscheduleview.h
@@ -95,6 +95,7 @@ private:
     QColor m_btimecolor = "#526A7F";
     QColor m_btTextColor = "#414D68";
     QFont m_textfont;
+    QFont m_timefont;
     QString m_timeFormat = "h:mm";
     QVector<QRect> m_drawRect;
 };


### PR DESCRIPTION
修改内容：
1. 统一搜索结果和年视图日程悬浮卡片的标题与时间文字颜色透明度，适配浅色和深色主题。
2. 为时间文字单独设置更轻的字重，增强其与日程标题的层级区分。
3. 统一相关日程提示信息的文本样式，避免不同入口的悬浮展示不一致。

Change summary:
1. Align title and time text color opacity for schedule hover cards in search and year views so light and dark themes render consistently.
2. Use a lighter font weight for time text to keep it visually distinct from schedule titles.
3. Unify tooltip text styling for related schedule entry points to avoid inconsistent hover presentation.

PMS: BUG-368745
