### PR TITLE
fix(widget): clear press state on popup dismiss

### DIFF
--- a/src/calendar-client/src/customWidget/scheduleview.cpp
+++ b/src/calendar-client/src/customWidget/scheduleview.cpp
@@ -551,7 +551,16 @@ void CScheduleView::slotScheduleShow(const bool isShow, const DSchedule::Ptr &ou
         }
     } else {
         // qCDebug(ClientLogger) << "Hiding schedule widget";
+        //记录浮窗位置用于隐藏后刷新阴影残留区域
+        const QRect popupRect = m_ScheduleRemindWidget->geometry();
         m_ScheduleRemindWidget->hide();
+        //清除日程条选中高亮状态并强制重绘，消除浮窗与日程条重合处的颜色割裂
+        if (m_graphicsView)
+            m_graphicsView->resetPressState();
+        if (m_alldaylist)
+            m_alldaylist->resetPressState();
+        //刷新浮窗周围区域以清除阴影/模糊残留
+        this->update(popupRect.adjusted(-20, -20, 20, 20));
     }
 }
 

--- a/src/calendar-client/src/view/draginfographicsview.cpp
+++ b/src/calendar-client/src/view/draginfographicsview.cpp
@@ -1095,6 +1095,21 @@ void DragInfoGraphicsView::pressScheduleInit()
     m_PressScheduleInfo = DSchedule::Ptr();
 }
 
+void DragInfoGraphicsView::resetPressState()
+{
+    qCDebug(ClientLogger) << "DragInfoGraphicsView::resetPressState";
+    m_press = false;
+    setPressSelectInfo(DSchedule::Ptr());
+    pressScheduleInit();
+    DragInfoItem::setPressFlag(false);
+    if (m_Scene) {
+        m_Scene->update();
+    }
+    if (viewport()) {
+        viewport()->update();
+    }
+}
+
 QDate DragInfoGraphicsView::getCurrentDate() const
 {
     // qCDebug(ClientLogger) << "DragInfoGraphicsView::getCurrentDate";

--- a/src/calendar-client/src/view/draginfographicsview.h
+++ b/src/calendar-client/src/view/draginfographicsview.h
@@ -99,6 +99,8 @@ public:
     virtual void setSelectSearchSchedule(const DSchedule::Ptr &scheduleInfo);
     //初始化点击日程
     void pressScheduleInit();
+    //重置点击选中状态并刷新场景，用于浮窗隐藏后清除选中高亮和阴影残留
+    void resetPressState();
     QDate getCurrentDate() const;
     void setCurrentDate(const QDate &currentDate);
 

--- a/src/calendar-client/src/widget/monthWidget/monthview.cpp
+++ b/src/calendar-client/src/widget/monthWidget/monthview.cpp
@@ -100,7 +100,14 @@ void CMonthView::slotScheduleRemindWidget(const bool isShow, const DSchedule::Pt
         }
     } else {
         // qCDebug(ClientLogger) << "Hiding schedule reminder widget";
+        //记录浮窗位置用于隐藏后刷新阴影残留区域
+        const QRect popupRect = m_remindWidget->geometry();
         m_remindWidget->hide();
+        //清除日程条选中高亮状态并强制重绘，消除浮窗与日程条重合处的颜色割裂
+        if (m_monthGraphicsView)
+            m_monthGraphicsView->resetPressState();
+        //刷新浮窗周围区域以清除阴影/模糊残留
+        this->update(popupRect.adjusted(-20, -20, 20, 20));
     }
 }
 


### PR DESCRIPTION
## 修复内容

点击日程弹出浮窗，再点击别处关闭后，日程条与浮窗重合区域出现颜色割裂残留。

### 原因
浮窗隐藏时只调用了 hide()，未清除日程条的选中高亮静态状态，也未强制 scene 重绘和刷新阴影残留区域，三者叠加导致重叠处颜色割裂。

### 改动
1. 在 DragInfoGraphicsView 中新增 resetPressState()，清除静态选中状态并强制场景与视口重绘。
2. 在周/日视图与月视图的浮窗隐藏逻辑中调用 resetPressState()，清除日程条残留高亮。
3. 隐藏浮窗前记录几何位置，关闭后重绘周边区域，清除阴影在重叠处的残留。
4. 覆盖周视图、日视图与月视图三个入口。

### 关联
PMS: https://pms.uniontech.com/bug-view-374903.html

## Summary by Sourcery

Ensure schedule popup dismissal fully clears selection and visual rendering remnants across calendar views.

Bug Fixes:
- Clear stale schedule selection highlights and popup shadow artifacts after dismissing schedule popups in week, day, and month views.

Enhancements:
- Centralize press-state reset and force scene, viewport, and surrounding-area refreshes when popups are hidden.