### PR TITLE
fix: adjust month view date table text colors to match design spec

### DIFF
--- a/src/calendar-client/src/view/graphicsItem/cmonthdayitem.cpp
+++ b/src/calendar-client/src/view/graphicsItem/cmonthdayitem.cpp
@@ -63,11 +63,12 @@ void CMonthDayItem::setTheMe(int type)
 
     if (type == 0 || type == 1) {
         // qCDebug(ClientLogger) << "Setting light theme colors";
-        m_dayNumColor = "#000000";
+        m_dayNumColor = QColor("#000000");
+        m_dayNumColor.setAlphaF(0.8);
         m_dayNumCurrentColor = "#FFFFFF";
 
-        m_LunerColor = "#5E5E5E";
-        m_LunerColor.setAlphaF(0.5);
+        m_LunerColor = QColor("#000000");
+        m_LunerColor.setAlphaF(0.4);
 
         m_fillColor = Qt::white;
         m_banColor = "#FF7171";
@@ -79,11 +80,12 @@ void CMonthDayItem::setTheMe(int type)
         m_BorderColor.setAlphaF(0.05);
     } else if (type == 2) {
         // qCDebug(ClientLogger) << "Setting dark theme colors";
-        m_dayNumColor = "#C0C6D4";
+        m_dayNumColor = QColor("#FFFFFF");
+        m_dayNumColor.setAlphaF(0.8);
         m_dayNumCurrentColor = "#B8D3FF";
 
-        m_LunerColor = "#ABDAFF";
-        m_LunerColor.setAlphaF(0.5);
+        m_LunerColor = QColor("#FFFFFF");
+        m_LunerColor.setAlphaF(0.4);
 
         m_fillColor = "#000000";
         m_fillColor.setAlphaF(0.05);

--- a/src/calendar-client/src/widget/monthWidget/monthweekview.cpp
+++ b/src/calendar-client/src/widget/monthWidget/monthweekview.cpp
@@ -176,9 +176,11 @@ void WeekRect::setTheMe(int type)
     m_activeColor = CScheduleDataManage::getScheduleDataManage()->getSystemActiveColor();
     if (type == 0 || type == 1) {
         // qCDebug(ClientLogger) << "Applying light theme";
-        m_testColor = "#6F6F6F";
+        m_testColor = QColor("#000000");
+        m_testColor.setAlphaF(0.5);
     } else {
         // qCDebug(ClientLogger) << "Applying dark theme";
-        m_testColor = "#C0C6D4";
+        m_testColor = QColor("#FFFFFF");
+        m_testColor.setAlphaF(0.5);
     }
 }


### PR DESCRIPTION
## 根因分析

月视图日期表格三类文案颜色均为硬编码常量，深色模式统一使用了偏蓝色调（`#C0C6D4`、`#ABDAFF`、`#B8D3FF`），与设计规范"白字 + 指定不透明度"不符；浅色模式为灰色/纯色，与"黑字 + 指定不透明度"不符。这是"文案偏蓝"的直接根因（强根因）。

关键证据：
- `src/calendar-client/src/widget/monthWidget/monthweekview.cpp:172` `WeekRect::setTheMe` — 周1~周5 表头深色 `m_testColor="#C0C6D4"`（偏蓝灰）
- `src/calendar-client/src/view/graphicsItem/cmonthdayitem.cpp:71` `CMonthDayItem::setTheMe` — 日期数字深色 `m_dayNumColor="#C0C6D4"`、农历深色 `m_LunerColor="#ABDAFF"+50%`

版本检查：6.5.40..HEAD 区间无颜色相关修复，问题在 6.5.42 仍存在。

## 修复方案

按 PMS 设计规范，仅修改 2 个文件 `setTheMe` 中的颜色常量（PMS 未提及的今日数字颜色、年/月份标题均不动）：

1. `monthweekview.cpp` 周1~周5 表头 `m_testColor` → 黑/白 + 50% 不透明度
2. `cmonthdayitem.cpp` 日期数字 `m_dayNumColor` → 黑/白 + 80%、农历 `m_LunerColor` → 黑/白 + 40%

深色模式：白字 + 不透明度；浅色模式：黑字 + 不透明度。仅改颜色常量值，不改函数签名、绘制逻辑、布局。

## 改动安全评估

低风险。仅修改颜色常量赋值，无函数签名变更，无调用者行为依赖具体颜色值（`References=0`）。颜色常量源自 2020-2021 初始实现，非某次 bug 修复产物；2025-10 的日志增强提交仅触及相邻注释行，未改动颜色值，本次修改不撤销其改动。

## Summary by Sourcery

Bug Fixes:
- Correct month view weekday header and date/lunar text colors to use black/white with specified opacity instead of hard-coded blue/gray tones.