### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/src/calendar-client/assets/dde-calendar.desktop
+++ b/src/calendar-client/assets/dde-calendar.desktop
@@ -198,7 +198,7 @@ Name[ug]=Deepin كالېندارى
 Name[uk]=Календар Deepin
 Name[vi]=Lịch Deepin
 Name[lo]=ປະຕິທິນ
-Name[zh_CN]=深度日历
-Name[zh_HK]=深度日曆
-Name[zh_TW]=Deepin 日曆
+Name[zh_CN]=日历
+Name[zh_HK]=日曆
+Name[zh_TW]=日曆
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Enhancements:
- Align zh_CN/zh_HK/zh_TW desktop file translations with branding by dropping the "深度"/"deepin" prefix in user-facing strings.