### PR TITLE
fix(dialog): update my schedule icon theme sync and scroll behavior

### DIFF
--- a/src/calendar-client/src/dialog/myscheduleview.cpp
+++ b/src/calendar-client/src/dialog/myscheduleview.cpp
@@ -95,16 +95,21 @@ void CMyScheduleView::slotAutoFeed(const QFont &font)
         resultStr += str;
     }
 
-    if (strList.count() * h > 100) {
+    const int scheduleContentH = strList.count() * h;
+    const bool needScroll = scheduleContentH > 100;
+    if (needScroll) {
         m_scheduleLabelH = 100;
     } else {
         int minH = 17;
-        m_scheduleLabelH = strList.count() * h;
+        m_scheduleLabelH = scheduleContentH;
         m_scheduleLabelH = m_scheduleLabelH >= minH ? m_scheduleLabelH : minH;
     }
     //更新控件高度
     area->setFixedHeight(m_scheduleLabelH);
+    area->setVerticalScrollBarPolicy(needScroll ? Qt::ScrollBarAsNeeded : Qt::ScrollBarAlwaysOff);
+    area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_scheduleLabel->setText(resultStr);
+    m_scheduleLabel->setFixedHeight(needScroll ? scheduleContentH : m_scheduleLabelH);
 
     m_timeLabelH = 26;
     if (m_scheduleInfo->lunnar()) {
@@ -183,6 +188,11 @@ void CMyScheduleView::setLabelTextColor(const int type)
     setPaletteTextColor(m_Title, titleColor);
     setPaletteTextColor(m_scheduleLabel, scheduleTitleColor);
     setPaletteTextColor(m_timeLabel, timeColor);
+}
+
+void CMyScheduleView::updateDialogIcon()
+{
+    setIcon(QIcon::fromTheme("dde-calendar"));
 }
 
 /**
@@ -301,8 +311,7 @@ void CMyScheduleView::initUI()
     m_Title->setAlignment(Qt::AlignCenter);
     DFontSizeManager::instance()->bind(m_Title, DFontSizeManager::T5, QFont::DemiBold);
     //设置日期图标
-    QIcon t_icon(CDynamicIcon::getInstance()->getPixmap());
-    setIcon(t_icon);
+    updateDialogIcon();
     m_Title->setText(tr("My Event"));
     m_Title->move(90, 0); // center x: (400-220)/2
 
@@ -315,6 +324,8 @@ void CMyScheduleView::initUI()
     area->setFocusPolicy(Qt::FocusPolicy::NoFocus);
     area->setFrameShape(QFrame::NoFrame);
     area->setFixedWidth(363);
+    area->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     area->setBackgroundRole(QPalette::Window);
     area->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
     area->setWidgetResizable(true);
@@ -379,6 +390,9 @@ void CMyScheduleView::initConnection()
     QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
                      this,
                      &CMyScheduleView::setLabelTextColor);
+    QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
+                     this,
+                     &CMyScheduleView::updateDialogIcon);
     //如果为节假日日程
     if (CScheduleOperation::isFestival(m_scheduleInfo)) {
         qCDebug(ClientLogger) << "Adding close button for festival schedule";

--- a/src/calendar-client/src/dialog/myscheduleview.h
+++ b/src/calendar-client/src/dialog/myscheduleview.h
@@ -49,6 +49,7 @@ private:
     //界面初始化
     void initUI();
     void initConnection();
+    void updateDialogIcon();
     //设置label文字颜色
     void setLabelTextColor(const int type);
     //设置调色板颜色


### PR DESCRIPTION
修改内容：
1. 在主题切换后同步刷新我的日程弹窗图标，确保左上角应用图标跟随系统主题变化。
2. 优化日程内容区域高度与滚动条显示逻辑，内容未超出可视区域时关闭滚动条和滚动效果。
3. 在内容超出显示区域时保留垂直滚动能力，避免完整内容被截断。

Change summary:
1. Refresh the My Schedule dialog icon when the theme changes so the top-left app icon stays in sync with the system theme.
2. Refine the schedule content height and scrollbar logic so scrolling stays disabled when the content fits in the visible area.
3. Keep vertical scrolling available only when the content exceeds the visible area to avoid truncating longer content.

PMS: BUG-368849
PMS: BUG-368851