### PR TITLE
fix(dialog): align my schedule dialog title and action button spacing

### DIFF
--- a/src/calendar-client/src/dialog/myscheduleview.cpp
+++ b/src/calendar-client/src/dialog/myscheduleview.cpp
@@ -166,13 +166,15 @@ void CMyScheduleView::setLabelTextColor(const int type)
     //时间显示颜色
     QColor timeColor;
     if (type == 2) {
-        titleColor = "#C0C6D4";
+        titleColor = "#FFFFFF";
+        titleColor.setAlphaF(0.85);
         scheduleTitleColor = "#FFFFFF";
         timeColor = "#FFFFFF";
         timeColor.setAlphaF(0.7);
         qCDebug(ClientLogger) << "Using dark theme colors";
     } else {
-        titleColor = "#001A2E";
+        titleColor = "#000000";
+        titleColor.setAlphaF(0.85);
         scheduleTitleColor = "#000000";
         scheduleTitleColor.setAlphaF(0.9);
         timeColor = "#000000";
@@ -347,7 +349,7 @@ void CMyScheduleView::initUI()
         qCDebug(ClientLogger) << "Adding OK button for festival schedule";
         addButton(tr("OK", "button"), false, DDialog::ButtonNormal);
         QAbstractButton *button_ok = getButton(0);
-        button_ok->setFixedSize(360, 36);
+        button_ok->setFixedSize(380, 36);
     } else {
         qCDebug(ClientLogger) << "Adding Delete and Edit buttons for regular schedule";
         addButton(tr("Delete", "button"), false, DDialog::ButtonNormal);


### PR DESCRIPTION
修改内容：
1. 调整我的日程详情弹窗标题颜色透明度，使浅色和深色主题下的标题显示保持一致。
2. 增加节假日日程确认按钮和普通日程操作按钮宽度，统一左右边距表现。
3. 保持按钮区域与弹窗边缘及中间分隔位置的视觉间距更稳定。

Change summary:
1. Adjust the title color opacity in the My Schedule detail dialog so the title renders consistently in light and dark themes.
2. Increase the width of the holiday confirm button and regular schedule action buttons to keep horizontal spacing consistent.
3. Keep the button area visually aligned with the dialog edges and center divider.

PMS: BUG-368795