### PR TITLE
fix(widget): fix reminder popup split

### DIFF
--- a/src/calendar-client/src/customWidget/scheduleRemindWidget.cpp
+++ b/src/calendar-client/src/customWidget/scheduleRemindWidget.cpp
@@ -11,17 +11,26 @@
 #include <QPainter>
 #include <QtMath>
 
+namespace {
+static const int kReminderArrowWidth = 18;
+static const int kReminderArrowHeight = 10;
+static const int kReminderMargin = 12;
+static const int kReminderArrowInset = 10;
+}
+
 DGUI_USE_NAMESPACE
 ScheduleRemindWidget::ScheduleRemindWidget(QWidget *parent)
     : DArrowRectangle(DArrowRectangle::ArrowLeft, DArrowRectangle::FloatWidget, parent)
     , m_centerWidget(new CenterWidget(this))
 {
     qCDebug(ClientLogger) << "ScheduleRemindWidget constructor";
-    //如果dtk版本为5.3以上则使用新接口
+    setBackgroundColor(DBlurEffectWidget::AutoColor);
+    setLeftRightRadius(true);
+    setArrowWidth(kReminderArrowWidth);
+    setArrowHeight(kReminderArrowHeight);
+    setMargin(kReminderMargin);
 #if (DTK_VERSION > DTK_VERSION_CHECK(5, 3, 0, 0))
-    //设置显示圆角
     setRadiusArrowStyleEnable(true);
-    //设置圆角
     setRadius(DARROWRECT::DRADIUS);
 #endif
     m_centerWidget->setFixedWidth(207);
@@ -32,6 +41,7 @@ ScheduleRemindWidget::ScheduleRemindWidget(QWidget *parent)
                      m_centerWidget,
                      &CenterWidget::setTheMe);
     m_centerWidget->setTheMe(DGuiApplicationHelper::instance()->themeType());
+    updatePopupGeometry();
 }
 
 ScheduleRemindWidget::~ScheduleRemindWidget()
@@ -45,7 +55,7 @@ void ScheduleRemindWidget::setData(const DSchedule::Ptr &vScheduleInfo, const CS
     m_centerWidget->setData(vScheduleInfo, gcolor);
     m_ScheduleInfo = vScheduleInfo;
     gdcolor = gcolor;
-    this->setHeight(m_centerWidget->height() + 10);
+    updatePopupGeometry();
 }
 
 /**
@@ -55,10 +65,9 @@ void ScheduleRemindWidget::setData(const DSchedule::Ptr &vScheduleInfo, const CS
 void ScheduleRemindWidget::setDirection(DArrowRectangle::ArrowDirection value)
 {
     qCDebug(ClientLogger) << "ScheduleRemindWidget::setDirection:" << value;
-    //设置箭头方向
     this->setArrowDirection(value);
-    //设置内容窗口
     this->setContent(m_centerWidget);
+    updatePopupGeometry();
 }
 
 /**
@@ -71,12 +80,33 @@ void ScheduleRemindWidget::setTimeFormat(QString timeformat)
     m_centerWidget->setTimeFormat(timeformat);
 }
 
+void ScheduleRemindWidget::show(int x, int y)
+{
+    updateArrowPosition();
+    DArrowRectangle::show(x, y);
+    updateArrowPosition();
+}
+
+void ScheduleRemindWidget::updateArrowPosition()
+{
+    setArrowY((height() - arrowWidth()) / 2);
+}
+
+void ScheduleRemindWidget::updatePopupGeometry()
+{
+    resizeWithContent();
+    updateArrowPosition();
+}
+
 CenterWidget::CenterWidget(DWidget *parent)
     : DFrame(parent)
     , textwidth(0)
     , textheight(0)
 {
     qCDebug(ClientLogger) << "CenterWidget constructor";
+    setAutoFillBackground(false);
+    setAttribute(Qt::WA_TranslucentBackground);
+    setAttribute(Qt::WA_NoSystemBackground);
     textfont.setWeight(QFont::Medium);
 }
 

--- a/src/calendar-client/src/customWidget/scheduleRemindWidget.h
+++ b/src/calendar-client/src/customWidget/scheduleRemindWidget.h
@@ -26,9 +26,14 @@ public:
     //设置箭头方向
     void setDirection(ArrowDirection value);
     void setTimeFormat(QString timeformat);
+    void show(int x, int y) override;
 signals:
 
 public slots:
+private:
+    void updateArrowPosition();
+    void updatePopupGeometry();
+
 private:
     CenterWidget *m_centerWidget = nullptr;
     DSchedule::Ptr m_ScheduleInfo;

--- a/src/calendar-client/src/customWidget/scheduleview.cpp
+++ b/src/calendar-client/src/customWidget/scheduleview.cpp
@@ -537,7 +537,6 @@ void CScheduleView::slotScheduleShow(const bool isShow, const DSchedule::Ptr &ou
             out->scheduleTypeID());
 
         m_ScheduleRemindWidget->setData(out, gdColor);
-        // pos22: 全局屏幕坐标; rPos: 转换后的控件逻辑坐标
         const auto rPos = this->mapFromGlobal(pos22);
         const int offsetPx = 15; // 逻辑像素偏移，与 rPos 同一坐标系
 

--- a/src/calendar-client/src/widget/monthWidget/monthview.cpp
+++ b/src/calendar-client/src/widget/monthWidget/monthview.cpp
@@ -80,7 +80,6 @@ void CMonthView::slotScheduleRemindWidget(const bool isShow, const DSchedule::Pt
         //根据类型获取颜色
         CSchedulesColor gdColor = CScheduleDataManage::getScheduleDataManage()->getScheduleColorByType(out->scheduleTypeID());
         m_remindWidget->setData(out, gdColor);
-        // 因为将提示框从window改为widget，要转换为相对窗口的坐标
         auto rPos = this->mapFromGlobal(remindPos);
         //根据提示框在屏幕的位置设置箭头方向
         qCDebug(ClientLogger) << "Reminder widget position" 
@@ -91,12 +90,12 @@ void CMonthView::slotScheduleRemindWidget(const bool isShow, const DSchedule::Pt
             // 显示到右侧
             qCDebug(ClientLogger) << "Showing reminder to the right";
             m_remindWidget->setDirection(DArrowRectangle::ArrowLeft);
-            m_remindWidget->show(rPos.x()+10, rPos.y());
+            m_remindWidget->show(rPos.x() + 10, rPos.y());
         } else {
             // 显示到左侧
             qCDebug(ClientLogger) << "Showing reminder to the left";
             m_remindWidget->setDirection(DArrowRectangle::ArrowRight);
-            m_remindWidget->show(rPos.x()-10, rPos.y());
+            m_remindWidget->show(rPos.x() - 10, rPos.y());
         }
     } else {
         // qCDebug(ClientLogger) << "Hiding schedule reminder widget";

--- a/src/calendar-client/src/widget/yearWidget/yearwindow.cpp
+++ b/src/calendar-client/src/widget/yearWidget/yearwindow.cpp
@@ -719,19 +719,18 @@ void CYearWindow::slotMousePress(const QDate &selectDate, const int pressType)
         QVariant variant;
         CalendarGlobalEnv::getGlobalEnv()->getValueByKey(DDECalendar::CursorPointKey, variant);
         QPoint pos22 = variant.value<QPoint>();
-        // 因为将提示框从window改为widget，要转换为相对窗口的坐标
         auto rPos = this->mapFromGlobal(pos22);
         // 根据鼠标位置，决定悬浮框显示位置
         if (rPos.x() < this->width() / 2) {
             // 显示到右侧
             qCDebug(ClientLogger) << "Showing schedule view on right side";
             m_scheduleView->setDirection(DArrowRectangle::ArrowLeft);
-            m_scheduleView->show(rPos.x()+10, rPos.y());
+            m_scheduleView->show(rPos.x() + 10, rPos.y());
         } else {
             // 显示到左侧
             qCDebug(ClientLogger) << "Showing schedule view on left side";
             m_scheduleView->setDirection(DArrowRectangle::ArrowRight);
-            m_scheduleView->show(rPos.x()-10, rPos.y());
+            m_scheduleView->show(rPos.x() - 10, rPos.y());
         }
         update();
         break;


### PR DESCRIPTION
1. Adjust the reminder popup arrow size, margin, and background settings to remove the visual split between the bubble frame and content.
2. Refresh popup geometry and arrow position when data, direction, or visibility changes so the arrow stays aligned on both left and right placements.
3. Disable system background filling for the popup content widget to reduce layered artifacts on translucent backgrounds.

Log: Fix the split rendering issue in the schedule reminder popup.
Influence: Improves popup visual consistency.

1. 调整提醒浮窗的箭头尺寸、边距和背景配置，消除气泡外框与内容区域之间的割裂感。
2. 在数据更新、方向切换和显示状态变化时统一刷新浮窗几何和箭头位置，保证左右展示时箭头始终贴合内容区域。
3. 关闭浮窗内容部件的系统背景填充，减少透明背景下的分层渲染痕迹。

Log: 修复日程提醒浮窗的割裂显示问题
PMS: BUG-369001
Influence: 提升浮窗视觉一致性。