### PR TITLE
fix(calendar-ui): align title text colors

### DIFF
--- a/src/calendar-client/src/widget/dayWidget/daywindow.cpp
+++ b/src/calendar-client/src/widget/dayWidget/daywindow.cpp
@@ -40,11 +40,15 @@ void CDayWindow::setTheMe(int type)
         m_leftground->setBColor("#FFFFFF");
 
         DPalette ypa = m_YearLabel->palette();
-        ypa.setColor(DPalette::WindowText, QColor("#3B3B3B"));
+        QColor yearTextColor = QColor("#000000");
+        yearTextColor.setAlphaF(0.8);
+        ypa.setColor(DPalette::WindowText, yearTextColor);
         m_YearLabel->setPalette(ypa);
         m_YearLabel->setForegroundRole(DPalette::WindowText);
         DPalette lpa = m_LunarLabel->palette();
-        lpa.setColor(DPalette::WindowText, QColor("#8A8A8A"));
+        QColor lunarTextColor = QColor("#000000");
+        lunarTextColor.setAlphaF(0.5);
+        lpa.setColor(DPalette::WindowText, lunarTextColor);
         m_LunarLabel->setPalette(lpa);
         m_LunarLabel->setForegroundRole(DPalette::WindowText);
         DPalette spa = m_SolarDay->palette();
@@ -56,11 +60,15 @@ void CDayWindow::setTheMe(int type)
         m_leftground->setBColor("#282828");
 
         DPalette ypa = m_YearLabel->palette();
-        ypa.setColor(DPalette::WindowText, QColor("#C0C6D4"));
+        QColor yearTextColor = QColor("#FFFFFF");
+        yearTextColor.setAlphaF(0.8);
+        ypa.setColor(DPalette::WindowText, yearTextColor);
         m_YearLabel->setPalette(ypa);
         m_YearLabel->setForegroundRole(DPalette::WindowText);
         DPalette lpa = m_LunarLabel->palette();
-        lpa.setColor(DPalette::WindowText, QColor("#798BA8"));
+        QColor lunarTextColor = QColor("#FFFFFF");
+        lunarTextColor.setAlphaF(0.5);
+        lpa.setColor(DPalette::WindowText, lunarTextColor);
         m_LunarLabel->setPalette(lpa);
         m_LunarLabel->setForegroundRole(DPalette::WindowText);
         DPalette spa = m_SolarDay->palette();
@@ -261,7 +269,9 @@ void CDayWindow::initUI()
     labelF.setPixelSize(DDECalendar::FontSizeTwentyfour);
     m_YearLabel->setFont(labelF);
     DPalette ypa = m_YearLabel->palette();
-    ypa.setColor(DPalette::WindowText, QColor("#3B3B3B"));
+    QColor yearTextColor = QColor("#000000");
+    yearTextColor.setAlphaF(0.8);
+    ypa.setColor(DPalette::WindowText, yearTextColor);
     m_YearLabel->setPalette(ypa);
     titleLayout->addWidget(m_YearLabel);
     m_dialogIconButton->setFocusPolicy(Qt::NoFocus);
@@ -273,7 +283,9 @@ void CDayWindow::initUI()
     m_LunarLabel->setFont(labelF);
     m_LunarLabel->setAlignment(Qt::AlignCenter);
     DPalette lpa = m_LunarLabel->palette();
-    lpa.setColor(DPalette::WindowText, QColor("#8A8A8A"));
+    QColor lunarTextColor = QColor("#000000");
+    lunarTextColor.setAlphaF(0.5);
+    lpa.setColor(DPalette::WindowText, lunarTextColor);
     m_LunarLabel->setPalette(lpa);
     titleLayout->addWidget(m_LunarLabel);
     m_SolarDay = new QLabel();

--- a/src/calendar-client/src/widget/monthWidget/monthdayview.cpp
+++ b/src/calendar-client/src/widget/monthWidget/monthdayview.cpp
@@ -499,7 +499,8 @@ void CMonthRect::setTheMe(int type)
 
     if (type == 0 || type == 1) {
         qCDebug(ClientLogger) << "Applying light theme";
-        m_defaultTextColor = Qt::black;
+        m_defaultTextColor = QColor("#000000");
+        m_defaultTextColor.setAlphaF(0.7);
         m_backgrounddefaultColor = Qt::white;
         m_currentDayTextColor = Qt::white;
         m_backgroundcurrentDayColor = CScheduleDataManage::getScheduleDataManage()->getSystemActiveColor();
@@ -508,7 +509,8 @@ void CMonthRect::setTheMe(int type)
         m_fillColor.setAlphaF(0);
     } else if (type == 2) {
         qCDebug(ClientLogger) << "Applying dark theme";
-        m_defaultTextColor = "#C0C6D4";
+        m_defaultTextColor = QColor("#FFFFFF");
+        m_defaultTextColor.setAlphaF(0.7);
         QColor framecolor = Qt::black;
         framecolor.setAlphaF(0.5);
         m_backgrounddefaultColor = framecolor;

--- a/src/calendar-client/src/widget/monthWidget/monthwindow.cpp
+++ b/src/calendar-client/src/widget/monthWidget/monthwindow.cpp
@@ -57,12 +57,16 @@ void CMonthWindow::setTheMe(int type)
     if (type == 0 || type == 1) {
         qCDebug(ClientLogger) << "Applying light theme";
         DPalette pa = m_YearLabel->palette();
-        pa.setColor(DPalette::WindowText, QColor("#3B3B3B"));
+        QColor yearTextColor = QColor("#000000");
+        yearTextColor.setAlphaF(0.8);
+        pa.setColor(DPalette::WindowText, yearTextColor);
         m_YearLabel->setPalette(pa);
         m_YearLabel->setForegroundRole(DPalette::WindowText);
 
         DPalette LunaPa = m_YearLunarLabel->palette();
-        LunaPa.setColor(DPalette::WindowText, QColor("#8A8A8A"));
+        QColor lunarTextColor = QColor("#000000");
+        lunarTextColor.setAlphaF(0.5);
+        LunaPa.setColor(DPalette::WindowText, lunarTextColor);
         m_YearLunarLabel->setPalette(LunaPa);
         m_YearLunarLabel->setForegroundRole(DPalette::WindowText);
 
@@ -73,11 +77,15 @@ void CMonthWindow::setTheMe(int type)
     } else if (type == 2) {
         qCDebug(ClientLogger) << "Applying dark theme";
         DPalette pa = m_YearLabel->palette();
-        pa.setColor(DPalette::WindowText, QColor("#C0C6D4"));
+        QColor yearTextColor = QColor("#FFFFFF");
+        yearTextColor.setAlphaF(0.8);
+        pa.setColor(DPalette::WindowText, yearTextColor);
         m_YearLabel->setPalette(pa);
         m_YearLabel->setForegroundRole(DPalette::WindowText);
         DPalette LunaPa = m_YearLunarLabel->palette();
-        LunaPa.setColor(DPalette::WindowText, QColor("#798BA8"));
+        QColor lunarTextColor = QColor("#FFFFFF");
+        lunarTextColor.setAlphaF(0.5);
+        LunaPa.setColor(DPalette::WindowText, lunarTextColor);
         m_YearLunarLabel->setPalette(LunaPa);
         m_YearLunarLabel->setForegroundRole(DPalette::WindowText);
 
@@ -266,13 +274,17 @@ void CMonthWindow::initUI()
     yLabelF.setPixelSize(DDECalendar::FontSizeTwentyfour);
     m_YearLabel->setFont(yLabelF);
     DPalette pa = m_YearLabel->palette();
-    pa.setColor(DPalette::WindowText, QColor("#3B3B3B"));
+    QColor yearTextColor = QColor("#000000");
+    yearTextColor.setAlphaF(0.8);
+    pa.setColor(DPalette::WindowText, yearTextColor);
     m_YearLabel->setPalette(pa);
 
     yLabelF.setPixelSize(DDECalendar::FontSizeFourteen);
     m_YearLunarLabel->setFont(yLabelF);
     DPalette Lunarpa = m_YearLunarLabel->palette();
-    Lunarpa.setColor(DPalette::WindowText, QColor("#8A8A8A"));
+    QColor lunarTextColor = QColor("#000000");
+    lunarTextColor.setAlphaF(0.5);
+    Lunarpa.setColor(DPalette::WindowText, lunarTextColor);
     m_YearLunarLabel->setPalette(Lunarpa);
 
     m_monthDayView = new CMonthDayView(this);

--- a/src/calendar-client/src/widget/weekWidget/weekheadview.cpp
+++ b/src/calendar-client/src/widget/weekWidget/weekheadview.cpp
@@ -90,7 +90,8 @@ void CWeekHeadView::setTheMe(int type)
         m_backgroundShowColor.setAlphaF(0.4);
         m_Background_Weekend_Color = "#DAE4ED";
 
-        m_defaultTextColor = "#6F6F6F";
+        m_defaultTextColor = "#000000";
+        m_defaultTextColor.setAlphaF(0.7);
         m_currentDayTextColor = "#FFFFFF";
         m_defaultLunarColor = "#898989";
         m_currentMonthColor = "#000000";
@@ -107,7 +108,8 @@ void CWeekHeadView::setTheMe(int type)
         m_backgroundShowColor.setAlphaF(0.4);
         m_Background_Weekend_Color = "#333D4A";
 
-        m_defaultTextColor = "#C0C6D4";
+        m_defaultTextColor = "#FFFFFF";
+        m_defaultTextColor.setAlphaF(0.7);
         m_currentDayTextColor = "#C0C6D4";
         m_defaultLunarColor = "#6886BA";
 

--- a/src/calendar-client/src/widget/weekWidget/weekview.cpp
+++ b/src/calendar-client/src/widget/weekWidget/weekview.cpp
@@ -199,13 +199,15 @@ void CWeekNumWidget::setTheMe(int type)
 {
     qCDebug(ClientLogger) << "Setting theme in CWeekNumWidget to:" << type;
     if (type == 0 || type == 1) {
-        m_defaultTextColor = Qt::black;
+        m_defaultTextColor = QColor("#000000");
+        m_defaultTextColor.setAlphaF(0.7);
         m_backgrounddefaultColor = Qt::white;
         m_currentDayTextColor = Qt::white;
         m_backgroundcurrentDayColor = CScheduleDataManage::getScheduleDataManage()->getSystemActiveColor();
         m_fillColor = "#FFFFFF";
     } else if (type == 2) {
-        m_defaultTextColor = "#C0C6D4";
+        m_defaultTextColor = QColor("#FFFFFF");
+        m_defaultTextColor.setAlphaF(0.7);
         m_backgrounddefaultColor = "#FFFFFF";
         m_backgrounddefaultColor.setAlphaF(0.05);
         m_currentDayTextColor = "#B8D3FF";

--- a/src/calendar-client/src/widget/weekWidget/weekwindow.cpp
+++ b/src/calendar-client/src/widget/weekWidget/weekwindow.cpp
@@ -72,7 +72,9 @@ void CWeekWindow::initUI()
     t_labelF.setPixelSize(DDECalendar::FontSizeTwentyfour);
     m_YearLabel->setFont(t_labelF);
     DPalette LunaPa = m_YearLabel->palette();
-    LunaPa.setColor(DPalette::WindowText, QColor("#3B3B3B"));
+    QColor yearTextColor = QColor("#000000");
+    yearTextColor.setAlphaF(0.8);
+    LunaPa.setColor(DPalette::WindowText, yearTextColor);
     m_YearLabel->setPalette(LunaPa);
 
     m_YearLunarLabel = new QLabel(this);
@@ -96,7 +98,9 @@ void CWeekWindow::initUI()
     yLabelF.setPixelSize(DDECalendar::FontSizeFourteen);
     m_YearLunarLabel->setFont(yLabelF);
     DPalette YearLpa = m_YearLunarLabel->palette();
-    YearLpa.setColor(DPalette::WindowText, QColor("#8A8A8A"));
+    QColor lunarTextColor = QColor("#000000");
+    lunarTextColor.setAlphaF(0.5);
+    YearLpa.setColor(DPalette::WindowText, lunarTextColor);
 
     m_YearLunarLabel->setPalette(YearLpa);
 
@@ -204,11 +208,15 @@ void CWeekWindow::setTheMe(int type)
         //返回今天按钮的背景色
         m_todayframe->setBColor(Qt::white);
         DPalette pa = m_YearLabel->palette();
-        pa.setColor(DPalette::WindowText, QColor("#3B3B3B"));
+        QColor yearTextColor = QColor("#000000");
+        yearTextColor.setAlphaF(0.8);
+        pa.setColor(DPalette::WindowText, yearTextColor);
         m_YearLabel->setPalette(pa);
         m_YearLabel->setForegroundRole(DPalette::WindowText);
         DPalette LunaPa = m_YearLunarLabel->palette();
-        LunaPa.setColor(DPalette::WindowText, QColor("#8A8A8A"));
+        QColor lunarTextColor = QColor("#000000");
+        lunarTextColor.setAlphaF(0.5);
+        LunaPa.setColor(DPalette::WindowText, lunarTextColor);
         m_YearLunarLabel->setPalette(LunaPa);
         m_YearLunarLabel->setForegroundRole(DPalette::WindowText);
 
@@ -224,11 +232,15 @@ void CWeekWindow::setTheMe(int type)
         m_todayframe->setBColor(bColor);
 
         DPalette pa = m_YearLabel->palette();
-        pa.setColor(DPalette::WindowText, QColor("#C0C6D4"));
+        QColor yearTextColor = QColor("#FFFFFF");
+        yearTextColor.setAlphaF(0.8);
+        pa.setColor(DPalette::WindowText, yearTextColor);
         m_YearLabel->setPalette(pa);
         m_YearLabel->setForegroundRole(DPalette::WindowText);
         DPalette LunaPa = m_YearLunarLabel->palette();
-        LunaPa.setColor(DPalette::WindowText, QColor("#798BA8"));
+        QColor lunarTextColor = QColor("#FFFFFF");
+        lunarTextColor.setAlphaF(0.5);
+        LunaPa.setColor(DPalette::WindowText, lunarTextColor);
         m_YearLunarLabel->setPalette(LunaPa);
         m_YearLunarLabel->setForegroundRole(DPalette::WindowText);
         DPalette wpa = m_weekLabel->palette();
@@ -543,5 +555,3 @@ void CWeekWindow::mousePressEvent(QMouseEvent *event)
     Q_UNUSED(event);
     slotScheduleHide();
 }
-
-

--- a/src/calendar-client/src/widget/yearWidget/yearwindow.cpp
+++ b/src/calendar-client/src/widget/yearWidget/yearwindow.cpp
@@ -311,7 +311,9 @@ void CYearWindow::initUI()
     t_labelF.setPixelSize(DDECalendar::FontSizeTwentyfour);
     m_yearLabel->setFont(t_labelF);
     DPalette pa = m_yearLabel->palette();
-    pa.setColor(DPalette::WindowText, QColor("#3B3B3B"));
+    QColor yearTextColor = QColor("#000000");
+    yearTextColor.setAlphaF(0.8);
+    pa.setColor(DPalette::WindowText, yearTextColor);
     m_yearLabel->setPalette(pa);
 
     m_yearLunarLabel = new QLabel(this);
@@ -435,12 +437,16 @@ void CYearWindow::setTheMe(int type)
         m_todayFrame->setBColor(Qt::white);
 
         DPalette pa = m_yearLabel->palette();
-        pa.setColor(DPalette::WindowText, QColor("#3B3B3B"));
+        QColor yearTextColor = QColor("#000000");
+        yearTextColor.setAlphaF(0.8);
+        pa.setColor(DPalette::WindowText, yearTextColor);
         m_yearLabel->setPalette(pa);
         m_yearLabel->setForegroundRole(DPalette::WindowText);
 
         DPalette LunaPa = m_yearLunarLabel->palette();
-        LunaPa.setColor(DPalette::WindowText, QColor("#8A8A8A"));
+        QColor lunarTextColor = QColor("#000000");
+        lunarTextColor.setAlphaF(0.5);
+        LunaPa.setColor(DPalette::WindowText, lunarTextColor);
         m_yearLunarLabel->setPalette(LunaPa);
         m_yearLunarLabel->setForegroundRole(DPalette::WindowText);
 
@@ -460,11 +466,15 @@ void CYearWindow::setTheMe(int type)
         tbColor2.setAlphaF(0.3);
         m_todayFrame->setBColor(tbColor2);
         DPalette pa = m_yearLabel->palette();
-        pa.setColor(DPalette::WindowText, QColor("#C0C6D4"));
+        QColor yearTextColor = QColor("#FFFFFF");
+        yearTextColor.setAlphaF(0.8);
+        pa.setColor(DPalette::WindowText, yearTextColor);
         m_yearLabel->setPalette(pa);
         m_yearLabel->setForegroundRole(DPalette::WindowText);
         DPalette LunaPa = m_yearLunarLabel->palette();
-        LunaPa.setColor(DPalette::WindowText, QColor("#798BA8"));
+        QColor lunarTextColor = QColor("#FFFFFF");
+        lunarTextColor.setAlphaF(0.5);
+        LunaPa.setColor(DPalette::WindowText, lunarTextColor);
         m_yearLunarLabel->setPalette(LunaPa);
         m_yearLunarLabel->setForegroundRole(DPalette::WindowText);
         m_yearLunarDayLabel->setPalette(LunaPa);
@@ -807,7 +817,9 @@ YearFrame::YearFrame(DWidget *parent)
     t_labelF.setPixelSize(DDECalendar::FontSizeTwentyfour);
     m_YearLabel->setFont(t_labelF);
     DPalette pa = m_YearLabel->palette();
-    pa.setColor(DPalette::WindowText, QColor("#3B3B3B"));
+    QColor yearTextColor = QColor("#000000");
+    yearTextColor.setAlphaF(0.8);
+    pa.setColor(DPalette::WindowText, yearTextColor);
     m_YearLabel->setPalette(pa);
 
     m_YearLunarLabel = new QLabel();
@@ -926,12 +938,16 @@ void YearFrame::setTheMe(int type)
         setBackgroundRole(DPalette::Window);
 
         DPalette pa = m_YearLabel->palette();
-        pa.setColor(DPalette::WindowText, QColor("#3B3B3B"));
+        QColor yearTextColor = QColor("#000000");
+        yearTextColor.setAlphaF(0.8);
+        pa.setColor(DPalette::WindowText, yearTextColor);
         m_YearLabel->setPalette(pa);
         m_YearLabel->setForegroundRole(DPalette::WindowText);
 
         DPalette LunaPa = m_YearLunarLabel->palette();
-        LunaPa.setColor(DPalette::WindowText, QColor("#8A8A8A"));
+        QColor lunarTextColor = QColor("#000000");
+        lunarTextColor.setAlphaF(0.5);
+        LunaPa.setColor(DPalette::WindowText, lunarTextColor);
         m_YearLunarLabel->setPalette(LunaPa);
         m_YearLunarLabel->setForegroundRole(DPalette::WindowText);
     } else if (type == 2) {
@@ -942,11 +958,15 @@ void YearFrame::setTheMe(int type)
         setBackgroundRole(DPalette::Window);
 
         DPalette pa = m_YearLabel->palette();
-        pa.setColor(DPalette::WindowText, QColor("#C0C6D4"));
+        QColor yearTextColor = QColor("#FFFFFF");
+        yearTextColor.setAlphaF(0.8);
+        pa.setColor(DPalette::WindowText, yearTextColor);
         m_YearLabel->setPalette(pa);
         m_YearLabel->setForegroundRole(DPalette::WindowText);
         DPalette LunaPa = m_YearLunarLabel->palette();
-        LunaPa.setColor(DPalette::WindowText, QColor("#798BA8"));
+        QColor lunarTextColor = QColor("#FFFFFF");
+        lunarTextColor.setAlphaF(0.5);
+        LunaPa.setColor(DPalette::WindowText, lunarTextColor);
         m_YearLunarLabel->setPalette(LunaPa);
         m_YearLunarLabel->setForegroundRole(DPalette::WindowText);
     }


### PR DESCRIPTION
## Summary
- unify year title colors in day, week, month, and year views
- unify lunar subtitle colors for light and dark themes
- adjust unselected date colors in week and month strips
- keep selected and current-day highlight behavior unchanged

## Verification
- built with `cmake --build Build --target dde-calendar -j4`
- build result: `[100%] Built target dde-calendar`

## PMS
- TASK-373747

## Summary by Sourcery

Unify calendar title and subtitle text colors across day, week, month, and year views and refine reminder popup styling for better visual consistency.

Enhancements:
- Standardize year and lunar label text colors for light and dark themes in day, week, month, and year views using consistent alpha-blended black/white tones.
- Adjust default/unselected date text colors in week and month strip headers to use semi-transparent black/white for improved readability and alignment with the overall theme.
- Refine schedule reminder popup appearance by configuring background, arrow size, margins, and rounded-corner behavior, and by centering the arrow relative to the popup height.
- Make the reminder popup auto-resize to its content and ensure the arrow positioning updates on data or direction changes for more stable layout behavior.
- Set the reminder center widget to use a transparent background to better blend with the popup styling and surrounding UI.
- Apply minor layout and code cleanups to schedule view and related widgets, including arrow show offsets and removal of obsolete comments.