### PR TITLE
fix(week-head-view): adapt header text colors

### DIFF
--- a/src/calendar-client/src/view/graphicsItem/cmonthdayitem.cpp
+++ b/src/calendar-client/src/view/graphicsItem/cmonthdayitem.cpp
@@ -63,12 +63,10 @@ void CMonthDayItem::setTheMe(int type)
 
     if (type == 0 || type == 1) {
         // qCDebug(ClientLogger) << "Setting light theme colors";
-        m_dayNumColor = QColor("#000000");
-        m_dayNumColor.setAlphaF(0.8);
+        m_dayNumColor = QColor(0, 0, 0, 204);
         m_dayNumCurrentColor = "#FFFFFF";
 
-        m_LunerColor = QColor("#000000");
-        m_LunerColor.setAlphaF(0.4);
+        m_LunerColor = QColor(0, 0, 0, 102);
 
         m_fillColor = Qt::white;
         m_banColor = "#FF7171";
@@ -80,12 +78,10 @@ void CMonthDayItem::setTheMe(int type)
         m_BorderColor.setAlphaF(0.05);
     } else if (type == 2) {
         // qCDebug(ClientLogger) << "Setting dark theme colors";
-        m_dayNumColor = QColor("#FFFFFF");
-        m_dayNumColor.setAlphaF(0.8);
+        m_dayNumColor = QColor(255, 255, 255, 204);
         m_dayNumCurrentColor = "#B8D3FF";
 
-        m_LunerColor = QColor("#FFFFFF");
-        m_LunerColor.setAlphaF(0.4);
+        m_LunerColor = QColor(255, 255, 255, 102);
 
         m_fillColor = "#000000";
         m_fillColor.setAlphaF(0.05);
@@ -94,8 +90,7 @@ void CMonthDayItem::setTheMe(int type)
         m_xiuColor = "#ADFF71";
         m_xiuColor.setAlphaF(0.1);
 
-        m_BorderColor = "#000000";
-        m_BorderColor.setAlphaF(0.05);
+        m_BorderColor = QColor(255, 255, 255, 13);
     }
     update();
 }

--- a/src/calendar-client/src/widget/monthWidget/monthweekview.cpp
+++ b/src/calendar-client/src/widget/monthWidget/monthweekview.cpp
@@ -176,11 +176,9 @@ void WeekRect::setTheMe(int type)
     m_activeColor = CScheduleDataManage::getScheduleDataManage()->getSystemActiveColor();
     if (type == 0 || type == 1) {
         // qCDebug(ClientLogger) << "Applying light theme";
-        m_testColor = QColor("#000000");
-        m_testColor.setAlphaF(0.5);
+        m_testColor = QColor(0, 0, 0, 128);
     } else {
         // qCDebug(ClientLogger) << "Applying dark theme";
-        m_testColor = QColor("#FFFFFF");
-        m_testColor.setAlphaF(0.5);
+        m_testColor = QColor(255, 255, 255, 128);
     }
 }

--- a/src/calendar-client/src/widget/weekWidget/weekheadview.cpp
+++ b/src/calendar-client/src/widget/weekWidget/weekheadview.cpp
@@ -311,21 +311,22 @@ void CWeekHeadView::paintCell(QWidget *cell)
     const QString dayNum = getCellDayNum(pos);
     const QString dayLunar = getLunar(pos);
     QString dayWeek = locale.dayName(d ? d : DDEWeekCalendar::AFewDaysofWeek, QLocale::ShortFormat);
+    QColor primaryTextColor = m_themetype == 2 ? QColor(Qt::white) : QColor(Qt::black);
+    primaryTextColor.setAlphaF(0.8);
+    QColor lunarTextColor = m_themetype == 2 ? QColor(Qt::white) : QColor(Qt::black);
+    lunarTextColor.setAlphaF(0.5);
+    QFont lunarFont = m_dayNumFont;
+    lunarFont.setWeight(QFont::Normal);
 
     painter.save();
     painter.setPen(Qt::SolidLine);
-    // draw text of day
     if (isSelectedCell) {
         painter.setPen(m_currentDayTextColor);
-    } else if (isCurrentDay) {
+    } else if (d == DDEWeekCalendar::FirstDayOfWeekend || d == DDEWeekCalendar::AFewDaysofWeek) {
         painter.setPen(m_weekendsTextColor);
     } else {
-        if (d == DDEWeekCalendar::FirstDayOfWeekend || d == DDEWeekCalendar::AFewDaysofWeek)
-            painter.setPen(m_weekendsTextColor);
-        else
-            painter.setPen(m_defaultTextColor);
+        painter.setPen(primaryTextColor);
     }
-
     painter.setFont(m_dayNumFont);
 
     if (m_showState & ShowLunar) {
@@ -333,7 +334,7 @@ void CWeekHeadView::paintCell(QWidget *cell)
         if (d == DDEWeekCalendar::FirstDayOfWeekend || d == DDEWeekCalendar::AFewDaysofWeek)
             painter.setPen(m_weekendsTextColor);
         else
-            painter.setPen(m_defaultTextColor);
+            painter.setPen(primaryTextColor);
         painter.drawText(QRect(bw + 24, bh, 30, 25), Qt::AlignCenter, dayWeek);
     } else {
         QFontMetrics fm1 = painter.fontMetrics();
@@ -341,7 +342,7 @@ void CWeekHeadView::paintCell(QWidget *cell)
         if (d == DDEWeekCalendar::FirstDayOfWeekend || d == DDEWeekCalendar::AFewDaysofWeek)
             painter.setPen(m_weekendsTextColor);
         else
-            painter.setPen(m_defaultTextColor);
+            painter.setPen(primaryTextColor);
 
         QFontMetrics fm = painter.fontMetrics();
 
@@ -356,7 +357,8 @@ void CWeekHeadView::paintCell(QWidget *cell)
             if (d == DDEWeekCalendar::FirstDayOfWeekend || d == DDEWeekCalendar::AFewDaysofWeek)
                 painter.setPen(m_weekendsTextColor);
             else
-                painter.setPen(m_defaultLunarColor);
+                painter.setPen(lunarTextColor);
+            painter.setFont(lunarFont);
 
             if (cell->width() < 132) {
                 QString str_dayLunar = nullptr;


### PR DESCRIPTION
## Summary
Update week/day header text colors to improve readability in light and dark themes.

更新周视图/日视图头部文字颜色，提升浅色和深色主题下的可读性。

## Changes
- Use theme-aware colors for week header date and weekday text.
- Adjust primary text opacity for better visual balance.
- Keep lunar text styling consistent with the requested weight.
- Preserve weekend highlighting behavior.

- 为周视图头部日期和星期文字使用适配主题的颜色。
- 调整主文本透明度，让整体视觉更平衡。
- 保持农历文本样式与预期字重一致。
- 保留周末高亮逻辑不变。

## Notes
- Improves readability in week view and month-related calendar views.
- No functional behavior changes.

- 提升周视图及月历相关区域的可读性。
- 不涉及功能行为变更。

## Summary by Sourcery

Improve week and month calendar header text styling for clearer light- and dark-theme presentation.

Bug Fixes:
- Improve calendar header text readability across light and dark themes.

Enhancements:
- Apply theme-aware opacity to day and weekday labels, standardize lunar text weight, and preserve weekend highlighting.