### PR TITLE
chore: Update version to 6.5.42

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-calendar (6.5.42) unstable; urgency=medium
+
+  * chore: Update version to 6.5.42
+  * fix: add X-Deepin-Singleton flag to desktop file
+  * fix: remove deepin prefix from Chinese translations in desktop file
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 30 Jul 2026 15:22:11 +0800
+
 dde-calendar (6.5.41) unstable; urgency=medium
 
   * chore: Update version to 6.5.41

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.dde.calendar
   name: dde-calendar
-  version: 6.5.41.1
+  version: 6.5.42.1
   kind: app
   description: |
     calendar for deepin os.


### PR DESCRIPTION
- update version to 6.5.42

log: update version to 6.5.42

## Summary by Sourcery

Build:
- Update linglong package manifest to reference version 6.5.42.1.