### PR TITLE
feat(caldav): add protocol transport and calendar discovery

### DIFF
--- a/src/calendar-service/CMakeLists.txt
+++ b/src/calendar-service/CMakeLists.txt
@@ -21,7 +21,7 @@ set(APP_QRC "${APP_RES_DIR}/resources.qrc")
 # Find the library
 find_package(PkgConfig REQUIRED)
 find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Core)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core DBus Sql)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core DBus Network Sql)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
@@ -49,6 +49,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${OBJECT_BINARY_DIR} ../calend
 target_link_libraries(${PROJECT_NAME}
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::Network
     Qt${QT_VERSION_MAJOR}::Sql
     Dtk${DTK_VERSION_MAJOR}::Core
     commondata

--- a/src/calendar-service/src/caldav/dcaldavcalendarquery.cpp
+++ b/src/calendar-service/src/caldav/dcaldavcalendarquery.cpp
@@ -1,0 +1,518 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavcalendarquery.h"
+#include <QRegularExpression>
+
+#include <QXmlStreamReader>
+namespace {
+constexpr int kMaximumXmlDepth = 64;
+
+constexpr qint64 kMaximumCalDavXmlBytes = 4 * 1024 * 1024;
+constexpr int kMaximumCalDavResources = 4096;
+constexpr int kMaximumCalDavPropertyLength = 4096;
+}
+static bool hasAcceptableXmlDepth(const QByteArray &xml)
+{
+    QXmlStreamReader reader(xml);
+
+    int depth = 0;
+    while (!reader.atEnd()) {
+        reader.readNext();
+        if (reader.isStartElement()) {
+            if (++depth > kMaximumXmlDepth) {
+                return false;
+            }
+        } else if (reader.isEndElement()) {
+            --depth;
+        }
+    }
+    return !reader.hasError() && depth == 0;
+}
+namespace {
+QString formatUtcDateTime(const QDateTime &dateTime)
+{
+    return dateTime.toUTC().toString(QStringLiteral("yyyyMMddTHHmmssZ"));
+
+}
+QString xmlEscape(const QString &value)
+
+{
+    QString escaped = value;
+    escaped.replace(QLatin1Char('&'), QStringLiteral("&amp;"));
+    escaped.replace(QLatin1Char('<'), QStringLiteral("&lt;"));
+    escaped.replace(QLatin1Char('>'), QStringLiteral("&gt;"));
+
+    escaped.replace(QLatin1Char('\"'), QStringLiteral("&quot;"));
+    escaped.replace(QLatin1Char('\''), QStringLiteral("&apos;"));
+    return escaped;
+}
+QString uidFromCalendarData(const QString &calendarData)
+{
+    QStringList unfoldedLines;
+    const QStringList lines = calendarData.split(QRegularExpression(QStringLiteral("\\r?\\n")));
+    for (const QString &line : lines) {
+        if (!unfoldedLines.isEmpty() && (line.startsWith(QLatin1Char(' ')) || line.startsWith(QLatin1Char('\t')))) {
+            unfoldedLines.last().append(line.mid(1));
+
+        } else {
+            unfoldedLines.append(line);
+        }
+    }
+    for (const QString &line : unfoldedLines) {
+        const int separator = line.indexOf(QLatin1Char(':'));
+        if (separator < 1) {
+            continue;
+        }
+        const QString propertyName = line.left(separator);
+        if (propertyName.compare(QStringLiteral("UID"), Qt::CaseInsensitive) == 0
+            || propertyName.startsWith(QStringLiteral("UID;"), Qt::CaseInsensitive)) {
+
+            return line.mid(separator + 1);
+        }
+    }
+    return QString();
+}
+int httpStatusCode(const QString &status)
+{
+    const QStringList parts = status.simplified().split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    if (parts.size() < 2) {
+        return -1;
+    }
+    bool ok = false;
+    const int code = parts.at(1).toInt(&ok);
+    return ok ? code : -1;
+
+}
+void readProperties(QXmlStreamReader &reader, DCalDavCalendarQuery::RemoteEvent &properties)
+{
+    while (reader.readNextStartElement()) {
+        if (reader.name() == QStringLiteral("getetag")) {
+            properties.etag = reader.readElementText(QXmlStreamReader::SkipChildElements);
+        } else if (reader.name() == QStringLiteral("calendar-data")) {
+            properties.calendarData = reader.readElementText(QXmlStreamReader::SkipChildElements);
+        } else if (reader.name() == QStringLiteral("getcontenttype")) {
+            properties.contentType = reader.readElementText(QXmlStreamReader::SkipChildElements);
+        } else {
+
+            reader.skipCurrentElement();
+        }
+    }
+}
+void mergeProperties(const DCalDavCalendarQuery::RemoteEvent &source,
+                     DCalDavCalendarQuery::RemoteEvent &target)
+{
+    if (!source.etag.isEmpty()) {
+        target.etag = source.etag;
+    }
+    if (!source.calendarData.isEmpty()) {
+        target.calendarData = source.calendarData;
+    }
+    if (!source.contentType.isEmpty()) {
+        target.contentType = source.contentType;
+
+    }
+}
+void readPropertyStatus(QXmlStreamReader &reader, DCalDavCalendarQuery::RemoteEvent &event)
+{
+    DCalDavCalendarQuery::RemoteEvent properties;
+    int statusCode = -1;
+    while (reader.readNextStartElement()) {
+        if (reader.name() == QStringLiteral("prop")) {
+            readProperties(reader, properties);
+        } else if (reader.name() == QStringLiteral("status")) {
+            statusCode = httpStatusCode(reader.readElementText(QXmlStreamReader::SkipChildElements));
+        } else {
+            reader.skipCurrentElement();
+        }
+
+    }
+    if (statusCode >= 200 && statusCode < 300) {
+        mergeProperties(properties, event);
+        event.hasSuccessfulStatus = true;
+        event.deleted = false;
+    } else if (statusCode == 404 && !event.hasSuccessfulStatus) {
+        event.deleted = true;
+    }
+}
+
+void readResourceProperties(QXmlStreamReader &reader, DCalDavCalendarQuery::Resource &properties)
+{
+    while (reader.readNextStartElement()) {
+        if (reader.name() == QStringLiteral("getetag")) {
+
+            properties.etag = reader.readElementText(QXmlStreamReader::SkipChildElements);
+        } else if (reader.name() == QStringLiteral("getcontenttype")) {
+            properties.contentType = reader.readElementText(QXmlStreamReader::SkipChildElements);
+        } else if (reader.name() == QStringLiteral("calendar-data")) {
+            properties.calendarData = reader.readElementText(QXmlStreamReader::SkipChildElements);
+        } else {
+            reader.skipCurrentElement();
+        }
+    }
+}
+
+void mergeResourceProperties(const DCalDavCalendarQuery::Resource &source,
+                             DCalDavCalendarQuery::Resource &target)
+{
+    if (!source.etag.isEmpty()) {
+        target.etag = source.etag;
+    }
+    if (!source.contentType.isEmpty()) {
+        target.contentType = source.contentType;
+    }
+    if (!source.calendarData.isEmpty()) {
+        target.calendarData = source.calendarData;
+    }
+}
+
+void applyResourceStatus(int statusCode, DCalDavCalendarQuery::Resource &resource)
+{
+    if (statusCode >= 200 && statusCode < 300) {
+        resource.hasSuccessfulStatus = true;
+        resource.deleted = false;
+    } else if (statusCode == 404 && !resource.hasSuccessfulStatus) {
+        resource.deleted = true;
+    }
+}
+
+void readResourcePropertyStatus(QXmlStreamReader &reader,
+                                DCalDavCalendarQuery::Resource &resource)
+{
+    DCalDavCalendarQuery::Resource properties;
+    int statusCode = -1;
+    while (reader.readNextStartElement()) {
+        if (reader.name() == QStringLiteral("prop")) {
+            readResourceProperties(reader, properties);
+        } else if (reader.name() == QStringLiteral("status")) {
+            statusCode = httpStatusCode(reader.readElementText(QXmlStreamReader::SkipChildElements));
+        } else {
+            reader.skipCurrentElement();
+        }
+    }
+    if (statusCode >= 200 && statusCode < 300) {
+        mergeResourceProperties(properties, resource);
+    }
+    applyResourceStatus(statusCode, resource);
+}
+
+void readResponse(QXmlStreamReader &reader, DCalDavCalendarQuery::RemoteEventList &events)
+{
+    DCalDavCalendarQuery::RemoteEvent event;
+    while (reader.readNextStartElement()) {
+        if (reader.name() == QStringLiteral("href")) {
+            event.href = reader.readElementText(QXmlStreamReader::SkipChildElements);
+        } else if (reader.name() == QStringLiteral("propstat")) {
+            readPropertyStatus(reader, event);
+        } else {
+            reader.skipCurrentElement();
+        }
+    }
+
+    if (!event.href.isEmpty() && (event.deleted || !event.calendarData.isEmpty()
+                                  || !event.etag.isEmpty())) {
+        if (!event.deleted && !event.calendarData.isEmpty()) {
+            event.uid = uidFromCalendarData(event.calendarData);
+        }
+        events.append(event);
+    }
+}
+
+} // namespace
+
+DCalDavTransport::Request DCalDavCalendarQuery::firstSyncRequest(const QUrl &calendarUrl,
+                                                                  const QString &username,
+                                                                  const QString &password,
+                                                                  const QDateTime &referenceTime)
+{
+    const QDateTime rangeStart = referenceTime.addMonths(-1);
+    const QDateTime rangeEnd = referenceTime.addMonths(6);
+
+    DCalDavTransport::Request request;
+    request.url = calendarUrl;
+    request.method = "REPORT";
+    request.contentType = "application/xml; charset=utf-8";
+    request.username = username;
+    request.password = password;
+    request.maximumResponseBytes = kMaximumCalDavXmlBytes;
+    request.headers.insert("Depth", "1");
+    request.body = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                   "<c:calendar-query xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\">"
+                   "<d:prop><d:getetag/><d:getcontenttype/><c:calendar-data/></d:prop>"
+                   "<c:filter><c:comp-filter name=\"VCALENDAR\">"
+                   "<c:comp-filter name=\"VEVENT\">"
+                   "<c:time-range start=\"" + formatUtcDateTime(rangeStart).toUtf8()
+        + "\" end=\"" + formatUtcDateTime(rangeEnd).toUtf8()
+        + "\"/></c:comp-filter>"
+          "</c:comp-filter></c:filter>"
+          "</c:calendar-query>";
+    return request;
+}
+
+DCalDavTransport::Request DCalDavCalendarQuery::incrementalSyncRequest(const QUrl &calendarUrl,
+                                                                       const QString &username,
+                                                                       const QString &password,
+                                                                       const QString &syncToken)
+{
+    DCalDavTransport::Request request;
+    request.url = calendarUrl;
+    request.method = "REPORT";
+    request.contentType = "application/xml; charset=utf-8";
+    request.username = username;
+    request.password = password;
+    request.maximumResponseBytes = kMaximumCalDavXmlBytes;
+    request.headers.insert("Depth", "1");
+    request.body = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                   "<d:sync-collection xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\">"
+                   "<d:sync-token>" + xmlEscape(syncToken).toUtf8()
+        + "</d:sync-token><d:sync-level>1</d:sync-level>"
+          "<d:prop><d:getetag/><d:getcontenttype/><c:calendar-data/></d:prop>"
+          "</d:sync-collection>";
+    return request;
+}
+
+
+
+DCalDavTransport::Request DCalDavCalendarQuery::resourceListRequest(
+    const QUrl &calendarUrl, const QString &username, const QString &password)
+{
+    DCalDavTransport::Request request;
+    request.url = calendarUrl;
+    request.method = "REPORT";
+    request.contentType = "application/xml; charset=utf-8";
+    request.username = username;
+    request.password = password;
+    request.maximumResponseBytes = kMaximumCalDavXmlBytes;
+    request.headers.insert("Depth", "1");
+    request.body = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                   "<c:calendar-query xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\">"
+                   "<d:prop><d:getetag/><d:getcontenttype/><c:calendar-data/></d:prop>"
+                   "<c:filter><c:comp-filter name=\"VCALENDAR\">"
+                   "<c:comp-filter name=\"VEVENT\"/>"
+                   "</c:comp-filter></c:filter>"
+                   "</c:calendar-query>";
+    return request;
+}
+
+DCalDavTransport::Request DCalDavCalendarQuery::resourceGetRequest(
+    const QUrl &resourceUrl, const QString &username, const QString &password)
+{
+    DCalDavTransport::Request request;
+    request.url = resourceUrl;
+    request.method = "GET";
+    request.username = username;
+    request.password = password;
+    request.maximumResponseBytes = kMaximumCalDavXmlBytes;
+    return request;
+}
+
+DCalDavTransport::Request DCalDavCalendarQuery::resourceMultiGetRequest(
+    const QUrl &calendarUrl, const QString &username, const QString &password,
+    const QStringList &resourceHrefs)
+{
+    DCalDavTransport::Request request;
+    request.url = calendarUrl;
+    request.method = "REPORT";
+    request.contentType = "application/xml; charset=utf-8";
+    request.username = username;
+    request.password = password;
+    request.maximumResponseBytes = kMaximumCalDavXmlBytes;
+    request.headers.insert("Depth", "1");
+
+    QString hrefs;
+    for (const QString &resourceHref : resourceHrefs) {
+        QUrl hrefUrl(resourceHref);
+        QString href = resourceHref;
+        if (hrefUrl.isValid() && !hrefUrl.scheme().isEmpty()) {
+            href = hrefUrl.path(QUrl::FullyEncoded);
+            if (hrefUrl.hasQuery()) {
+                href.append(QLatin1Char('?'));
+                href.append(hrefUrl.query(QUrl::FullyEncoded));
+            }
+        }
+        if (!href.isEmpty()) {
+            hrefs.append(QStringLiteral("<d:href>%1</d:href>").arg(xmlEscape(href)));
+        }
+    }
+
+    request.body = QStringLiteral("<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                                  "<c:calendar-multiget xmlns:d=\"DAV:\" "
+                                  "xmlns:c=\"urn:ietf:params:xml:ns:caldav\">"
+                                  "<d:prop><d:getetag/><d:getcontenttype/><c:calendar-data/></d:prop>%1"
+                                  "</c:calendar-multiget>")
+                       .arg(hrefs)
+                       .toUtf8();
+    return request;
+}
+
+bool DCalDavCalendarQuery::parseResourceList(const QByteArray &xml, ResourceList &resources,
+                                             QString *errorMessage)
+{
+    if (!hasAcceptableXmlDepth(xml)) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("DAV response is too deeply nested.");
+        }
+        return false;
+    }
+    if (xml.size() > kMaximumCalDavXmlBytes) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("DAV resource response is too large.");
+        }
+        return false;
+    }
+    QXmlStreamReader reader(xml);
+    ResourceList parsed;
+    if (!reader.readNextStartElement() || reader.name() != QStringLiteral("multistatus")) {
+        if (errorMessage != nullptr) {
+            *errorMessage = reader.hasError() ? reader.errorString()
+                                              : QStringLiteral("Invalid DAV multistatus response.");
+        }
+        return false;
+    }
+
+    while (reader.readNextStartElement()) {
+        if (reader.name() != QStringLiteral("response")) {
+            reader.skipCurrentElement();
+            continue;
+        }
+        if (parsed.size() >= kMaximumCalDavResources) {
+            if (errorMessage != nullptr) {
+                *errorMessage = QStringLiteral("DAV resource response contains too many resources.");
+            }
+            return false;
+        }
+        Resource resource;
+        while (reader.readNextStartElement()) {
+            if (reader.name() == QStringLiteral("href")) {
+                resource.href = reader.readElementText(QXmlStreamReader::SkipChildElements);
+            } else if (reader.name() == QStringLiteral("propstat")) {
+                readResourcePropertyStatus(reader, resource);
+            } else if (reader.name() == QStringLiteral("status")) {
+                applyResourceStatus(
+                    httpStatusCode(reader.readElementText(QXmlStreamReader::SkipChildElements)), resource);
+            } else {
+                reader.skipCurrentElement();
+            }
+        }
+        const bool isEvent = resource.contentType.contains(QStringLiteral("vevent"), Qt::CaseInsensitive)
+            || (resource.contentType.isEmpty()
+                && resource.href.endsWith(QStringLiteral(".ics"), Qt::CaseInsensitive));
+        if (!resource.deleted && !resource.href.isEmpty()
+            && (!resource.etag.isEmpty() || isEvent || !resource.calendarData.isEmpty())) {
+            parsed.append(resource);
+        }
+    }
+
+    if (reader.hasError()) {
+        if (errorMessage != nullptr) {
+            *errorMessage = reader.errorString();
+        }
+        return false;
+    }
+    if (parsed.size() > kMaximumCalDavResources) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("DAV resource response contains too many resources.");
+        }
+        return false;
+    }
+    for (const Resource &resource : parsed) {
+        if (resource.href.size() > kMaximumCalDavPropertyLength
+            || resource.etag.size() > kMaximumCalDavPropertyLength
+            || resource.contentType.size() > kMaximumCalDavPropertyLength
+            || resource.calendarData.size() > kMaximumCalDavXmlBytes) {
+            if (errorMessage != nullptr) {
+                *errorMessage = QStringLiteral("DAV resource response contains oversized properties.");
+            }
+            return false;
+        }
+    }
+    resources = parsed;
+    return true;
+}
+
+bool DCalDavCalendarQuery::parseResponse(const QByteArray &xml, RemoteEventList &events,
+                                         QString *errorMessage)
+{
+    return parseResponseWithSyncToken(xml, events, nullptr, errorMessage);
+}
+
+bool DCalDavCalendarQuery::parseResponseWithSyncToken(const QByteArray &xml, RemoteEventList &events,
+                                                        QString *syncToken, QString *errorMessage)
+{
+    if (!hasAcceptableXmlDepth(xml)) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("DAV response is too deeply nested.");
+        }
+        return false;
+    }
+    if (xml.size() > kMaximumCalDavXmlBytes) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("DAV event response is too large.");
+        }
+        return false;
+    }
+    QXmlStreamReader reader(xml);
+    RemoteEventList parsed;
+    QString parsedSyncToken;
+    if (!reader.readNextStartElement() || reader.name() != QStringLiteral("multistatus")) {
+        if (errorMessage != nullptr) {
+            *errorMessage = reader.hasError() ? reader.errorString() : QStringLiteral("Invalid DAV multistatus response.");
+        }
+        return false;
+    }
+
+    while (reader.readNextStartElement()) {
+        if (reader.name() == QStringLiteral("response")) {
+            if (parsed.size() >= kMaximumCalDavResources) {
+                if (errorMessage != nullptr) {
+                    *errorMessage = QStringLiteral("DAV event response contains too many resources.");
+                }
+                return false;
+            }
+            readResponse(reader, parsed);
+        } else if (reader.name() == QStringLiteral("sync-token")) {
+            parsedSyncToken = reader.readElementText(QXmlStreamReader::SkipChildElements);
+        } else {
+            reader.skipCurrentElement();
+        }
+    }
+
+    if (reader.hasError()) {
+        if (errorMessage != nullptr) {
+            *errorMessage = reader.errorString();
+        }
+        return false;
+    }
+
+    if (parsed.size() > kMaximumCalDavResources
+        || parsedSyncToken.size() > kMaximumCalDavPropertyLength) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("DAV event response contains too many or oversized resources.");
+        }
+        return false;
+    }
+    for (const RemoteEvent &event : parsed) {
+        if (event.href.size() > kMaximumCalDavPropertyLength
+            || event.etag.size() > kMaximumCalDavPropertyLength
+            || event.contentType.size() > kMaximumCalDavPropertyLength
+            || event.calendarData.size() > kMaximumCalDavXmlBytes) {
+            if (errorMessage != nullptr) {
+                *errorMessage = QStringLiteral("DAV event response contains oversized properties.");
+            }
+            return false;
+        }
+        if (!event.deleted && !event.calendarData.isEmpty() && event.uid.isEmpty()) {
+            if (errorMessage != nullptr) {
+                *errorMessage = QStringLiteral("Calendar data is missing UID.");
+            }
+            return false;
+        }
+    }
+
+    events = parsed;
+    if (syncToken != nullptr) {
+        *syncToken = parsedSyncToken;
+    }
+    return true;
+}

--- a/src/calendar-service/src/caldav/dcaldavcalendarquery.h
+++ b/src/calendar-service/src/caldav/dcaldavcalendarquery.h
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVCALENDARQUERY_H
+#define DCALDAVCALENDARQUERY_H
+
+#include "dcaldavtransport.h"
+
+#include <QDateTime>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+class DCalDavCalendarQuery
+{
+public:
+    struct RemoteEvent {
+        QString href;
+        QString etag;
+        QString uid;
+        QString calendarData;
+        QString contentType;
+        bool deleted = false;
+        bool hasSuccessfulStatus = false;
+    };
+
+    struct Resource {
+        QString href;
+        QString etag;
+        QString contentType;
+        QString calendarData;
+        bool deleted = false;
+        bool hasSuccessfulStatus = false;
+    };
+
+    typedef QVector<RemoteEvent> RemoteEventList;
+    typedef QVector<Resource> ResourceList;
+
+    static DCalDavTransport::Request firstSyncRequest(const QUrl &calendarUrl, const QString &username,
+                                                       const QString &password,
+                                                       const QDateTime &referenceTime);
+    static DCalDavTransport::Request incrementalSyncRequest(const QUrl &calendarUrl, const QString &username,
+                                                            const QString &password, const QString &syncToken);
+    static DCalDavTransport::Request resourceListRequest(const QUrl &calendarUrl, const QString &username,
+                                                         const QString &password);
+    static DCalDavTransport::Request resourceGetRequest(const QUrl &resourceUrl, const QString &username,
+                                                        const QString &password);
+    static DCalDavTransport::Request resourceMultiGetRequest(const QUrl &calendarUrl,
+                                                             const QString &username,
+                                                             const QString &password,
+                                                             const QStringList &resourceHrefs);
+    static bool parseResponse(const QByteArray &xml, RemoteEventList &events,
+                              QString *errorMessage = nullptr);
+    static bool parseResponseWithSyncToken(const QByteArray &xml, RemoteEventList &events,
+                                           QString *syncToken, QString *errorMessage = nullptr);
+    static bool parseResourceList(const QByteArray &xml, ResourceList &resources,
+                                  QString *errorMessage = nullptr);
+};
+
+#endif // DCALDAVCALENDARQUERY_H

--- a/src/calendar-service/src/caldav/dcaldavdiscovery.cpp
+++ b/src/calendar-service/src/caldav/dcaldavdiscovery.cpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavdiscovery.h"
+
+QList<QUrl> DCalDavDiscovery::discoveryCandidates(const QUrl &serverUrl)
+{
+    QList<QUrl> candidates;
+    const QUrl normalizedServerUrl = DCalDavTransport::normalizeUrl(serverUrl);
+    if (!normalizedServerUrl.isValid()) {
+        return candidates;
+    }
+
+    QUrl wellKnown(normalizedServerUrl);
+    wellKnown.setPath(QStringLiteral("/.well-known/caldav"));
+    wellKnown.setQuery(QString());
+    wellKnown.setFragment(QString());
+    candidates.append(wellKnown);
+    if (normalizedServerUrl != wellKnown) {
+        candidates.append(normalizedServerUrl);
+    }
+    return candidates;
+}
+
+QUrl DCalDavDiscovery::resolveHref(const QUrl &baseUrl, const QString &href)
+{
+    const QUrl normalizedBaseUrl = DCalDavTransport::normalizeUrl(baseUrl);
+    if (!normalizedBaseUrl.isValid()) {
+        return QUrl();
+    }
+    const QUrl resolved = DCalDavTransport::normalizeUrl(normalizedBaseUrl.resolved(QUrl(href)));
+    if (!resolved.isValid() || !DCalDavTransport::isSameOrigin(normalizedBaseUrl, resolved)) {
+        return QUrl();
+    }
+    return resolved;
+}
+
+DCalDavTransport::Request DCalDavDiscovery::currentUserPrincipalRequest(const QUrl &url,
+                                                                          const QString &username,
+                                                                          const QString &password)
+{
+    DCalDavTransport::Request request;
+    request.url = url;
+    request.method = "PROPFIND";
+    request.contentType = "application/xml; charset=utf-8";
+    request.username = username;
+    request.password = password;
+    request.headers.insert("Depth", "0");
+    request.body = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                   "<d:propfind xmlns:d=\"DAV:\">"
+                   "<d:prop><d:current-user-principal/><d:displayname/></d:prop>"
+                   "</d:propfind>";
+    return request;
+}
+
+DCalDavTransport::Request DCalDavDiscovery::calendarHomeSetRequest(const QUrl &url,
+                                                                    const QString &username,
+                                                                    const QString &password)
+{
+    DCalDavTransport::Request request;
+    request.url = url;
+    request.method = "PROPFIND";
+    request.contentType = "application/xml; charset=utf-8";
+    request.username = username;
+    request.password = password;
+    request.headers.insert("Depth", "0");
+    request.body = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                   "<d:propfind xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\">"
+                   "<d:prop><c:calendar-home-set/><d:displayname/></d:prop>"
+                   "</d:propfind>";
+    return request;
+}
+
+DCalDavTransport::Request DCalDavDiscovery::calendarCollectionsRequest(const QUrl &url,
+                                                                        const QString &username,
+                                                                        const QString &password)
+{
+    DCalDavTransport::Request request;
+    request.url = url;
+    request.method = "PROPFIND";
+    request.contentType = "application/xml; charset=utf-8";
+    request.username = username;
+    request.password = password;
+    request.headers.insert("Depth", "1");
+    request.body = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                   "<d:propfind xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\" "
+                   "xmlns:ical=\"http://apple.com/ns/ical/\">"
+                   "<d:prop><d:resourcetype/><d:displayname/><ical:calendar-color/>"
+                   "<d:current-user-privilege-set/></d:prop>"
+                   "</d:propfind>";
+    return request;
+}

--- a/src/calendar-service/src/caldav/dcaldavdiscovery.h
+++ b/src/calendar-service/src/caldav/dcaldavdiscovery.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVDISCOVERY_H
+#define DCALDAVDISCOVERY_H
+
+#include "dcaldavtransport.h"
+
+#include <QList>
+
+class DCalDavDiscovery
+{
+public:
+    static QList<QUrl> discoveryCandidates(const QUrl &serverUrl);
+    static QUrl resolveHref(const QUrl &baseUrl, const QString &href);
+    static DCalDavTransport::Request currentUserPrincipalRequest(const QUrl &url,
+                                                                   const QString &username,
+                                                                   const QString &password);
+    static DCalDavTransport::Request calendarHomeSetRequest(const QUrl &url, const QString &username,
+                                                            const QString &password);
+    static DCalDavTransport::Request calendarCollectionsRequest(const QUrl &url, const QString &username,
+                                                                const QString &password);
+};
+
+#endif // DCALDAVDISCOVERY_H

--- a/src/calendar-service/src/caldav/dcaldavtransport.cpp
+++ b/src/calendar-service/src/caldav/dcaldavtransport.cpp
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavtransport.h"
+
+#include "commondef.h"
+
+#include <QAuthenticator>
+#include <QCryptographicHash>
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QSharedPointer>
+#include <QSslError>
+#include <QTimer>
+
+DCalDavTransport::DCalDavTransport(QObject *parent)
+    : QObject(parent)
+    , m_networkManager(new QNetworkAccessManager(this))
+{
+}
+
+QUrl DCalDavTransport::normalizeUrl(const QUrl &url)
+{
+    const QString input = url.toString(QUrl::FullyEncoded).trimmed();
+    if (input.isEmpty()) {
+        return QUrl();
+    }
+
+    QUrl normalized = url;
+    if (normalized.scheme().isEmpty()) {
+        normalized = QUrl(input.startsWith(QStringLiteral("//"))
+                              ? QStringLiteral("https:") + input
+                              : QStringLiteral("https://") + input);
+    }
+
+    if (!normalized.isValid() || normalized.host().isEmpty() || !normalized.userName().isEmpty()
+        || !normalized.password().isEmpty()) {
+        return QUrl();
+    }
+
+    normalized.setScheme(normalized.scheme().toLower());
+    if (normalized.scheme() != QStringLiteral("https")) {
+        return QUrl();
+    }
+    normalized.setFragment(QString());
+    return normalized;
+}
+
+bool DCalDavTransport::isSecureUrl(const QUrl &url)
+{
+    const QUrl normalized = normalizeUrl(url);
+    return normalized.isValid()
+        && normalized.scheme().compare(QStringLiteral("https"), Qt::CaseInsensitive) == 0
+        && !normalized.host().isEmpty();
+}
+
+bool DCalDavTransport::isSameOrigin(const QUrl &first, const QUrl &second)
+{
+    const QUrl normalizedFirst = normalizeUrl(first);
+    const QUrl normalizedSecond = normalizeUrl(second);
+    if (!isSecureUrl(normalizedFirst) || !isSecureUrl(normalizedSecond)) {
+        return false;
+    }
+
+    const auto effectivePort = [](const QUrl &url) { return url.port(443); };
+    return normalizedFirst.scheme().compare(normalizedSecond.scheme(), Qt::CaseInsensitive) == 0
+        && normalizedFirst.host().compare(normalizedSecond.host(), Qt::CaseInsensitive) == 0
+        && effectivePort(normalizedFirst) == effectivePort(normalizedSecond);
+}
+
+QString DCalDavTransport::urlForLog(const QUrl &url)
+{
+    const QUrl normalized = normalizeUrl(url);
+    if (!normalized.isValid() || normalized.host().isEmpty()) {
+        return QStringLiteral("<invalid-url>");
+    }
+
+    const QByteArray hostHash = QCryptographicHash::hash(normalized.host().toUtf8(),
+                                                         QCryptographicHash::Sha256)
+                                    .toHex()
+                                    .left(12);
+    return QStringLiteral("caldav-host:%1").arg(QString::fromLatin1(hostHash));
+}
+
+DCalDavTransport::Error DCalDavTransport::classifyError(QNetworkReply::NetworkError networkError,
+                                                         int httpStatus,
+                                                         bool certificateInvalid,
+                                                         bool timedOut,
+                                                         bool responseTooLarge)
+{
+    if (responseTooLarge) {
+        return ResponseTooLarge;
+    }
+    if (certificateInvalid) {
+        return CertificateInvalid;
+    }
+    if (timedOut) {
+        return RequestTimedOut;
+    }
+    if (httpStatus == 401) {
+        return AuthenticationFailed;
+    }
+    if (httpStatus == 403) {
+        return PermissionDenied;
+    }
+    if (httpStatus == 429) {
+        return RateLimited;
+    }
+    if (httpStatus == 503) {
+        return ServerUnavailable;
+    }
+    // An HTTP response, including conflict and not-found responses, is not a
+    // transport failure. Callers use the status code to apply protocol-specific
+    // handling such as ETag conflicts and idempotent DELETEs.
+    if (httpStatus > 0 || networkError == QNetworkReply::NoError) {
+        return NoError;
+    }
+    if (networkError == QNetworkReply::HostNotFoundError
+        || networkError == QNetworkReply::ConnectionRefusedError
+        || networkError == QNetworkReply::TemporaryNetworkFailureError
+        || networkError == QNetworkReply::NetworkSessionFailedError) {
+        return NetworkUnavailable;
+    }
+    return NetworkError;
+}
+
+void DCalDavTransport::cancel()
+{
+    const QSet<QNetworkReply *> replies = m_activeReplies;
+    m_activeReplies.clear();
+    for (const QMetaObject::Connection &connection : m_authenticationConnections) {
+        QObject::disconnect(connection);
+    }
+    m_authenticationConnections.clear();
+    for (QNetworkReply *reply : replies) {
+        if (reply == nullptr) {
+            continue;
+        }
+        QObject::disconnect(reply, nullptr, nullptr, nullptr);
+        reply->abort();
+        reply->deleteLater();
+    }
+}
+
+void DCalDavTransport::send(const Request &request, const Callback &callback)
+{
+    send(request, callback, 0, normalizeUrl(request.url));
+}
+
+void DCalDavTransport::send(const Request &request, const Callback &callback, int redirectCount,
+                            const QUrl &redirectOrigin)
+{
+    if (!callback) {
+        return;
+    }
+
+    const QUrl normalizedUrl = normalizeUrl(request.url);
+    Response invalidResponse;
+    invalidResponse.finalUrl = normalizedUrl.isValid() ? normalizedUrl : request.url;
+    if (!normalizedUrl.isValid()) {
+        invalidResponse.error = InvalidUrl;
+        callback(invalidResponse);
+        return;
+    }
+    if (!isSecureUrl(normalizedUrl)) {
+        invalidResponse.error = InsecureUrl;
+        callback(invalidResponse);
+        return;
+    }
+
+    const Request effectiveRequest = [&request, &normalizedUrl] {
+        Request result = request;
+        result.url = normalizedUrl;
+        return result;
+    }();
+    const QUrl effectiveRedirectOrigin = normalizeUrl(redirectOrigin).isValid()
+        ? normalizeUrl(redirectOrigin)
+        : normalizedUrl;
+
+    QNetworkRequest networkRequest(effectiveRequest.url);
+    // CalDAV discovery must retain PROPFIND/REPORT and their XML bodies after a redirect.
+    networkRequest.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                                QNetworkRequest::ManualRedirectPolicy);
+    networkRequest.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("dde-calendar-caldav"));
+    if (!effectiveRequest.contentType.isEmpty()) {
+        networkRequest.setHeader(QNetworkRequest::ContentTypeHeader, effectiveRequest.contentType);
+    }
+    networkRequest.setRawHeader("Accept", "application/xml, text/xml, text/calendar");
+    for (auto header = effectiveRequest.headers.constBegin(); header != effectiveRequest.headers.constEnd(); ++header) {
+        networkRequest.setRawHeader(header.key(), header.value());
+    }
+    if (!effectiveRequest.username.isEmpty() || !effectiveRequest.password.isEmpty()) {
+        const QByteArray authorization = (effectiveRequest.username + QLatin1Char(':') + effectiveRequest.password).toUtf8().toBase64();
+        networkRequest.setRawHeader("Authorization", "Basic " + authorization);
+    }
+
+    QNetworkReply *reply = m_networkManager->sendCustomRequest(networkRequest, effectiveRequest.method, effectiveRequest.body);
+    m_activeReplies.insert(reply);
+    reply->setProperty("caldavMaximumResponseBytes", effectiveRequest.maximumResponseBytes);
+
+    // Some CalDAV servers require a challenge-response retry even when the
+    // request already carries preemptive Basic authentication.
+    const QSharedPointer<QMetaObject::Connection> authenticationConnection =
+        QSharedPointer<QMetaObject::Connection>::create();
+    *authenticationConnection = connect(
+        m_networkManager, &QNetworkAccessManager::authenticationRequired, this,
+        [reply, effectiveRequest](QNetworkReply *authenticationReply, QAuthenticator *authenticator) {
+            if (authenticationReply != reply) {
+                return;
+            }
+            qCDebug(ServiceLogger) << "CalDAV authentication challenge received"
+                                  << "endpoint:" << DCalDavTransport::urlForLog(authenticationReply->url());
+            authenticator->setUser(effectiveRequest.username);
+            authenticator->setPassword(effectiveRequest.password);
+        });
+    m_authenticationConnections.append(*authenticationConnection);
+    QTimer *timer = new QTimer(reply);
+    timer->setSingleShot(true);
+    timer->start(effectiveRequest.timeoutMilliseconds);
+
+    QSharedPointer<QByteArray> responseBody(new QByteArray);
+    connect(reply, &QNetworkReply::readyRead, reply, [reply, responseBody, effectiveRequest]() {
+        responseBody->append(reply->readAll());
+        if (responseBody->size() > effectiveRequest.maximumResponseBytes) {
+            reply->setProperty("caldavResponseTooLarge", true);
+            reply->abort();
+        }
+    });
+    connect(reply, &QNetworkReply::sslErrors, reply, [reply](const QList<QSslError> &) {
+        reply->setProperty("caldavCertificateInvalid", true);
+        reply->abort();
+    });
+    connect(timer, &QTimer::timeout, reply, [reply]() {
+        reply->setProperty("caldavTimedOut", true);
+        reply->abort();
+    });
+    connect(reply, &QNetworkReply::finished, reply,
+            [this, reply, timer, responseBody, effectiveRequest, callback, redirectCount,
+             effectiveRedirectOrigin, authenticationConnection]() {
+        m_activeReplies.remove(reply);
+        QObject::disconnect(*authenticationConnection);
+        m_authenticationConnections.removeAll(*authenticationConnection);
+        timer->stop();
+        Response response;
+        response.httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        response.finalUrl = reply->url();
+        response.retryAfter = reply->rawHeader("Retry-After");
+        response.etag = reply->rawHeader("ETag");
+        responseBody->append(reply->readAll());
+        if (responseBody->size() > reply->property("caldavMaximumResponseBytes").toLongLong()) {
+            reply->setProperty("caldavResponseTooLarge", true);
+        }
+        response.body = *responseBody;
+        response.error = classifyError(reply->error(), response.httpStatus,
+                                       reply->property("caldavCertificateInvalid").toBool(),
+                                       reply->property("caldavTimedOut").toBool(),
+                                       reply->property("caldavResponseTooLarge").toBool());
+
+        const QUrl redirectTarget = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
+        const bool isRedirect = response.httpStatus >= 300 && response.httpStatus < 400;
+        if (isRedirect && redirectTarget.isValid()) {
+            const QUrl nextUrl = normalizeUrl(reply->url().resolved(redirectTarget));
+            reply->deleteLater();
+            constexpr int maximumRedirectCount = 5;
+            if (!nextUrl.isValid()) {
+                response.error = InvalidUrl;
+                callback(response);
+                return;
+            }
+            if (!isSecureUrl(nextUrl)) {
+                response.error = InsecureUrl;
+                callback(response);
+                return;
+            }
+            if (redirectCount >= maximumRedirectCount || !isSameOrigin(effectiveRedirectOrigin, nextUrl)) {
+                // Never forward Basic credentials to a different origin.
+                response.error = NetworkError;
+                callback(response);
+                return;
+            }
+
+            Request redirectedRequest = effectiveRequest;
+            redirectedRequest.url = nextUrl;
+            send(redirectedRequest, callback, redirectCount + 1, effectiveRedirectOrigin);
+            return;
+        }
+        if (isRedirect) {
+            response.error = NetworkError;
+        }
+        callback(response);
+        reply->deleteLater();
+    });
+}

--- a/src/calendar-service/src/caldav/dcaldavtransport.h
+++ b/src/calendar-service/src/caldav/dcaldavtransport.h
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVTRANSPORT_H
+#define DCALDAVTRANSPORT_H
+
+#include <QByteArray>
+#include <QList>
+#include <QMap>
+#include <QSet>
+#include <QNetworkReply>
+#include <QObject>
+#include <QUrl>
+
+#include <functional>
+
+class QNetworkAccessManager;
+
+class DCalDavTransport : public QObject
+{
+    Q_OBJECT
+public:
+    enum Error {
+        NoError,
+        InvalidUrl,
+        InsecureUrl,
+        CertificateInvalid,
+        NetworkUnavailable,
+        RequestTimedOut,
+        AuthenticationFailed,
+        PermissionDenied,
+        RateLimited,
+        ServerUnavailable,
+        ResponseTooLarge,
+        NetworkError,
+    };
+
+    struct Request {
+        QUrl url;
+        QByteArray method;
+        QByteArray body;
+        QByteArray contentType;
+        QString username;
+        QString password;
+        int timeoutMilliseconds = 15000;
+        qint64 maximumResponseBytes = 1024 * 1024;
+        QMap<QByteArray, QByteArray> headers;
+    };
+
+    struct Response {
+        Error error = NoError;
+        int httpStatus = 0;
+        QUrl finalUrl;
+        QByteArray body;
+        QByteArray retryAfter;
+        QByteArray etag;
+    };
+
+    typedef std::function<void(const Response &)> Callback;
+
+    explicit DCalDavTransport(QObject *parent = nullptr);
+
+    void send(const Request &request, const Callback &callback);
+    void cancel();
+
+    static QUrl normalizeUrl(const QUrl &url);
+    static bool isSecureUrl(const QUrl &url);
+    static bool isSameOrigin(const QUrl &first, const QUrl &second);
+    static QString urlForLog(const QUrl &url);
+    static Error classifyError(QNetworkReply::NetworkError networkError, int httpStatus,
+                               bool certificateInvalid, bool timedOut, bool responseTooLarge);
+
+private:
+    void send(const Request &request, const Callback &callback, int redirectCount,
+              const QUrl &redirectOrigin);
+
+    QNetworkAccessManager *m_networkManager = nullptr;
+    QSet<QNetworkReply *> m_activeReplies;
+    QList<QMetaObject::Connection> m_authenticationConnections;
+};
+
+#endif // DCALDAVTRANSPORT_H

--- a/src/calendar-service/src/caldav/dcaldavxmlreader.cpp
+++ b/src/calendar-service/src/caldav/dcaldavxmlreader.cpp
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavxmlreader.h"
+
+#include <QXmlStreamReader>
+
+namespace {
+constexpr int kMaximumXmlDepth = 64;
+constexpr qint64 kMaximumDiscoveryXmlBytes = 4 * 1024 * 1024;
+constexpr int kMaximumCalendarCollections = 256;
+constexpr int kMaximumPropertyLength = 4096;
+}
+
+static bool hasAcceptableXmlDepth(const QByteArray &xml)
+{
+    QXmlStreamReader reader(xml);
+    int depth = 0;
+    while (!reader.atEnd()) {
+        reader.readNext();
+        if (reader.isStartElement()) {
+            if (++depth > kMaximumXmlDepth) {
+                return false;
+            }
+        } else if (reader.isEndElement()) {
+            --depth;
+        }
+    }
+    return !reader.hasError() && depth == 0;
+}
+
+namespace {
+
+struct DiscoveryProperties
+{
+    QString currentUserPrincipalHref;
+    QString calendarHomeSetHref;
+    QString displayName;
+    QString color;
+    int privileges = DCalDavXmlReader::NoPrivilege;
+    bool privilegesKnown = false;
+    bool isCalendar = false;
+};
+
+int httpStatusCode(const QString &status)
+{
+    const QStringList parts = status.simplified().split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    if (parts.size() < 2) {
+        return -1;
+    }
+    bool ok = false;
+    const int code = parts.at(1).toInt(&ok);
+    return ok ? code : -1;
+}
+
+void readPrivilegeSet(QXmlStreamReader &reader, int &privileges)
+{
+    while (reader.readNextStartElement()) {
+        if (reader.name() != QStringLiteral("privilege")) {
+            reader.skipCurrentElement();
+            continue;
+        }
+        while (reader.readNextStartElement()) {
+            const auto privilegeName = reader.name();
+            if (privilegeName == QStringLiteral("read")) {
+                privileges |= DCalDavXmlReader::ReadPrivilege;
+            } else if (privilegeName == QStringLiteral("write")
+                       || privilegeName == QStringLiteral("write-content")
+                       || privilegeName == QStringLiteral("write-properties")) {
+                // CalDAV servers commonly advertise write permission using
+                // the DAV write-content/write-properties privileges instead
+                // of the aggregate DAV write privilege.
+                privileges |= DCalDavXmlReader::WritePrivilege;
+            }
+            reader.skipCurrentElement();
+        }
+    }
+}
+
+bool readResourceType(QXmlStreamReader &reader)
+{
+    bool isCalendar = false;
+    while (reader.readNextStartElement()) {
+        if (reader.name() == QStringLiteral("calendar")) {
+            isCalendar = true;
+        }
+        reader.skipCurrentElement();
+    }
+    return isCalendar;
+}
+
+void readProperty(QXmlStreamReader &reader, DiscoveryProperties &properties)
+{
+    while (reader.readNextStartElement()) {
+        const auto name = reader.name();
+        if (name == QStringLiteral("current-user-principal")) {
+            while (reader.readNextStartElement()) {
+                if (reader.name() == QStringLiteral("href")) {
+                    properties.currentUserPrincipalHref =
+                        reader.readElementText(QXmlStreamReader::SkipChildElements);
+                } else {
+                    reader.skipCurrentElement();
+                }
+            }
+        } else if (name == QStringLiteral("calendar-home-set")) {
+            while (reader.readNextStartElement()) {
+                if (reader.name() == QStringLiteral("href")) {
+                    properties.calendarHomeSetHref =
+                        reader.readElementText(QXmlStreamReader::SkipChildElements);
+                } else {
+                    reader.skipCurrentElement();
+                }
+            }
+        } else if (name == QStringLiteral("displayname")) {
+            properties.displayName = reader.readElementText(QXmlStreamReader::SkipChildElements);
+        } else if (name == QStringLiteral("calendar-color")) {
+            properties.color = reader.readElementText(QXmlStreamReader::SkipChildElements);
+        } else if (name == QStringLiteral("resourcetype")) {
+            properties.isCalendar = readResourceType(reader);
+        } else if (name == QStringLiteral("current-user-privilege-set")) {
+            properties.privilegesKnown = true;
+            readPrivilegeSet(reader, properties.privileges);
+        } else {
+            reader.skipCurrentElement();
+        }
+    }
+}
+
+void mergeProperties(const DiscoveryProperties &source,
+                     DCalDavXmlReader::DiscoveryResult &result,
+                     DCalDavXmlReader::CalendarCollection &collection,
+                     bool &isCalendar)
+{
+    if (!source.currentUserPrincipalHref.isEmpty()) {
+        result.currentUserPrincipalHref = source.currentUserPrincipalHref;
+    }
+    if (!source.calendarHomeSetHref.isEmpty()) {
+        result.calendarHomeSetHref = source.calendarHomeSetHref;
+    }
+    if (!source.displayName.isEmpty()) {
+        collection.displayName = source.displayName;
+    }
+    if (!source.color.isEmpty()) {
+        collection.color = source.color;
+    }
+    if (source.isCalendar) {
+        isCalendar = true;
+    }
+    if (source.privilegesKnown) {
+        collection.privilegesKnown = true;
+        collection.privileges |= source.privileges;
+    }
+}
+
+void readPropertyStatus(QXmlStreamReader &reader, DCalDavXmlReader::DiscoveryResult &result,
+                        DCalDavXmlReader::CalendarCollection &collection, bool &isCalendar)
+{
+    DiscoveryProperties properties;
+    int statusCode = -1;
+    while (reader.readNextStartElement()) {
+        if (reader.name() == QStringLiteral("prop")) {
+            readProperty(reader, properties);
+        } else if (reader.name() == QStringLiteral("status")) {
+            statusCode = httpStatusCode(reader.readElementText(QXmlStreamReader::SkipChildElements));
+        } else {
+            reader.skipCurrentElement();
+        }
+    }
+    if (statusCode >= 200 && statusCode < 300) {
+        mergeProperties(properties, result, collection, isCalendar);
+    }
+}
+
+void readResponse(QXmlStreamReader &reader, DCalDavXmlReader::DiscoveryResult &result)
+{
+    DCalDavXmlReader::CalendarCollection collection;
+    bool isCalendar = false;
+    while (reader.readNextStartElement()) {
+        if (reader.name() == QStringLiteral("href")) {
+            collection.href = reader.readElementText(QXmlStreamReader::SkipChildElements);
+        } else if (reader.name() == QStringLiteral("propstat")) {
+            readPropertyStatus(reader, result, collection, isCalendar);
+        } else {
+            reader.skipCurrentElement();
+        }
+    }
+
+    if (isCalendar && !collection.href.isEmpty()
+        && collection.href.size() <= kMaximumPropertyLength) {
+        result.calendarCollections.append(collection);
+    } else if (!collection.href.isEmpty() && result.principalDisplayName.isEmpty()) {
+        result.principalDisplayName = collection.displayName;
+    }
+}
+
+} // namespace
+
+bool DCalDavXmlReader::parseDiscovery(const QByteArray &xml, DiscoveryResult &result, QString *errorMessage)
+{
+    if (!hasAcceptableXmlDepth(xml)) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("DAV discovery response is too deeply nested.");
+        }
+        return false;
+    }
+    if (xml.size() > kMaximumDiscoveryXmlBytes) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("DAV discovery response is too large.");
+        }
+        return false;
+    }
+    QXmlStreamReader reader(xml);
+    DiscoveryResult parsed;
+    if (!reader.readNextStartElement() || reader.name() != QStringLiteral("multistatus")) {
+        if (errorMessage != nullptr) {
+            *errorMessage = reader.hasError() ? reader.errorString() : QStringLiteral("Invalid DAV multistatus response.");
+        }
+        return false;
+    }
+
+    while (reader.readNextStartElement()) {
+        if (reader.name() == QStringLiteral("response")) {
+            readResponse(reader, parsed);
+            if (parsed.calendarCollections.size() > kMaximumCalendarCollections) {
+                if (errorMessage != nullptr) {
+                    *errorMessage = QStringLiteral("DAV discovery response contains too many calendar collections.");
+                }
+                return false;
+            }
+        } else {
+            reader.skipCurrentElement();
+        }
+    }
+
+    if (reader.hasError()) {
+        if (errorMessage != nullptr) {
+            *errorMessage = reader.errorString();
+        }
+        return false;
+    }
+
+    if (parsed.currentUserPrincipalHref.size() > kMaximumPropertyLength
+        || parsed.calendarHomeSetHref.size() > kMaximumPropertyLength
+        || parsed.principalDisplayName.size() > kMaximumPropertyLength
+        || parsed.calendarCollections.size() > kMaximumCalendarCollections) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("DAV discovery response contains oversized or excessive properties.");
+        }
+        return false;
+    }
+    for (const CalendarCollection &collection : parsed.calendarCollections) {
+        if (collection.href.size() > kMaximumPropertyLength
+            || collection.displayName.size() > kMaximumPropertyLength
+            || collection.color.size() > kMaximumPropertyLength) {
+            if (errorMessage != nullptr) {
+                *errorMessage = QStringLiteral("DAV calendar collection contains oversized properties.");
+            }
+            return false;
+        }
+    }
+    result = parsed;
+    return true;
+}

--- a/src/calendar-service/src/caldav/dcaldavxmlreader.h
+++ b/src/calendar-service/src/caldav/dcaldavxmlreader.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVXMLREADER_H
+#define DCALDAVXMLREADER_H
+
+#include <QString>
+#include <QVector>
+
+class DCalDavXmlReader
+{
+public:
+    enum Privilege {
+        NoPrivilege = 0,
+        ReadPrivilege = 0x1,
+        WritePrivilege = 0x2,
+    };
+
+    struct CalendarCollection {
+        QString href;
+        QString displayName;
+        QString color;
+        int privileges = NoPrivilege;
+        bool privilegesKnown = false;
+    };
+
+    struct DiscoveryResult {
+        QString currentUserPrincipalHref;
+        QString calendarHomeSetHref;
+        QString principalDisplayName;
+        QVector<CalendarCollection> calendarCollections;
+    };
+
+    static bool parseDiscovery(const QByteArray &xml, DiscoveryResult &result, QString *errorMessage = nullptr);
+};
+
+#endif // DCALDAVXMLREADER_H


### PR DESCRIPTION
Implement Qt Network transport, TLS error handling, XML discovery parsing, and CalDAV calendar/resource query helpers.

实现 Qt Network 传输、TLS 错误处理、XML 服务发现解析，
以及 CalDAV 日历资源查询。

Log: 增加 CalDAV 协议访问层
PMS: TASK-393989
Influence: 为账户验证、日历发现和后续同步功能提供网络访问能力

## Summary by Sourcery

Provide the CalDAV network access layer needed for secure account validation, calendar discovery, and event synchronization.

New Features:
- Add a Qt Network-based CalDAV transport for authenticated HTTPS requests, cancellation, redirects, and response handling.
- Add CalDAV discovery request helpers and XML parsing for principals, calendar home sets, collections, display names, colors, and privileges.
- Add CalDAV calendar query helpers for initial and incremental event sync, resource listing, retrieval, and multiget operations.
- Add parsing of CalDAV event and resource responses, including ETags, calendar data, UIDs, sync tokens, and deletions.

Bug Fixes:
- Reject insecure or cross-origin redirects and invalid TLS certificates, and classify authentication, timeout, availability, rate-limit, permission, and oversized-response failures.

Enhancements:
- Apply bounded XML and response parsing to protect discovery and synchronization operations from excessive nesting, sizes, properties, and resource counts.

Build:
- Link the calendar service against Qt Network.