### PR TITLE
feat(common): add CalDAV common foundation

### DIFF
--- a/src/calendar-client/src/dbus/dbuscalendar_adaptor.cpp
+++ b/src/calendar-client/src/dbus/dbuscalendar_adaptor.cpp
@@ -26,6 +26,7 @@
 #include <QtCore/QStringList>
 #include <QtCore/QUuid>
 #include <QtCore/QVariant>
+#include <QSharedPointer>
 
 /*
  * Implementation of adaptor class CalendarAdaptor
@@ -82,11 +83,13 @@ static QString pickUserScheduleType(const DScheduleType::List &types)
 // available between the caller's earlier check and now), then falls back
 // to a synchronous call to AccountManager to get account list.
 // Returns an invalid interface (isValid() == false) if unavailable.
-static QDBusInterface getLocalAccountInterface()
+using QDBusInterfacePtr = QSharedPointer<QDBusInterface>;
+
+static QDBusInterfacePtr getLocalAccountInterface()
 {
     auto item = gAccountManager->getLocalAccountItem();
     if (item) {
-        return QDBusInterface(
+        return QDBusInterfacePtr::create(
             "com.deepin.dataserver.Calendar",
             item->getAccount()->dbusPath(),
             item->getAccount()->dbusInterface(),
@@ -104,18 +107,18 @@ static QDBusInterface getLocalAccountInterface()
     QDBusReply<QString> reply = mgrIface.call("getAccountList");
     if (!reply.isValid()) {
         qCWarning(ClientLogger) << "Failed to get account list:" << reply.error().message();
-        return QDBusInterface("", "", "", QDBusConnection::sessionBus());
+        return QDBusInterfacePtr::create("", "", "", QDBusConnection::sessionBus());
     }
 
     DAccount::List accountList;
     if (!DAccount::fromJsonListString(accountList, reply.value())) {
         qCWarning(ClientLogger) << "Failed to parse account list";
-        return QDBusInterface("", "", "", QDBusConnection::sessionBus());
+        return QDBusInterfacePtr::create("", "", "", QDBusConnection::sessionBus());
     }
 
     for (const auto &acc : accountList) {
         if (acc->accountType() == DAccount::Account_Local) {
-            return QDBusInterface(
+            return QDBusInterfacePtr::create(
                 "com.deepin.dataserver.Calendar",
                 acc->dbusPath(),
                 acc->dbusInterface(),
@@ -124,7 +127,7 @@ static QDBusInterface getLocalAccountInterface()
     }
 
     qCWarning(ClientLogger) << "No local account found";
-    return QDBusInterface("", "", "", QDBusConnection::sessionBus());
+    return QDBusInterfacePtr::create("", "", "", QDBusConnection::sessionBus());
 }
 
 // Apply JSON update fields to an existing schedule.
@@ -440,13 +443,13 @@ QString CalendarAdaptor::CreateSchedule(const QString &scheduleData)
         }
 
         // Fallback: directly call backend service synchronously
-        QDBusInterface accountIface = getLocalAccountInterface();
-        if (!accountIface.isValid()) {
+        QDBusInterfacePtr accountIface = getLocalAccountInterface();
+        if (!accountIface->isValid()) {
             return QString();
         }
 
         // Get schedule type list
-        QDBusReply<QString> typeListReply = accountIface.call("getScheduleTypeList");
+        QDBusReply<QString> typeListReply = accountIface->call("getScheduleTypeList");
         if (!typeListReply.isValid()) {
             qCWarning(ClientLogger) << "Failed to get schedule type list:" << typeListReply.error().message();
             return QString();
@@ -463,7 +466,7 @@ QString CalendarAdaptor::CreateSchedule(const QString &scheduleData)
         // Create the schedule
         QString scheduleJson;
         DSchedule::toJsonString(schedule, scheduleJson);
-        QDBusReply<QString> createReply = accountIface.call("createSchedule", QVariant(scheduleJson));
+        QDBusReply<QString> createReply = accountIface->call("createSchedule", QVariant(scheduleJson));
         if (!createReply.isValid()) {
             qCWarning(ClientLogger) << "Failed to create schedule:" << createReply.error().message();
             return QString();
@@ -503,11 +506,11 @@ bool CalendarAdaptor::ModifySchedule(const QString &scheduleId,
                 }
             }
             // Fallback: directly call backend
-            QDBusInterface accountIface = getLocalAccountInterface();
-            if (!accountIface.isValid()) {
+            QDBusInterfacePtr accountIface = getLocalAccountInterface();
+            if (!accountIface->isValid()) {
                 return false;
             }
-            QDBusReply<bool> delReply = accountIface.call("deleteScheduleByScheduleID", QVariant(scheduleId));
+            QDBusReply<bool> delReply = accountIface->call("deleteScheduleByScheduleID", QVariant(scheduleId));
             return delReply.isValid() && delReply.value();
 
         } else if (operation == "update") {
@@ -530,13 +533,13 @@ bool CalendarAdaptor::ModifySchedule(const QString &scheduleId,
 
             // Fallback: directly call backend
             // (reached when account is null OR schedule not in cache)
-            QDBusInterface accountIface = getLocalAccountInterface();
-            if (!accountIface.isValid()) {
+            QDBusInterfacePtr accountIface = getLocalAccountInterface();
+            if (!accountIface->isValid()) {
                 return false;
             }
 
             // Fetch existing schedule, merge updates, then save
-            QDBusReply<QString> getReply = accountIface.call("getScheduleByScheduleID", QVariant(scheduleId));
+            QDBusReply<QString> getReply = accountIface->call("getScheduleByScheduleID", QVariant(scheduleId));
             if (!getReply.isValid()) {
                 return false;
             }
@@ -551,7 +554,7 @@ bool CalendarAdaptor::ModifySchedule(const QString &scheduleId,
 
             QString scheduleJson;
             DSchedule::toJsonString(schedule, scheduleJson);
-            QDBusReply<bool> updReply = accountIface.call("updateSchedule", QVariant(scheduleJson));
+            QDBusReply<bool> updReply = accountIface->call("updateSchedule", QVariant(scheduleJson));
             return updReply.isValid() && updReply.value();
 
         } else if (operation == "snooze") {

--- a/src/calendar-common/src/dcaldavaccountinfo.h
+++ b/src/calendar-common/src/dcaldavaccountinfo.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVACCOUNTINFO_H
+#define DCALDAVACCOUNTINFO_H
+
+#include <QDateTime>
+#include <QString>
+
+class DCalDavAccountInfo
+{
+public:
+    QString accountId;
+    int providerType = 0;
+    QString serverUrl;
+    QString username;
+    QString credentialRef;
+    QString accountColor;
+    int retryCount = 0;
+    QDateTime nextRetryAt;
+};
+
+#endif // DCALDAVACCOUNTINFO_H

--- a/src/calendar-common/src/dcaldavaccountstatus.h
+++ b/src/calendar-common/src/dcaldavaccountstatus.h
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVACCOUNTSTATUS_H
+#define DCALDAVACCOUNTSTATUS_H
+
+#include "dcaldaverrorcode.h"
+
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QRegularExpression>
+#include <QString>
+#include <QVector>
+
+class DCalDavSyncStatus
+{
+public:
+    enum Value {
+        Idle = 0,
+        Running = 1,
+        Succeeded = 2,
+        Failed = 3,
+        AuthenticationRequired = 4,
+        PermissionDenied = 5,
+        Conflict = 6,
+        RetryScheduled = 7,
+    };
+
+    static Value fromErrorCode(DCalDavErrorCode errorCode)
+    {
+        switch (errorCode) {
+        case DCalDavErrorCode::AuthenticationFailed:
+            return AuthenticationRequired;
+        case DCalDavErrorCode::PermissionDenied:
+            return PermissionDenied;
+        case DCalDavErrorCode::Conflict:
+            return Conflict;
+        default:
+            return Failed;
+        }
+    }
+
+    static QString localizedFailureReason(DCalDavErrorCode errorCode)
+    {
+        switch (errorCode) {
+        case DCalDavErrorCode::CertificateInvalid:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus", "The server certificate is invalid.");
+        case DCalDavErrorCode::AuthenticationFailed:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus", "Incorrect username or password. Please try again.");
+        case DCalDavErrorCode::UnsupportedCalDav:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus",
+                "This server does not support CalDAV.");
+        case DCalDavErrorCode::ParseError:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus",
+                "Unable to parse the data returned by the server. Please verify the server address or try again later.");
+        case DCalDavErrorCode::PermissionDenied:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus", "The server denied access.");
+        case DCalDavErrorCode::RequestTimedOut:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus", "The server request timed out.");
+        case DCalDavErrorCode::NetworkUnavailable:
+        case DCalDavErrorCode::NetworkError:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus",
+                "Unable to connect to the server. Please check your network connection and server address.");
+        default:
+            return QCoreApplication::translate("DCalDavSyncStatus", "Synchronization failed.");
+        }
+    }
+
+};
+
+class DCalDavCredentialReference
+{
+public:
+    static bool isValid(const QString &reference)
+    {
+        if (reference.isEmpty()) {
+            return true;
+        }
+        static const QRegularExpression pattern(
+            QStringLiteral("^secret-service:(/(?:[A-Za-z0-9_]+))+$"));
+        return reference.size() <= 512 && pattern.match(reference).hasMatch();
+    }
+};
+
+class DCalDavAccountStatus
+{
+public:
+    typedef QVector<DCalDavAccountStatus> List;
+
+    QString accountId;
+    QString displayName;
+    int providerType = 0;
+    int syncStatus = 0;
+    QDateTime lastSuccessfulSync;
+    QString failureReason;
+    int failureCode = static_cast<int>(DCalDavErrorCode::NoError);
+    QString accountColor;
+    bool supportsWrite = true;
+    int pendingOperationCount = 0;
+    int pendingDeleteCount = 0;
+    int conflictCount = 0;
+    QDateTime nextRetryAt;
+
+    static QString toJsonListString(const List &statusList)
+    {
+        QJsonArray array;
+        for (const DCalDavAccountStatus &status : statusList) {
+            QJsonObject object;
+            object.insert(QStringLiteral("accountId"), status.accountId);
+            object.insert(QStringLiteral("displayName"), status.displayName);
+            object.insert(QStringLiteral("providerType"), status.providerType);
+            object.insert(QStringLiteral("syncStatus"), status.syncStatus);
+            object.insert(QStringLiteral("lastSuccessfulSync"), status.lastSuccessfulSync.toString(Qt::ISODate));
+            object.insert(QStringLiteral("failureReason"), status.failureReason);
+            object.insert(QStringLiteral("failureCode"), status.failureCode);
+            object.insert(QStringLiteral("accountColor"), status.accountColor);
+            object.insert(QStringLiteral("supportsWrite"), status.supportsWrite);
+            object.insert(QStringLiteral("pendingOperationCount"), status.pendingOperationCount);
+            object.insert(QStringLiteral("pendingDeleteCount"), status.pendingDeleteCount);
+            object.insert(QStringLiteral("conflictCount"), status.conflictCount);
+            object.insert(QStringLiteral("nextRetryAt"), status.nextRetryAt.toString(Qt::ISODate));
+            array.append(object);
+        }
+        return QString::fromUtf8(QJsonDocument(array).toJson(QJsonDocument::Compact));
+    }
+
+    static bool fromJsonListString(List &statusList, const QString &json)
+    {
+        const QJsonDocument document = QJsonDocument::fromJson(json.toUtf8());
+        if (!document.isArray()) {
+            return false;
+        }
+
+        List parsed;
+        for (const QJsonValue &value : document.array()) {
+            if (!value.isObject()) {
+                return false;
+            }
+            const QJsonObject object = value.toObject();
+            DCalDavAccountStatus status;
+            status.accountId = object.value(QStringLiteral("accountId")).toString();
+            status.displayName = object.value(QStringLiteral("displayName")).toString();
+            status.providerType = object.value(QStringLiteral("providerType")).toInt();
+            status.syncStatus = object.value(QStringLiteral("syncStatus")).toInt();
+            status.lastSuccessfulSync = QDateTime::fromString(object.value(QStringLiteral("lastSuccessfulSync")).toString(), Qt::ISODate);
+            status.failureReason = object.value(QStringLiteral("failureReason")).toString();
+            status.failureCode = object.contains(QStringLiteral("failureCode"))
+                ? object.value(QStringLiteral("failureCode")).toInt()
+                : static_cast<int>(DCalDavErrorCode::NoError);
+            status.accountColor = object.value(QStringLiteral("accountColor")).toString();
+            status.supportsWrite = object.value(QStringLiteral("supportsWrite")).toBool(true);
+            status.pendingOperationCount = object.value(QStringLiteral("pendingOperationCount")).toInt();
+            status.pendingDeleteCount = object.value(QStringLiteral("pendingDeleteCount")).toInt();
+            status.conflictCount = object.value(QStringLiteral("conflictCount")).toInt();
+            status.nextRetryAt = QDateTime::fromString(
+                object.value(QStringLiteral("nextRetryAt")).toString(), Qt::ISODate);
+            parsed.append(status);
+        }
+        statusList = parsed;
+        return true;
+    }
+};
+
+#endif // DCALDAVACCOUNTSTATUS_H

--- a/src/calendar-common/src/dcaldavcalendarinfo.h
+++ b/src/calendar-common/src/dcaldavcalendarinfo.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVCALENDARINFO_H
+#define DCALDAVCALENDARINFO_H
+
+#include <QString>
+#include <QVector>
+
+class DCalDavCalendarInfo
+{
+public:
+    typedef QVector<DCalDavCalendarInfo> List;
+
+    QString calendarId;
+    QString accountId;
+    QString href;
+    QString displayName;
+    QString color;
+    QString scheduleTypeID;
+    QString syncToken;
+    bool initialSyncCompleted = false;
+    int privileges = 0;
+    bool privilegesKnown = false;
+    bool enabled = true;
+};
+
+#endif // DCALDAVCALENDARINFO_H

--- a/src/calendar-common/src/dcaldavcategoryinfo.h
+++ b/src/calendar-common/src/dcaldavcategoryinfo.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVCATEGORYINFO_H
+#define DCALDAVCATEGORYINFO_H
+
+#include <QString>
+#include <QVector>
+
+class DCalDavCategoryInfo
+{
+public:
+    typedef QVector<DCalDavCategoryInfo> List;
+
+    QString accountId;
+    QString calendarId;
+    QString categoryKey;
+    QString scheduleTypeId;
+};
+
+#endif // DCALDAVCATEGORYINFO_H

--- a/src/calendar-common/src/dcaldavcredentialstore.cpp
+++ b/src/calendar-common/src/dcaldavcredentialstore.cpp
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavcredentialstore.h"
+
+#include <QDBusArgument>
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusMessage>
+#include <QDBusMetaType>
+#include <QDBusObjectPath>
+#include <QDBusVariant>
+#include <QEventLoop>
+#include <QMap>
+#include <QVariant>
+#include <QVariantMap>
+#include <QRegularExpression>
+#include <QTimer>
+
+typedef QMap<QString, QString> DCalDavSecretAttributes;
+Q_DECLARE_METATYPE(DCalDavSecretAttributes)
+
+namespace {
+
+const char *const SecretServiceName = "org.freedesktop.secrets";
+const char *const SecretServicePath = "/org/freedesktop/secrets";
+const char *const DefaultCollectionPath = "/org/freedesktop/secrets/aliases/default";
+const char *const SecretServiceInterface = "org.freedesktop.Secret.Service";
+const char *const SecretCollectionInterface = "org.freedesktop.Secret.Collection";
+const char *const SecretItemInterface = "org.freedesktop.Secret.Item";
+const char *const SecretPromptInterface = "org.freedesktop.Secret.Prompt";
+constexpr int kSecretServiceTimeoutMs = 10000;
+constexpr int kSecretPromptTimeoutMs = 30000;
+const char *const CalendarApplicationAttribute = "org.deepin.dde-calendar";
+
+void setError(QString *errorMessage, const QString &message)
+{
+    if (errorMessage != nullptr) {
+        *errorMessage = message;
+    }
+}
+
+bool isRootPath(const QDBusObjectPath &path)
+{
+    return path.path().isEmpty() || path.path() == QStringLiteral("/");
+}
+
+class SecretPromptWaiter final : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SecretPromptWaiter(QEventLoop *eventLoop)
+        : m_eventLoop(eventLoop)
+    {
+    }
+
+    bool completed() const
+    {
+        return m_completed;
+    }
+
+    bool dismissed() const
+    {
+        return m_dismissed;
+    }
+
+public slots:
+    void slotCompleted(bool dismissed)
+    {
+        m_dismissed = dismissed;
+        m_completed = true;
+        if (m_eventLoop != nullptr) {
+            m_eventLoop->quit();
+        }
+    }
+
+private:
+    QEventLoop *m_eventLoop = nullptr;
+    bool m_completed = false;
+    bool m_dismissed = false;
+};
+
+bool promptAndWait(QDBusConnection bus, const QDBusObjectPath &promptPath,
+                  QString *errorMessage)
+{
+    if (isRootPath(promptPath)) {
+        return true;
+    }
+    if (!bus.isConnected() || promptPath.path().isEmpty()) {
+        setError(errorMessage, QStringLiteral("Secret Service prompt is unavailable."));
+        return false;
+    }
+
+    QDBusInterface prompt(QLatin1String(SecretServiceName), promptPath.path(),
+                          QLatin1String(SecretPromptInterface), bus);
+    prompt.setTimeout(kSecretServiceTimeoutMs);
+    if (!prompt.isValid()) {
+        setError(errorMessage, QStringLiteral("Secret Service prompt is unavailable."));
+        return false;
+    }
+
+    QEventLoop eventLoop;
+    QTimer timeoutTimer;
+    timeoutTimer.setSingleShot(true);
+    SecretPromptWaiter waiter(&eventLoop);
+    if (!bus.connect(QLatin1String(SecretServiceName), promptPath.path(),
+                     QLatin1String(SecretPromptInterface), QStringLiteral("Completed"),
+                     &waiter, SLOT(slotCompleted(bool)))) {
+        setError(errorMessage, QStringLiteral("Secret Service prompt could not be monitored."));
+        return false;
+    }
+
+    const QDBusMessage reply = prompt.call(QStringLiteral("Prompt"), QString());
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        bus.disconnect(QLatin1String(SecretServiceName), promptPath.path(),
+                      QLatin1String(SecretPromptInterface), QStringLiteral("Completed"),
+                      &waiter, SLOT(slotCompleted(bool)));
+        setError(errorMessage, QStringLiteral("Secret Service prompt could not be shown."));
+        return false;
+    }
+
+    QObject::connect(&timeoutTimer, &QTimer::timeout, &eventLoop, &QEventLoop::quit);
+    timeoutTimer.start(kSecretPromptTimeoutMs);
+    if (!waiter.completed()) {
+        eventLoop.exec();
+    }
+    bus.disconnect(QLatin1String(SecretServiceName), promptPath.path(),
+                   QLatin1String(SecretPromptInterface), QStringLiteral("Completed"),
+                   &waiter, SLOT(slotCompleted(bool)));
+
+    if (!waiter.completed()) {
+        setError(errorMessage, QStringLiteral("Secret Service prompt timed out."));
+        return false;
+    }
+    if (waiter.dismissed()) {
+        setError(errorMessage, QStringLiteral("Secret Service prompt was dismissed."));
+        return false;
+    }
+    return true;
+}
+
+bool openSession(const QDBusConnection &bus, QDBusObjectPath &sessionPath, QString *errorMessage)
+{
+    if (!bus.isConnected()) {
+        setError(errorMessage, QStringLiteral("Session D-Bus is unavailable."));
+        return false;
+    }
+
+    QDBusInterface service(QLatin1String(SecretServiceName),
+                           QLatin1String(SecretServicePath),
+                           QLatin1String(SecretServiceInterface), bus);
+    service.setTimeout(kSecretServiceTimeoutMs);
+    if (!service.isValid()) {
+        setError(errorMessage, QStringLiteral("Secret Service is unavailable."));
+        return false;
+    }
+
+    const QDBusMessage reply = service.call(
+        QStringLiteral("OpenSession"), QStringLiteral("plain"),
+        QVariant::fromValue(QDBusVariant(QString())));
+    if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().size() < 2) {
+        setError(errorMessage, QStringLiteral("Secret Service session could not be opened."));
+        return false;
+    }
+
+    sessionPath = reply.arguments().at(1).value<QDBusObjectPath>();
+    if (sessionPath.path().isEmpty()) {
+        setError(errorMessage, QStringLiteral("Secret Service returned an invalid session."));
+        return false;
+    }
+    return true;
+}
+
+void closeSession(const QDBusConnection &bus, const QDBusObjectPath &sessionPath)
+{
+    if (sessionPath.path().isEmpty()) {
+        return;
+    }
+    QDBusInterface service(QLatin1String(SecretServiceName),
+                           QLatin1String(SecretServicePath),
+                           QLatin1String(SecretServiceInterface), bus);
+    if (service.isValid()) {
+        service.setTimeout(kSecretServiceTimeoutMs);
+        service.call(QStringLiteral("CloseSession"), QVariant::fromValue(sessionPath));
+    }
+}
+
+} // namespace
+
+bool DCalDavCredentialStore::storePassword(const QString &label, const QString &password,
+                                           QString &credentialRef, QString *errorMessage)
+{
+    credentialRef.clear();
+    if (label.trimmed().isEmpty() || password.isEmpty()) {
+        setError(errorMessage, QStringLiteral("CalDAV credential label or password is empty."));
+        return false;
+    }
+
+    const QDBusConnection bus = QDBusConnection::sessionBus();
+    QDBusObjectPath sessionPath;
+    if (!openSession(bus, sessionPath, errorMessage)) {
+        return false;
+    }
+
+    qDBusRegisterMetaType<DCalDavSecretAttributes>();
+    QVariantMap properties;
+    properties.insert(QStringLiteral("org.freedesktop.Secret.Item.Label"), label);
+    DCalDavSecretAttributes attributes;
+    attributes.insert(QStringLiteral("application"), QLatin1String(CalendarApplicationAttribute));
+    properties.insert(QStringLiteral("org.freedesktop.Secret.Item.Attributes"),
+                      QVariant::fromValue(attributes));
+
+    QDBusArgument secret;
+    secret.beginStructure();
+    secret << sessionPath << QByteArray() << password.toUtf8() << QStringLiteral("text/plain");
+    secret.endStructure();
+
+    QDBusInterface collection(QLatin1String(SecretServiceName),
+                              QLatin1String(DefaultCollectionPath),
+                              QLatin1String(SecretCollectionInterface), bus);
+    collection.setTimeout(kSecretServiceTimeoutMs);
+    const QDBusMessage reply = collection.call(
+        QStringLiteral("CreateItem"), properties, QVariant::fromValue(secret), false);
+    if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().size() < 2) {
+        closeSession(bus, sessionPath);
+        setError(errorMessage, QStringLiteral("Secret Service item could not be created."));
+        return false;
+    }
+
+    const QDBusObjectPath itemPath = reply.arguments().at(0).value<QDBusObjectPath>();
+    const QDBusObjectPath promptPath = reply.arguments().at(1).value<QDBusObjectPath>();
+    if (!promptAndWait(bus, promptPath, errorMessage)) {
+        closeSession(bus, sessionPath);
+        return false;
+    }
+    closeSession(bus, sessionPath);
+    if (itemPath.path().isEmpty() || itemPath.path() == QStringLiteral("/")) {
+        setError(errorMessage, QStringLiteral("Secret Service returned an invalid item."));
+        return false;
+    }
+
+    credentialRef = QStringLiteral("secret-service:") + itemPath.path();
+    return true;
+}
+
+bool DCalDavCredentialStore::readPassword(const QString &credentialRef, QString &password,
+                                          QString *errorMessage)
+{
+    password.clear();
+    QString itemPath;
+    if (!parseItemPath(credentialRef, itemPath)) {
+        setError(errorMessage, QStringLiteral("Invalid Secret Service credential reference."));
+        return false;
+    }
+
+    const QDBusConnection bus = QDBusConnection::sessionBus();
+    QDBusObjectPath sessionPath;
+    if (!openSession(bus, sessionPath, errorMessage)) {
+        return false;
+    }
+
+    bool success = false;
+    QDBusInterface item(QLatin1String(SecretServiceName), itemPath,
+                        QLatin1String(SecretItemInterface), bus);
+    item.setTimeout(kSecretServiceTimeoutMs);
+    if (item.isValid()) {
+        const QDBusMessage reply = item.call(
+            QStringLiteral("GetSecret"), QVariant::fromValue(sessionPath));
+        if (reply.type() != QDBusMessage::ErrorMessage && !reply.arguments().isEmpty()) {
+            const QDBusArgument secret = reply.arguments().first().value<QDBusArgument>();
+            QDBusObjectPath returnedSession;
+            QByteArray parameters;
+            QByteArray value;
+            QString contentType;
+            secret.beginStructure();
+            secret >> returnedSession >> parameters >> value >> contentType;
+            secret.endStructure();
+            if (returnedSession == sessionPath && !value.isNull()) {
+                password = QString::fromUtf8(value);
+                success = true;
+            }
+        }
+    }
+    closeSession(bus, sessionPath);
+
+    if (!success) {
+        setError(errorMessage, QStringLiteral("Secret Service item could not be read."));
+    }
+    return success;
+}
+
+bool DCalDavCredentialStore::deletePassword(const QString &credentialRef, QString *errorMessage)
+{
+    QString itemPath;
+    if (!parseItemPath(credentialRef, itemPath)) {
+        setError(errorMessage, QStringLiteral("Invalid Secret Service credential reference."));
+        return false;
+    }
+
+    const QDBusConnection bus = QDBusConnection::sessionBus();
+    if (!bus.isConnected()) {
+        setError(errorMessage, QStringLiteral("Session D-Bus is unavailable."));
+        return false;
+    }
+
+    QDBusInterface item(QLatin1String(SecretServiceName), itemPath,
+                        QLatin1String(SecretItemInterface), bus);
+    item.setTimeout(kSecretServiceTimeoutMs);
+    if (!item.isValid()) {
+        setError(errorMessage, QStringLiteral("Secret Service item is unavailable."));
+        return false;
+    }
+
+    const QDBusMessage reply = item.call(QStringLiteral("Delete"));
+    if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().isEmpty()) {
+        setError(errorMessage, QStringLiteral("Secret Service item could not be deleted."));
+        return false;
+    }
+
+    const QDBusObjectPath promptPath = reply.arguments().first().value<QDBusObjectPath>();
+    return promptAndWait(bus, promptPath, errorMessage);
+}
+
+bool DCalDavCredentialStore::parseItemPath(const QString &credentialRef, QString &itemPath)
+{
+    itemPath.clear();
+    const QString prefix = QStringLiteral("secret-service:");
+    if (!credentialRef.startsWith(prefix)) {
+        return false;
+    }
+
+    itemPath = credentialRef.mid(prefix.size());
+    static const QRegularExpression objectPathPattern(
+        QStringLiteral("^(/(?:[A-Za-z0-9_]+))+$"));
+    if (!objectPathPattern.match(itemPath).hasMatch() || itemPath.size() > 512) {
+        itemPath.clear();
+        return false;
+    }
+    return true;
+}
+
+#include "dcaldavcredentialstore.moc"

--- a/src/calendar-common/src/dcaldavcredentialstore.h
+++ b/src/calendar-common/src/dcaldavcredentialstore.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVCREDENTIALSTORE_H
+#define DCALDAVCREDENTIALSTORE_H
+
+#include <QString>
+
+class DCalDavCredentialStore
+{
+public:
+    // credentialRef stores only a Secret Service item reference. Secrets are
+    // never persisted or logged by this class.
+    static bool storePassword(const QString &label, const QString &password,
+                              QString &credentialRef, QString *errorMessage = nullptr);
+    static bool readPassword(const QString &credentialRef, QString &password,
+                             QString *errorMessage = nullptr);
+    static bool deletePassword(const QString &credentialRef, QString *errorMessage = nullptr);
+
+private:
+    static bool parseItemPath(const QString &credentialRef, QString &itemPath);
+};
+
+#endif // DCALDAVCREDENTIALSTORE_H

--- a/src/calendar-common/src/dcaldaverrorcode.h
+++ b/src/calendar-common/src/dcaldaverrorcode.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVERRORCODE_H
+#define DCALDAVERRORCODE_H
+
+enum class DCalDavErrorCode {
+        NoError = 0,
+        InvalidRequest,
+        NetworkUnavailable,
+        RequestTimedOut,
+        CertificateInvalid,
+        AuthenticationFailed,
+        PermissionDenied,
+        RateLimited,
+        ServerUnavailable,
+        Conflict,
+        ResponseTooLarge,
+        NetworkError,
+        UnsupportedCalDav,
+        ParseError,
+        StorageError,
+    Unknown,
+};
+
+#endif // DCALDAVERRORCODE_H

--- a/src/calendar-common/src/dcaldaveventmappinginfo.h
+++ b/src/calendar-common/src/dcaldaveventmappinginfo.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVEVENTMAPPINGINFO_H
+#define DCALDAVEVENTMAPPINGINFO_H
+
+#include <QString>
+#include <QVector>
+
+class DCalDavEventMappingInfo
+{
+public:
+    typedef QVector<DCalDavEventMappingInfo> List;
+
+    QString localScheduleID;
+    QString accountID;
+    QString calendarID;
+    QString uid;
+    QString href;
+    QString etag;
+    QString originalIcs;
+};
+
+#endif // DCALDAVEVENTMAPPINGINFO_H

--- a/src/calendar-common/src/dcaldavoutboxitem.h
+++ b/src/calendar-common/src/dcaldavoutboxitem.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVOUTBOXITEM_H
+#define DCALDAVOUTBOXITEM_H
+
+#include <QDateTime>
+#include <QString>
+#include <QVector>
+
+class DCalDavOutboxItem
+{
+public:
+    enum OperationType {
+        CreateOperation = 0,
+        ModifyOperation = 1,
+        DeleteOperation = 2,
+    };
+
+    enum FailureType {
+        NoFailure = 0,
+        NetworkFailure = 1,
+        AuthenticationFailure = 2,
+        PermissionFailure = 3,
+        ConflictFailure = 4,
+        PermanentFailure = 5,
+    };
+
+    typedef QVector<DCalDavOutboxItem> List;
+
+    QString operationID;
+    QString accountID;
+    QString localScheduleID;
+    OperationType operationType = CreateOperation;
+    QString baseEtag;
+    QString conflictIcs;
+    QString serverIcs;
+    int retryCount = 0;
+    QDateTime nextRetryAt;
+    FailureType failureType = NoFailure;
+};
+
+#endif // DCALDAVOUTBOXITEM_H

--- a/src/calendar-common/src/dcaldavprofile.h
+++ b/src/calendar-common/src/dcaldavprofile.h
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVPROFILE_H
+#define DCALDAVPROFILE_H
+
+#include <QCoreApplication>
+#include <QString>
+#include <QUrl>
+
+class DCalDavProviderProfile
+{
+public:
+    enum ProviderType {
+        Provider_DingTalk,
+        Provider_WeCom,
+        Provider_TencentMeeting,
+        Provider_QQMail,
+        Provider_Feishu,
+        Provider_Other
+    };
+
+    DCalDavProviderProfile()
+        : providerType(Provider_Other)
+        , serverUrlEditable(true)
+        , requiresUsername(true)
+        , requiresPassword(true)
+        , supportsWrite(true)
+    {
+    }
+
+    static QString providerName(ProviderType type)
+    {
+        switch (type) {
+        case Provider_DingTalk:
+            return QCoreApplication::translate("DCalDavProviderProfile", "DingTalk");
+        case Provider_WeCom:
+            return QCoreApplication::translate("DCalDavProviderProfile", "WeCom");
+        case Provider_TencentMeeting:
+            return QCoreApplication::translate("DCalDavProviderProfile", "Tencent Meeting");
+        case Provider_QQMail:
+            return QCoreApplication::translate("DCalDavProviderProfile", "QQ Mail");
+        case Provider_Feishu:
+            return QCoreApplication::translate("DCalDavProviderProfile", "Feishu");
+        case Provider_Other:
+        default:
+            return QCoreApplication::translate("DCalDavProviderProfile", "Other CalDAV");
+        }
+    }
+
+    static QString accountDisplayName(ProviderType type, const QString &name)
+    {
+        return name.isEmpty() ? name : providerName(type) + QStringLiteral("-") + name;
+    }
+
+    static QUrl normalizeServerUrl(const QString &serverUrl)
+    {
+        QString value = serverUrl.trimmed();
+        if (value.isEmpty()) {
+            return QUrl();
+        }
+        if (!value.contains(QStringLiteral("://"))) {
+            value.prepend(QStringLiteral("https://"));
+        }
+        QUrl url(value);
+        if (!url.isValid() || url.host().isEmpty() || !url.userName().isEmpty()
+            || !url.password().isEmpty()
+            || url.scheme().compare(QStringLiteral("https"), Qt::CaseInsensitive) != 0) {
+            return QUrl();
+        }
+        url.setScheme(QStringLiteral("https"));
+        url.setFragment(QString());
+        return url;
+    }
+
+    static ProviderType providerTypeForServerUrl(const QString &serverUrl, ProviderType fallback)
+    {
+        const QString host = QUrl(serverUrl).host().toLower();
+        if (host == QStringLiteral("caldav.wecom.work")) {
+            return Provider_WeCom;
+        }
+        if (host == QStringLiteral("cal.meeting.tencent.com")) {
+            return Provider_TencentMeeting;
+        }
+        if (host == QStringLiteral("calendar.dingtalk.com")) {
+            return Provider_DingTalk;
+        }
+        if (host == QStringLiteral("dav.qq.com")) {
+            return Provider_QQMail;
+        }
+        if (host == QStringLiteral("caldav.feishu.cn")) {
+            return Provider_Feishu;
+        }
+        return fallback;
+    }
+
+    static DCalDavProviderProfile forProvider(ProviderType type)
+    {
+        DCalDavProviderProfile profile;
+        profile.providerType = type;
+
+        switch (type) {
+        case Provider_DingTalk:
+            profile.displayName = QStringLiteral("DingTalk");
+            profile.serverUrl = QStringLiteral("https://calendar.dingtalk.com");
+            break;
+        case Provider_WeCom:
+            profile.displayName = QStringLiteral("WeCom");
+            profile.serverUrl = QStringLiteral("https://caldav.wecom.work");
+            break;
+        case Provider_TencentMeeting:
+            profile.displayName = QStringLiteral("Tencent Meeting");
+            profile.serverUrl = QStringLiteral("https://cal.meeting.tencent.com/caldav/");
+            break;
+        case Provider_QQMail:
+            profile.displayName = QStringLiteral("QQ Mail");
+            profile.serverUrl = QStringLiteral("https://dav.qq.com");
+            break;
+        case Provider_Feishu:
+            profile.displayName = QStringLiteral("Feishu");
+            profile.serverUrl = QStringLiteral("https://caldav.feishu.cn");
+            break;
+        case Provider_Other:
+            profile.displayName = QStringLiteral("Other CalDAV");
+            break;
+        }
+
+        return profile;
+    }
+
+    ProviderType providerType;
+    QString displayName;
+    QString serverUrl;
+    bool serverUrlEditable;
+    bool requiresUsername;
+    bool requiresPassword;
+    bool supportsWrite;
+};
+
+#endif // DCALDAVPROFILE_H

--- a/src/calendar-common/src/dcaldavrecoveryitem.h
+++ b/src/calendar-common/src/dcaldavrecoveryitem.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVRECOVERYITEM_H
+#define DCALDAVRECOVERYITEM_H
+
+#include <QDateTime>
+#include <QString>
+#include <QVector>
+
+class DCalDavRecoveryItem
+{
+public:
+    enum OperationType {
+        CreateOperation = 0,
+        ModifyOperation = 1,
+        DeleteOperation = 2,
+        LocalCreateOperation = 3,
+    };
+
+    typedef QVector<DCalDavRecoveryItem> List;
+
+    QString accountID;
+    QString localScheduleID;
+    OperationType operationType = CreateOperation;
+    QString scheduleIcs;
+    QString calendarID;
+    QString href;
+    QString etag;
+    QString originalIcs;
+    QDateTime createdAt;
+};
+
+#endif // DCALDAVRECOVERYITEM_H

--- a/src/calendar-common/src/dcaldavvalidationerror.h
+++ b/src/calendar-common/src/dcaldavvalidationerror.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVVALIDATIONERROR_H
+#define DCALDAVVALIDATIONERROR_H
+
+class DCalDavValidationError
+{
+public:
+    enum Type {
+        NoError = 0,
+        NetworkUnavailable,
+        AuthenticationFailed,
+        UnsupportedCalDav,
+        CertificateInvalid,
+        Other,
+        ServerRejected,
+        ParseError,
+    };
+};
+
+class DCalDavScheduleCreateError
+{
+public:
+    enum Type {
+        NoError = 0,
+        NetworkUnavailable,
+        PermissionDenied,
+    };
+};
+
+#endif // DCALDAVVALIDATIONERROR_H

--- a/src/calendar-common/src/dcalendareventlog.cpp
+++ b/src/calendar-common/src/dcalendareventlog.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcalendareventlog.h"
+#include "commondef.h"
+
+#include <QDateTime>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QVariant>
+#include <QDebug>
+
+DCalendarEventLog &DCalendarEventLog::instance()
+{
+    static DCalendarEventLog eventLog;
+    return eventLog;
+}
+
+DCalendarEventLog::DCalendarEventLog()
+    : m_library(QStringLiteral("libdeepin-event-log.so"))
+{
+    m_library.setLoadHints(QLibrary::PreventUnloadHint);
+    if (!m_library.load()) {
+        qCWarning(CommonLogger) << "Failed to load calendar event log library:" << m_library.errorString();
+        return;
+    }
+
+    m_initialize = reinterpret_cast<InitializeFunction>(m_library.resolve("Initialize"));
+    m_writeEventLog = reinterpret_cast<WriteEventLogFunction>(m_library.resolve("WriteEventLog"));
+    if (m_initialize == nullptr || m_writeEventLog == nullptr) {
+        qCWarning(CommonLogger) << "Calendar event log symbols are unavailable"
+                                << "library:" << m_library.fileName()
+                                << "error:" << m_library.errorString()
+                                << "initializeResolved:" << (m_initialize != nullptr)
+                                << "writeResolved:" << (m_writeEventLog != nullptr);
+        return;
+    }
+
+    m_available = m_initialize(std::string("dde-calendar"), true);
+    if (!m_available) {
+        qCWarning(CommonLogger) << "Calendar event log initialization failed";
+    }
+}
+
+void DCalendarEventLog::reportAddAccountClicked()
+{
+    writeEvent(AddAccountClicked);
+}
+
+void DCalendarEventLog::reportLoginClicked(
+    DCalDavProviderProfile::ProviderType providerType)
+{
+    writeEvent(LoginClicked, {{QStringLiteral("account_type"), accountType(providerType)}});
+}
+
+void DCalendarEventLog::reportLoginValidationFinished(
+    bool success, DCalDavValidationError::Type validationError)
+{
+    QJsonObject fields;
+    fields.insert(QStringLiteral("verify_result"), success
+                      ? QStringLiteral("success")
+                      : QStringLiteral("fail"));
+    if (!success) {
+        fields.insert(QStringLiteral("fail_reason"), validationFailureReason(validationError));
+    }
+    writeEvent(LoginValidationFinished, fields);
+}
+
+void DCalendarEventLog::reportDeleteAccount(bool deleteData)
+{
+    writeEvent(DeleteAccount, {{QStringLiteral("delete_data"), deleteData}});
+}
+
+void DCalendarEventLog::writeEvent(EventType eventType, const QJsonObject &fields)
+{
+    if (!m_available || m_writeEventLog == nullptr) {
+        qCDebug(CommonLogger) << "Calendar event log is unavailable; event skipped"
+                             << "initialized:" << m_available
+                             << "writeResolved:" << (m_writeEventLog != nullptr);
+        return;
+    }
+
+    QJsonObject event(fields);
+    event.insert(QStringLiteral("tid"), static_cast<int>(eventType));
+    event.insert(QStringLiteral("event_time"),
+                 QJsonValue::fromVariant(QVariant::fromValue(
+                     QDateTime::currentMSecsSinceEpoch())));
+    m_writeEventLog(QJsonDocument(event).toJson(QJsonDocument::Compact).toStdString());
+}
+
+QString DCalendarEventLog::accountType(
+    DCalDavProviderProfile::ProviderType providerType)
+{
+    switch (providerType) {
+    case DCalDavProviderProfile::Provider_DingTalk:
+        return QStringLiteral("dingtalk");
+    case DCalDavProviderProfile::Provider_WeCom:
+        return QStringLiteral("wecom");
+    case DCalDavProviderProfile::Provider_TencentMeeting:
+        return QStringLiteral("tencent_meeting");
+    case DCalDavProviderProfile::Provider_QQMail:
+        return QStringLiteral("qqmail");
+    case DCalDavProviderProfile::Provider_Feishu:
+        return QStringLiteral("feishu");
+    case DCalDavProviderProfile::Provider_Other:
+        return QStringLiteral("caldav_other");
+    default:
+        return QStringLiteral("unknown");
+    }
+}
+
+QString DCalendarEventLog::validationFailureReason(
+    DCalDavValidationError::Type validationError)
+{
+    switch (validationError) {
+    case DCalDavValidationError::AuthenticationFailed:
+        return QStringLiteral("credential_error");
+    case DCalDavValidationError::UnsupportedCalDav:
+    case DCalDavValidationError::ParseError:
+        return QStringLiteral("protocol_error");
+    case DCalDavValidationError::NetworkUnavailable:
+        return QStringLiteral("network_timeout");
+    case DCalDavValidationError::ServerRejected:
+        return QStringLiteral("server_reject");
+    case DCalDavValidationError::CertificateInvalid:
+    case DCalDavValidationError::Other:
+    case DCalDavValidationError::NoError:
+    default:
+        return QStringLiteral("other");
+    }
+}

--- a/src/calendar-common/src/dcalendareventlog.h
+++ b/src/calendar-common/src/dcalendareventlog.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALENDAREVENTLOG_H
+#define DCALENDAREVENTLOG_H
+
+#include "dcaldavprofile.h"
+#include "dcaldavvalidationerror.h"
+
+#include <QJsonObject>
+#include <QLibrary>
+#include <QString>
+
+#include <string>
+
+class DCalendarEventLog
+{
+public:
+    enum EventType {
+        AddAccountClicked = 1002000000,
+        LoginClicked = 1002000001,
+        LoginValidationFinished = 1002000002,
+        DeleteAccount = 1002000003,
+    };
+
+    static DCalendarEventLog &instance();
+
+    void reportAddAccountClicked();
+    void reportLoginClicked(DCalDavProviderProfile::ProviderType providerType);
+    void reportLoginValidationFinished(bool success,
+                                       DCalDavValidationError::Type validationError);
+    void reportDeleteAccount(bool deleteData);
+
+private:
+    using InitializeFunction = bool (*)(const std::string &, bool);
+    using WriteEventLogFunction = void (*)(const std::string &);
+
+    DCalendarEventLog();
+
+    void writeEvent(EventType eventType, const QJsonObject &fields = {});
+    static QString accountType(DCalDavProviderProfile::ProviderType providerType);
+    static QString validationFailureReason(DCalDavValidationError::Type validationError);
+
+    QLibrary m_library;
+    InitializeFunction m_initialize = nullptr;
+    WriteEventLogFunction m_writeEventLog = nullptr;
+    bool m_available = false;
+};
+
+#endif // DCALENDAREVENTLOG_H

--- a/src/calendar-common/src/dschedule.cpp
+++ b/src/calendar-common/src/dschedule.cpp
@@ -18,6 +18,31 @@
 #define Duration_Day 24 * 60 * 60
 #define Duration_Week 7 * 24 * 60 * 60
 
+namespace {
+
+QDate displayDate(const QDateTime &dateTime, bool allDay = false)
+{
+    return allDay ? dateTime.date() : dateTime.toLocalTime().date();
+}
+
+bool hasUsableRecurrence(const DSchedule::Ptr &schedule)
+{
+    if (schedule.isNull() || !schedule->recurs()) {
+        return false;
+    }
+
+    const KCalendarCore::Recurrence *recurrence = schedule->recurrence();
+    const KCalendarCore::RecurrenceRule *rule = recurrence->defaultRRuleConst();
+    if (rule != nullptr && rule->recurrenceType() != KCalendarCore::RecurrenceRule::rNone
+        && !rule->rrule().isEmpty()) {
+        return true;
+    }
+
+    return !recurrence->rDates().isEmpty() || !recurrence->rDateTimes().isEmpty();
+}
+
+} // namespace
+
 DSchedule::DSchedule()
     : KCalendarCore::Event()
     , m_fileName("")
@@ -35,6 +60,7 @@ DSchedule::DSchedule(const DSchedule &schedule)
 {
     // qCDebug(CommonLogger) << "DSchedule copy constructor called for schedule:" << schedule.summary();
     this->setScheduleTypeID(schedule.scheduleTypeID());
+    this->setAccountColor(schedule.accountColor());
 }
 
 DSchedule::DSchedule(const KCalendarCore::Event &event)
@@ -62,6 +88,16 @@ void DSchedule::setScheduleTypeID(const QString &typeID)
 {
     // qCDebug(CommonLogger) << "Setting scheduleTypeID to:" << typeID;
     m_scheduleTypeID = typeID;
+}
+
+QString DSchedule::accountColor() const
+{
+    return m_accountColor;
+}
+
+void DSchedule::setAccountColor(const QString &color)
+{
+    m_accountColor = color;
 }
 
 bool DSchedule::isMoved()
@@ -318,8 +354,19 @@ bool DSchedule::fromIcsString(Ptr &schedule, const QString &string)
     KCalendarCore::MemoryCalendar::Ptr _cal(new KCalendarCore::MemoryCalendar(timezone));
     if (icalformat.fromString(_cal, string)) {
         KCalendarCore::Event::List eventList = _cal->events();
-        if (eventList.size() > 0) {
-            schedule = DSchedule::Ptr(new DSchedule(*eventList.at(0).data())); // eventList.at(0).staticCast<DSchedule>();
+        if (!eventList.isEmpty()) {
+            // A CalDAV resource may contain the master VEVENT followed by
+            // detached exception VEVENTs. This model stores one schedule, so
+            // prefer the master instead of relying on provider-specific event
+            // ordering. EXDATE/RDATE data on the master remains intact.
+            KCalendarCore::Event::Ptr selectedEvent = eventList.first();
+            for (const KCalendarCore::Event::Ptr &event : eventList) {
+                if (!event->hasRecurrenceId()) {
+                    selectedEvent = event;
+                    break;
+                }
+            }
+            schedule = DSchedule::Ptr(new DSchedule(*selectedEvent.data()));
             // qCDebug(CommonLogger) << "Successfully parsed schedule:" << schedule->summary();
             resBool = true;
         }
@@ -451,7 +498,7 @@ void DSchedule::expendRecurrence(DSchedule::Map &scheduleMap, const DSchedule::P
         queryDtStart.setTime(QTime(0,0,0));
     }
 
-    if (schedule->recurs()) {
+    if (hasUsableRecurrence(schedule)) {
         //获取日程的开始结束时间差
         qint64 interval = schedule->dtStart().secsTo(schedule->dtEnd());
         QList<QDateTime> dtList = schedule->recurrence()->timesInInterval(queryDtStart, dtEnd);
@@ -466,12 +513,12 @@ void DSchedule::expendRecurrence(DSchedule::Map &scheduleMap, const DSchedule::P
             if (schedule->dtStart() != dt) {
                 newSchedule->setRecurrenceId(dt);
             }
-            scheduleMap[dt.date()].append(newSchedule);
+            scheduleMap[displayDate(dt, schedule->allDay())].append(newSchedule);
         }
     } else {
         // qCDebug(CommonLogger) << "Schedule does not recur, checking if it falls within the interval.";
         if (!(schedule->dtStart() > dtEnd || schedule->dtEnd() < queryDtStart)) {
-            scheduleMap[schedule->dtStart().date()].append(schedule);
+            scheduleMap[displayDate(schedule->dtStart(), schedule->allDay())].append(schedule);
         }
     }
 }
@@ -488,7 +535,7 @@ QMap<QDate, DSchedule::List> DSchedule::convertSchedules(const DScheduleQueryPar
         //获取日程的开始结束时间差
         qint64 interval = schedule->dtStart().secsTo(schedule->dtEnd());
         //如果存在重复日程
-        if (schedule->recurs()) {
+        if (hasUsableRecurrence(schedule)) {
             // qCDebug(CommonLogger) << "Processing recurring schedule:" << schedule->summary();
             //如果为农历日程
             if (schedule->lunnar()) {
@@ -515,7 +562,7 @@ QMap<QDate, DSchedule::List> DSchedule::convertSchedules(const DScheduleQueryPar
                     if (schedule->dtStart() != recurDateTime) {
                         newSchedule->setRecurrenceId(recurDateTime);
                     }
-                    scheduleMap[recurDateTime.date()].append(newSchedule);
+                    scheduleMap[displayDate(recurDateTime, schedule->allDay())].append(newSchedule);
                 }
             } else {
                 // qCDebug(CommonLogger) << "Processing Gregorian recurring schedule.";
@@ -532,16 +579,18 @@ QMap<QDate, DSchedule::List> DSchedule::convertSchedules(const DScheduleQueryPar
                 queryDtStart.setTime(QTime(0,0,0));
             }
             if (!(schedule->dtEnd() < queryDtStart || schedule->dtStart() > dtEnd)) {
-                if (extend && schedule->isMultiDay()) {
+                const QDate displayStartDate = displayDate(schedule->dtStart(), schedule->allDay());
+                const QDate displayEndDate = displayDate(schedule->dtEnd(), schedule->allDay());
+                if (extend && displayStartDate != displayEndDate) {
                     // qCDebug(CommonLogger) << "Expanding multi-day schedule.";
                     //需要扩展的天数
-                    int extenddays = static_cast<int>(schedule->dtStart().daysTo(schedule->dtEnd()));
+                    const int extenddays = displayStartDate.daysTo(displayEndDate);
                     for (int i = 0; i <= extenddays; ++i) {
                         // 开始结束日期已经在查询时间范围内
-                        scheduleMap[schedule->dtStart().date().addDays(i)].append(schedule);
+                        scheduleMap[displayStartDate.addDays(i)].append(schedule);
                     }
                 } else {
-                    scheduleMap[schedule->dtStart().date()].append(schedule);
+                    scheduleMap[displayStartDate].append(schedule);
                 }
             }
         }

--- a/src/calendar-common/src/dschedule.h
+++ b/src/calendar-common/src/dschedule.h
@@ -57,6 +57,9 @@ public:
     QString scheduleTypeID() const;
     void setScheduleTypeID(const QString &typeID);
 
+    QString accountColor() const;
+    void setAccountColor(const QString &color);
+
     //为了与旧数据兼容处理（与联系人交互中使用的是自增ID作为日程的ID）
     int dbID() const;
     void setDbID(int id);
@@ -120,6 +123,7 @@ private:
     QString m_fileName; //日程对应文件名称
     //日程类型
     QString m_scheduleTypeID;
+    QString m_accountColor;
     bool m_moved = false;
     int m_compatibleID; //为了与旧数据兼容处理（与联系人交互中使用的是自增ID作为日程的ID）
 };

--- a/src/calendar-common/src/units.cpp
+++ b/src/calendar-common/src/units.cpp
@@ -18,8 +18,16 @@
 QString dtToString(const QDateTime &dt)
 {
     // qCDebug(CommonLogger) << "Converting QDateTime to string:" << dt;
-    QTime _offsetTime = QTime(0, 0).addSecs(dt.timeZone().offsetFromUtc(dt));
-    return QString("%1+%2").arg(dt.toString("yyyy-MM-ddThh:mm:ss")).arg(_offsetTime.toString("hh:mm"));
+    const int offsetSeconds = dt.timeZone().offsetFromUtc(dt);
+    const QChar sign = offsetSeconds < 0 ? QLatin1Char('-') : QLatin1Char('+');
+    const int absoluteSeconds = qAbs(offsetSeconds);
+    const int hours = absoluteSeconds / 3600;
+    const int minutes = (absoluteSeconds % 3600) / 60;
+    return QStringLiteral("%1%2%3:%4")
+        .arg(dt.toString(QStringLiteral("yyyy-MM-ddThh:mm:ss")))
+        .arg(sign)
+        .arg(hours, 2, 10, QLatin1Char('0'))
+        .arg(minutes, 2, 10, QLatin1Char('0'));
 }
 
 QDateTime dtConvert(const QDateTime &datetime)
@@ -32,10 +40,9 @@ QDateTime dtConvert(const QDateTime &datetime)
 
 QDateTime dtFromString(const QString &st)
 {
-    // qCDebug(CommonLogger) << "Converting string to QDateTime:" << st;
-    QDateTime &&dtSt = QDateTime::fromString(st, Qt::ISODate);
-    //转换为本地时区
-    return QDateTime(dtSt.date(),dtSt.time());
+    // 保留字符串中的时区/UTC 偏移，显示层再根据当前系统时区转换。
+    // 不能在这里转成本地时间，否则用户修改系统时区后会丢失原始时刻。
+    return QDateTime::fromString(st, Qt::ISODate);
 }
 
 QString getDBPath()

--- a/src/calendar-common/src/units.h
+++ b/src/calendar-common/src/units.h
@@ -8,6 +8,7 @@
 #include <QString>
 #include <QDateTime>
 #include <QMap>
+#include <QStringList>
 #include <QDir>
 #include <QProcess>
 #include <QSharedPointer>
@@ -26,6 +27,12 @@ static const QMap<QString, QString> GTypeColor = {
     {"6cfd1459-1085-47e9-8ca6-379d47ec319a", "#5D51FF"},
     {"70080e96-e68d-40af-9cca-2f41021f6142", "#A950FF"},
     {"8ac5c8bb-55ce-4264-8b0a-5d32116cf983", "#717171"}};
+
+// CalDAV uses a separate fixed nine-color palette from local calendars.
+static const QStringList GCalDavTypeColors = {
+    QStringLiteral("#FF282A"), QStringLiteral("#FF5F00"), QStringLiteral("#A0D900"),
+    QStringLiteral("#5EC938"), QStringLiteral("#43CED5"), QStringLiteral("#4381D5"),
+    QStringLiteral("#175BDF"), QStringLiteral("#D312EF"), QStringLiteral("#C0875F")};
 
 QString dtToString(const QDateTime &dt);
 QDateTime dtFromString(const QString &st);


### PR DESCRIPTION
Add shared CalDAV models, error codes, credential storage, event logging, timezone helpers, recurrence support, and provider color definitions.

新增 CalDAV 公共数据模型、错误码、凭据存储、数据埋点、
时区与重复规则处理，以及厂商颜色定义。

Log: 增加 CalDAV 公共底层能力
PMS: TASK-393989
Influence: 为后续服务端同步、账户管理和客户端 UI 提供统一基础接口

## Summary by Sourcery

Establish shared CalDAV foundations for account management, synchronization, credential handling, provider integration, and reliable calendar data processing.

New Features:
- Add shared CalDAV account, calendar, category, event mapping, outbox, recovery, provider profile, and account status models.
- Add Secret Service-backed credential storage for securely managing CalDAV passwords.
- Add calendar account event logging and localized synchronization failure status handling.
- Add CalDAV provider definitions, server URL normalization, provider detection, and a dedicated color palette.

Bug Fixes:
- Preserve timezone offsets during date conversion and correctly format negative UTC offsets.
- Improve recurrence expansion and multi-day display handling across local timezones.
- Select the master event when parsing iCalendar data containing detached recurrence exceptions.
- Make local-account D-Bus fallback interfaces safely lifetime-managed.

Enhancements:
- Extend schedules with account color metadata and improve recurrence validation for RRULE, RDATE, and recurrence data.