### PR TITLE
fix(month-view): adjust text colors in month view

### DIFF
--- a/src/calendar-client/src/view/graphicsItem/cmonthdayitem.cpp
+++ b/src/calendar-client/src/view/graphicsItem/cmonthdayitem.cpp
@@ -63,12 +63,10 @@ void CMonthDayItem::setTheMe(int type)
 
     if (type == 0 || type == 1) {
         // qCDebug(ClientLogger) << "Setting light theme colors";
-        m_dayNumColor = QColor("#000000");
-        m_dayNumColor.setAlphaF(0.8);
+        m_dayNumColor = QColor(0, 0, 0, 204);
         m_dayNumCurrentColor = "#FFFFFF";
 
-        m_LunerColor = QColor("#000000");
-        m_LunerColor.setAlphaF(0.4);
+        m_LunerColor = QColor(0, 0, 0, 102);
 
         m_fillColor = Qt::white;
         m_banColor = "#FF7171";
@@ -80,12 +78,10 @@ void CMonthDayItem::setTheMe(int type)
         m_BorderColor.setAlphaF(0.05);
     } else if (type == 2) {
         // qCDebug(ClientLogger) << "Setting dark theme colors";
-        m_dayNumColor = QColor("#FFFFFF");
-        m_dayNumColor.setAlphaF(0.8);
+        m_dayNumColor = QColor(255, 255, 255, 204);
         m_dayNumCurrentColor = "#B8D3FF";
 
-        m_LunerColor = QColor("#FFFFFF");
-        m_LunerColor.setAlphaF(0.4);
+        m_LunerColor = QColor(255, 255, 255, 102);
 
         m_fillColor = "#000000";
         m_fillColor.setAlphaF(0.05);
@@ -94,8 +90,7 @@ void CMonthDayItem::setTheMe(int type)
         m_xiuColor = "#ADFF71";
         m_xiuColor.setAlphaF(0.1);
 
-        m_BorderColor = "#000000";
-        m_BorderColor.setAlphaF(0.05);
+        m_BorderColor = QColor(255, 255, 255, 13);
     }
     update();
 }

--- a/src/calendar-client/src/widget/monthWidget/monthweekview.cpp
+++ b/src/calendar-client/src/widget/monthWidget/monthweekview.cpp
@@ -176,11 +176,9 @@ void WeekRect::setTheMe(int type)
     m_activeColor = CScheduleDataManage::getScheduleDataManage()->getSystemActiveColor();
     if (type == 0 || type == 1) {
         // qCDebug(ClientLogger) << "Applying light theme";
-        m_testColor = QColor("#000000");
-        m_testColor.setAlphaF(0.5);
+        m_testColor = QColor(0, 0, 0, 128);
     } else {
         // qCDebug(ClientLogger) << "Applying dark theme";
-        m_testColor = QColor("#FFFFFF");
-        m_testColor.setAlphaF(0.5);
+        m_testColor = QColor(255, 255, 255, 128);
     }
 }


### PR DESCRIPTION
## Summary
- adjust month view weekday header colors for Monday to Friday in light and dark themes
- update day number and lunar text opacity in month cells for both themes
- fix month cell divider color in dark mode

## Verification
- built target: `cmake --build Build --target dde-calendar -j4`

## Bug
- PMS-373785
- https://pms.uniontech.com/bug-view-373785.html

## Summary by Sourcery

Bug Fixes:
- Correct month-view text, lunar-label, weekday-header, and divider colors across light and dark themes.