### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/src/calendar-client/assets/dde-calendar.desktop
+++ b/src/calendar-client/assets/dde-calendar.desktop
@@ -11,6 +11,7 @@ Terminal=false
 Type=Application
 #X-Deepin-TurboType=dtkwidget
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 X-MultipleArgs=false
 
 # Translations:


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

New Features:
- Mark the calendar application as a singleton via the X-Deepin-Singleton flag in its desktop file to support specialized handling by the application manager and window system.