### PR TITLE
fix: update Arabic (ar) translations

### DIFF
--- a/translations/dde-calendar-service_ar.ts
+++ b/translations/dde-calendar-service_ar.ts
@@ -869,7 +869,7 @@
     <message>
         <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="258"/>
         <source>%1 to %2</source>
-        <translation>'%1 إلى %2'</translation>
+        <translation>&apos;%1 إلى %2&apos;</translation>
     </message>
     <message>
         <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="296"/>
@@ -1041,12 +1041,12 @@
     <message>
         <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="152"/>
         <source>Color:</source>
-        <translation>'اللون:'</translation>
+        <translation>&apos;اللون:&apos;</translation>
     </message>
     <message>
         <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="156"/>
         <source>ICS File:</source>
-        <translation>'ملف ICS:'</translation>
+        <translation>&apos;ملف ICS:&apos;</translation>
     </message>
     <message>
         <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="167"/>

--- a/translations/dde-calendar_ar.ts
+++ b/translations/dde-calendar_ar.ts
@@ -869,7 +869,7 @@
     <message>
         <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="258"/>
         <source>%1 to %2</source>
-        <translation>'%1 إلى %2'</translation>
+        <translation>&apos;%1 إلى %2&apos;</translation>
     </message>
     <message>
         <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="296"/>
@@ -1041,12 +1041,12 @@
     <message>
         <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="152"/>
         <source>Color:</source>
-        <translation>'اللون:'</translation>
+        <translation>&apos;اللون:&apos;</translation>
     </message>
     <message>
         <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="156"/>
         <source>ICS File:</source>
-        <translation>'ملف ICS:'</translation>
+        <translation>&apos;ملف ICS:&apos;</translation>
     </message>
     <message>
         <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="167"/>


### PR DESCRIPTION
Update Arabic (ar) translations

## Summary by Sourcery

Bug Fixes:
- Correct Arabic translation markup in both calendar translation catalogs by escaping apostrophes as XML entities.