### PR TITLE
fix(widget): keep popup inside schedule view bounds

### DIFF
--- a/src/calendar-client/src/customWidget/scheduleview.cpp
+++ b/src/calendar-client/src/customWidget/scheduleview.cpp
@@ -539,15 +539,26 @@ void CScheduleView::slotScheduleShow(const bool isShow, const DSchedule::Ptr &ou
         m_ScheduleRemindWidget->setData(out, gdColor);
         const auto rPos = this->mapFromGlobal(pos22);
         const int offsetPx = 15; // 逻辑像素偏移，与 rPos 同一坐标系
+        //rPos 相对于 CScheduleView，边界判断也用 CScheduleView 自身宽度，
+        //避免日视图右侧有迷你日历时浮窗超出视图右边界被裁剪
+        const int popupW = m_ScheduleRemindWidget->width();
+        const int popupH = m_ScheduleRemindWidget->height();
+        //箭头垂直居中，计算浮窗上下边界以防止纵向溢出
+        const int arrowY = (popupH - m_ScheduleRemindWidget->arrowWidth()) / 2;
+        int showY = rPos.y();
+        if (showY - arrowY < 0)
+            showY = arrowY;
+        else if (showY - arrowY + popupH > this->height())
+            showY = this->height() - popupH + arrowY;
 
-        if ((rPos.x() + m_ScheduleRemindWidget->width() + offsetPx) > this->window()->width()) {
+        if ((rPos.x() + popupW + offsetPx) > this->width()) {
             qCDebug(ClientLogger) << "Positioning widget to the right";
             m_ScheduleRemindWidget->setDirection(DArrowRectangle::ArrowRight);
-            m_ScheduleRemindWidget->show(rPos.x() - offsetPx, rPos.y());
+            m_ScheduleRemindWidget->show(rPos.x() - offsetPx, showY);
         } else {
             qCDebug(ClientLogger) << "Positioning widget to the left";
             m_ScheduleRemindWidget->setDirection(DArrowRectangle::ArrowLeft);
-            m_ScheduleRemindWidget->show(rPos.x() + offsetPx, rPos.y());
+            m_ScheduleRemindWidget->show(rPos.x() + offsetPx, showY);
         }
     } else {
         // qCDebug(ClientLogger) << "Hiding schedule widget";


### PR DESCRIPTION
## 修复内容

日视图里点击日程弹出的浮窗有时显示不全，被右侧迷你日历遮挡。

### 原因
浮窗右边界判断用的是 `this->window()->width()`（整个窗口宽度），但 `rPos` 是相对于 `CScheduleView` 的坐标。日视图中 `CScheduleView` 只占窗口左侧约一半，右侧还有迷你日历，导致边界判断几乎永远不成立，浮窗总是往右弹，超出 `CScheduleView` 右边界被裁剪。

### 改动
1. 浮窗右边界判断由窗口宽度改为 CScheduleView 自身宽度，避免浮窗超出日视图右边界被迷你日历遮挡。
2. 限制浮窗纵向位置，箭头保持垂直居中，防止浮窗上下溢出日程视图。
3. 日视图与周视图共用同一弹窗路径，一并修复。

### 关联
PMS: https://pms.uniontech.com/bug-view-374977.html

## Summary by Sourcery

Keep schedule reminder popups fully visible within day and week schedule views.

Bug Fixes:
- Keep schedule reminder popups within the schedule view's horizontal bounds so they are not clipped or obscured by the mini calendar.
- Constrain popup placement vertically within the schedule view while preserving the arrow's centered alignment.