### PR TITLE
fix: Update cppcheck workflow to use checkout@v7

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

参考 [deepin-camera#501](https://github.com/linuxdeepin/deepin-camera/pull/501)，更新 dde-calendar 的 cppcheck 工作流。

## Changes

- 将 `.github/workflows/cppcheck.yml` 中的 `actions/checkout` 从 `v3` 升级到 `v7`
- 启用 `allow-unsafe-pr-checkout: true`

与 deepin-camera#501 的修改完全一致，diff 的 blob hash 也相同（`e808a89b..85544fae`）。

```diff
       - run: export
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
```

## Why

`actions/checkout@v3` 已较旧，且在 `pull_request_target` 触发场景下需要
`allow-unsafe-pr-checkout` 才能正常拉取 PR 的 head commit 进行 cppcheck 检查。

Reference: https://github.com/linuxdeepin/deepin-camera/pull/501

## Summary by Sourcery

CI:
- Bump actions/checkout in the cppcheck workflow from v3 to v7 and enable allow-unsafe-pr-checkout for pull_request_target runs.