### PR TITLE
fix: adjust schedule dialog button spacing

### DIFF
--- a/src/calendar-client/src/dialog/myscheduleview.cpp
+++ b/src/calendar-client/src/dialog/myscheduleview.cpp
@@ -347,14 +347,14 @@ void CMyScheduleView::initUI()
         qCDebug(ClientLogger) << "Adding OK button for festival schedule";
         addButton(tr("OK", "button"), false, DDialog::ButtonNormal);
         QAbstractButton *button_ok = getButton(0);
-        button_ok->setFixedSize(360, 36);
+        button_ok->setFixedSize(380, 36);
     } else {
         qCDebug(ClientLogger) << "Adding Delete and Edit buttons for regular schedule";
         addButton(tr("Delete", "button"), false, DDialog::ButtonNormal);
         addButton(tr("Edit", "button"), false, DDialog::ButtonRecommend);
         for (int i = 0; i < buttonCount(); i++) {
             QAbstractButton *button = getButton(i);
-            button->setFixedSize(165, 36);
+            button->setFixedSize(180, 36);
         }
         //TODO:如果为不可修改日程则设置删除按钮无效
     }


### PR DESCRIPTION
修改内容：
- 调整我的日程弹窗按钮宽度，使按钮距离弹窗左右边缘为 10px。
- 调整普通日程弹窗删除和编辑按钮宽度，使两个按钮距离中间分割线均为 10px。
- 节假日日程单个确认按钮宽度同步调整，保持左右边距为 10px。

验证：
- 已执行 make -j8 编译通过。