### PR TITLE
fix(day-view): add right margin to today button in mini calendar

### DIFF
--- a/src/calendar-client/src/widget/dayWidget/daymonthview.cpp
+++ b/src/calendar-client/src/widget/dayWidget/daymonthview.cpp
@@ -217,7 +217,7 @@ void CDayMonthView::initUI()
     QHBoxLayout *titleLayout = new QHBoxLayout;
     titleLayout->setContentsMargins(0, 0, 0, 0);
     titleLayout->setSpacing(0);
-    titleLayout->setContentsMargins(0, 0, 0, 3);
+    titleLayout->setContentsMargins(0, 0, 10, 3);
     //add separator line
     m_currentMouth = new CustomFrame(this);
     m_currentMouth->setFixedSize(74, DDEDayCalendar::D_MLabelHeight);


### PR DESCRIPTION
## 修复内容

日视图下，小日历右上角"返回今天"按钮右侧贴边，与背景圆角之间无间距，应当为 10px。

### 原因
标题栏布局 `titleLayout` 右侧 contents margin 为 0，"返回今天"按钮以 `Qt::AlignRight` 右对齐，导致按钮紧贴小日历背景右边缘。

### 改动
1. 将 `CDayMonthView::initUI()` 中标题栏布局右侧边距由 0 改为 10px，使"返回今天"按钮与背景保持 10px 间距。

### 关联
PMS: https://pms.uniontech.com/bug-view-375039.html

## Summary by Sourcery

Bug Fixes:
- Add the intended 10px right spacing between the day view mini-calendar’s “Return to Today” button and its rounded background edge.