### PR TITLE
feat(database): add CalDAV persistence and migration support

### DIFF
--- a/src/calendar-service/src/dbmanager/daccountdatabase.cpp
+++ b/src/calendar-service/src/dbmanager/daccountdatabase.cpp
@@ -19,7 +19,7 @@ DAccountDataBase::DAccountDataBase(const DAccount::Ptr &account, QObject *parent
     : DDataBase(parent)
     , m_account(account)
 {
-    setConnectionName(m_account->accountName());
+    setConnectionName(m_account->accountID());
 }
 
 QString DAccountDataBase::createSchedule(const DSchedule::Ptr &schedule)
@@ -28,7 +28,9 @@ QString DAccountDataBase::createSchedule(const DSchedule::Ptr &schedule)
         qCDebug(ServiceLogger) << "Creating schedule:" << schedule->summary() 
                               << "Start:" << schedule->dtStart().toString();
         SqliteQuery query(m_database);
-        schedule->setUid(DDataBase::createUuid());
+        if (schedule->uid().isEmpty() || schedule->uid() == QStringLiteral("0")) {
+            schedule->setUid(DDataBase::createUuid());
+        }
 
         QString strSql("INSERT INTO schedules                                                   \
                        (scheduleID, scheduleTypeID, summary, description, allDay, dtStart   \
@@ -78,7 +80,7 @@ bool DAccountDataBase::updateSchedule(const DSchedule::Ptr &schedule)
         QString strSql("UPDATE schedules                                                  \
                        SET scheduleTypeID=?, summary=?, description=?, allDay=?           \
                 , dtStart=?, dtEnd=?, isAlarm=?,titlePinyin=?, isLunar=?, ics=?, fileName=?             \
-                , dtUpdate=? WHERE scheduleID= ?;");
+                , dtUpdate=?, dtDelete=?, isDeleted=0 WHERE scheduleID= ?;");
         if (query.prepare(strSql)) {
             query.addBindValue(schedule->scheduleTypeID());
             query.addBindValue(schedule->summary());
@@ -92,6 +94,7 @@ bool DAccountDataBase::updateSchedule(const DSchedule::Ptr &schedule)
             query.addBindValue(DSchedule::toIcsString(schedule));
             query.addBindValue(schedule->fileName());
             query.addBindValue(dtToString(schedule->lastModified()));
+            query.addBindValue(QString());
             query.addBindValue(schedule->schedulingID());
             if (query.exec()) {
                 resbool = true;
@@ -118,12 +121,16 @@ DSchedule::Ptr DAccountDataBase::getScheduleByScheduleID(const QString &schedule
     DSchedule::Ptr schedule;
     if (query.prepare(strSql)) {
         query.addBindValue(scheduleID);
-        schedule = DSchedule::Ptr(new DSchedule);
         if (query.exec()) {
             if (query.next()) {
-                QString &&icsStr = query.value("ics").toString();
-                DSchedule::fromIcsString(schedule, icsStr);
-                schedule->setScheduleTypeID(query.value("scheduleTypeID").toString());
+                const QString ics = query.value("ics").toString();
+                DSchedule::Ptr parsedSchedule;
+                if (DSchedule::fromIcsString(parsedSchedule, ics) && !parsedSchedule.isNull()) {
+                    parsedSchedule->setScheduleTypeID(query.value("scheduleTypeID").toString());
+                    schedule = parsedSchedule;
+                } else {
+                    qCWarning(ServiceLogger) << "Failed to parse schedule ICS for scheduleID:" << scheduleID;
+                }
             }
         } else {
             qCWarning(ServiceLogger) << Q_FUNC_INFO << query.lastError();
@@ -138,6 +145,109 @@ DSchedule::Ptr DAccountDataBase::getScheduleByScheduleID(const QString &schedule
     }
 
     return schedule;
+}
+
+bool DAccountDataBase::scheduleExistsByScheduleID(const QString &scheduleID) const
+{
+    if (scheduleID.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "SELECT 1 FROM schedules WHERE scheduleID = ? LIMIT 1"))) {
+        return false;
+    }
+    query.addBindValue(scheduleID);
+    return query.exec() && query.next();
+}
+
+bool DAccountDataBase::isScheduleDeletedByScheduleID(const QString &scheduleID) const
+{
+    if (scheduleID.isEmpty()) {
+        return false;
+    }
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "SELECT isDeleted FROM schedules WHERE scheduleID = ? LIMIT 1"))) {
+        return false;
+    }
+    query.addBindValue(scheduleID);
+    return query.exec() && query.next() && query.value(0).toInt() != 0;
+}
+
+bool DAccountDataBase::upsertCalDavRecoveryItem(const DCalDavRecoveryItem &item)
+{
+    if (item.accountID.isEmpty() || item.localScheduleID.isEmpty() || item.scheduleIcs.isEmpty()) {
+        return false;
+    }
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "INSERT OR REPLACE INTO caldavRecovery "
+            "(accountID, localScheduleID, operationType, scheduleIcs, calendarID, href, etag, "
+            "originalIcs, createdAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"))) {
+        return false;
+    }
+    query.addBindValue(item.accountID);
+    query.addBindValue(item.localScheduleID);
+    query.addBindValue(static_cast<int>(item.operationType));
+    query.addBindValue(item.scheduleIcs);
+    query.addBindValue(item.calendarID);
+    query.addBindValue(item.href);
+    query.addBindValue(item.etag);
+    query.addBindValue(item.originalIcs);
+    query.addBindValue((item.createdAt.isValid() ? item.createdAt : QDateTime::currentDateTimeUtc())
+                           .toUTC().toString(Qt::ISODate));
+    return query.exec();
+}
+
+DCalDavRecoveryItem::List DAccountDataBase::getCalDavRecoveryItems(const QString &accountID) const
+{
+    DCalDavRecoveryItem::List items;
+    if (accountID.isEmpty()) {
+        return items;
+    }
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "SELECT accountID, localScheduleID, operationType, scheduleIcs, calendarID, href, etag, "
+            "originalIcs, createdAt FROM caldavRecovery WHERE accountID = ? ORDER BY createdAt"))) {
+        return items;
+    }
+    query.addBindValue(accountID);
+    if (!query.exec()) {
+        return items;
+    }
+    while (query.next()) {
+        DCalDavRecoveryItem item;
+        item.accountID = query.value("accountID").toString();
+        item.localScheduleID = query.value("localScheduleID").toString();
+        item.operationType = static_cast<DCalDavRecoveryItem::OperationType>(
+            query.value("operationType").toInt());
+        item.scheduleIcs = query.value("scheduleIcs").toString();
+        item.calendarID = query.value("calendarID").toString();
+        item.href = query.value("href").toString();
+        item.etag = query.value("etag").toString();
+        item.originalIcs = query.value("originalIcs").toString();
+        item.createdAt = QDateTime::fromString(query.value("createdAt").toString(), Qt::ISODate);
+        items.append(item);
+    }
+    return items;
+}
+
+bool DAccountDataBase::deleteCalDavRecoveryItem(const QString &accountID,
+                                                 const QString &localScheduleID)
+{
+    if (accountID.isEmpty() || localScheduleID.isEmpty()) {
+        return false;
+    }
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "DELETE FROM caldavRecovery WHERE accountID = ? AND localScheduleID = ?"))) {
+        return false;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(localScheduleID);
+    return query.exec();
 }
 
 QStringList DAccountDataBase::getScheduleIDListByTypeID(const QString &typeID)
@@ -212,6 +322,35 @@ bool DAccountDataBase::deleteSchedulesByScheduleTypeID(const QString &typeID, co
         query.finish();
     }
     return resBool;
+}
+
+DSchedule::List DAccountDataBase::getScheduleListByTypeID(const QString &typeID)
+{
+    DSchedule::List scheduleList;
+    const QString sql = QStringLiteral(
+        "SELECT ics, scheduleTypeID FROM schedules WHERE scheduleTypeID = ? AND isDeleted = 0");
+    SqliteQuery query(m_database);
+    if (query.prepare(sql)) {
+        query.addBindValue(typeID);
+        if (query.exec()) {
+            while (query.next()) {
+                DSchedule::Ptr schedule;
+                if (DSchedule::fromIcsString(schedule, query.value("ics").toString())
+                    && !schedule.isNull()) {
+                    schedule->setScheduleTypeID(query.value("scheduleTypeID").toString());
+                    scheduleList.append(schedule);
+                }
+            }
+        } else {
+            qCWarning(ServiceLogger) << Q_FUNC_INFO << query.lastError();
+        }
+    } else {
+        qCWarning(ServiceLogger) << Q_FUNC_INFO << query.lastError();
+    }
+    if (query.isActive()) {
+        query.finish();
+    }
+    return scheduleList;
 }
 
 DSchedule::List DAccountDataBase::querySchedulesByKey(const QString &key)
@@ -351,6 +490,11 @@ void DAccountDataBase::initDBData()
         //如果存在则连接数据库
         qCDebug(ServiceLogger) << "Database file exists, opening connection";
         dbOpen();
+    }
+    SqliteQuery recoverySchemaQuery(m_database);
+    if (!recoverySchemaQuery.exec(sql_create_caldavRecovery)) {
+        qCWarning(ServiceLogger) << "Failed to create CalDAV recovery table:"
+                                 << recoverySchemaQuery.lastError().text();
     }
 }
 
@@ -1064,6 +1208,11 @@ void DAccountDataBase::createDB()
         res = query.exec(sql_create_remindTask);
         if (!res) {
             qCWarning(ServiceLogger) << "Failed to create remindTask table:" << query.lastError().text();
+        }
+
+        res = query.exec(sql_create_caldavRecovery);
+        if (!res) {
+            qCWarning(ServiceLogger) << "Failed to create CalDAV recovery table:" << query.lastError().text();
         }
 
         if (query.isActive()) {

--- a/src/calendar-service/src/dbmanager/daccountdatabase.h
+++ b/src/calendar-service/src/dbmanager/daccountdatabase.h
@@ -12,6 +12,7 @@
 #include "dreminddata.h"
 #include "duploadtaskdata.h"
 #include "dtypecolor.h"
+#include "dcaldavrecoveryitem.h"
 
 #include <QSharedPointer>
 
@@ -30,9 +31,16 @@ public:
     bool updateSchedule(const DSchedule::Ptr &schedule);
     //根据日程id获取日程信息
     DSchedule::Ptr getScheduleByScheduleID(const QString &scheduleID);
+    bool scheduleExistsByScheduleID(const QString &scheduleID) const;
+    bool isScheduleDeletedByScheduleID(const QString &scheduleID) const;
+
+    bool upsertCalDavRecoveryItem(const DCalDavRecoveryItem &item);
+    DCalDavRecoveryItem::List getCalDavRecoveryItems(const QString &accountID) const;
+    bool deleteCalDavRecoveryItem(const QString &accountID, const QString &localScheduleID);
 
     //根据日程类型ID获取日程id列表
     QStringList getScheduleIDListByTypeID(const QString &typeID);
+    DSchedule::List getScheduleListByTypeID(const QString &typeID);
     bool deleteScheduleByScheduleID(const QString &scheduleID, const int isDeleted = 0);
     bool deleteSchedulesByScheduleTypeID(const QString &typeID, const int isDeleted = 0);
     //根据关键字查询一定范围内的日程

--- a/src/calendar-service/src/dbmanager/daccountmanagerdatabase.cpp
+++ b/src/calendar-service/src/dbmanager/daccountmanagerdatabase.cpp
@@ -7,10 +7,14 @@
 #include "units.h"
 
 #include "commondef.h"
+#include "dcaldavaccountstatus.h"
+#include "dcaldavprofile.h"
+#include <QSet>
 #include <QSqlQuery>
 #include <QtDebug>
 #include <QSqlError>
 #include <QFile>
+#include <QUrl>
 
 DAccountManagerDataBase::DAccountManagerDataBase(QObject *parent)
     : DDataBase(parent)
@@ -24,6 +28,11 @@ void DAccountManagerDataBase::initDBData()
     qCDebug(ServiceLogger) << "Initializing account manager database";
     createDB();
     initAccountManagerDB();
+}
+
+void DAccountManagerDataBase::ensureSchema()
+{
+    createDB();
 }
 
 DAccount::List DAccountManagerDataBase::getAccountList()
@@ -218,6 +227,1177 @@ void DAccountManagerDataBase::setCalendarGeneralSettings(const DCalendarGeneralS
     }
 }
 
+QString DAccountManagerDataBase::getCalDavAccountStatusList()
+{
+    DCalDavAccountStatus::List statusList;
+    const QString sql = "SELECT caldavAccount.accountID, caldavAccount.providerType, caldavAccount.syncStatus, "
+                        "caldavAccount.lastSuccessfulSync, caldavAccount.failureReason, caldavAccount.failureCode, caldavAccount.accountColor, "
+                        "caldavAccount.serverUrl, accountManager.displayName, "
+                        "(SELECT COUNT(*) FROM caldavOutbox outbox "
+                        " WHERE outbox.accountID = caldavAccount.accountID) AS pendingOperationCount, "
+                        "(SELECT COUNT(*) FROM caldavOutbox deleteBox "
+                        " WHERE deleteBox.accountID = caldavAccount.accountID "
+                        " AND deleteBox.operationType = 2) AS pendingDeleteCount, "
+                        "(SELECT COUNT(*) FROM caldavOutbox conflictBox "
+                        " WHERE conflictBox.accountID = caldavAccount.accountID AND conflictBox.failureType = 4) AS conflictCount, "
+                        "(SELECT COUNT(*) FROM caldavCalendar calendarCount "
+                        " WHERE calendarCount.accountID = caldavAccount.accountID) AS calendarCount, "
+                        "(SELECT COUNT(*) FROM caldavCalendar writableCalendar "
+                        " WHERE writableCalendar.accountID = caldavAccount.accountID "
+                        " AND (writableCalendar.privileges & 2) != 0) AS writableCalendarCount, "
+                        "CASE WHEN caldavAccount.nextRetryAt IS NULL OR caldavAccount.nextRetryAt = '' THEN "
+                        " (SELECT MIN(retryBox.nextRetryAt) FROM caldavOutbox retryBox "
+                        "  WHERE retryBox.accountID = caldavAccount.accountID AND retryBox.failureType = 1 "
+                        "  AND retryBox.nextRetryAt IS NOT NULL AND retryBox.nextRetryAt != '') "
+                        "WHEN (SELECT MIN(retryBox.nextRetryAt) FROM caldavOutbox retryBox "
+                        "      WHERE retryBox.accountID = caldavAccount.accountID AND retryBox.failureType = 1 "
+                        "      AND retryBox.nextRetryAt IS NOT NULL AND retryBox.nextRetryAt != '') IS NULL "
+                        " THEN caldavAccount.nextRetryAt "
+                        "WHEN caldavAccount.nextRetryAt < (SELECT MIN(retryBox.nextRetryAt) FROM caldavOutbox retryBox "
+                        "      WHERE retryBox.accountID = caldavAccount.accountID AND retryBox.failureType = 1 "
+                        "      AND retryBox.nextRetryAt IS NOT NULL AND retryBox.nextRetryAt != '') "
+                        " THEN caldavAccount.nextRetryAt "
+                        "ELSE (SELECT MIN(retryBox.nextRetryAt) FROM caldavOutbox retryBox "
+                        "      WHERE retryBox.accountID = caldavAccount.accountID AND retryBox.failureType = 1 "
+                        "      AND retryBox.nextRetryAt IS NOT NULL AND retryBox.nextRetryAt != '') END AS nextRetryAt "
+                        "FROM caldavAccount LEFT JOIN accountManager ON caldavAccount.accountID = accountManager.accountID";
+    SqliteQuery query(m_database);
+    if (!query.prepare(sql) || !query.exec()) {
+        qCWarning(ServiceLogger) << "Failed to get CalDAV account statuses:" << query.lastError().text();
+        return QStringLiteral("[]");
+    }
+
+    while (query.next()) {
+        DCalDavAccountStatus status;
+        status.accountId = query.value("accountID").toString();
+        status.displayName = query.value("displayName").toString();
+        const auto storedProviderType = static_cast<DCalDavProviderProfile::ProviderType>(
+            query.value("providerType").toInt());
+        status.providerType = DCalDavProviderProfile::providerTypeForServerUrl(
+            query.value("serverUrl").toString(), storedProviderType);
+        status.syncStatus = query.value("syncStatus").toInt();
+        status.lastSuccessfulSync = QDateTime::fromString(query.value("lastSuccessfulSync").toString(), Qt::ISODate);
+        status.failureReason = query.value("failureReason").toString();
+        status.failureCode = query.value("failureCode").toInt();
+        status.accountColor = query.value("accountColor").toString();
+        const bool providerSupportsWrite = DCalDavProviderProfile::forProvider(
+            static_cast<DCalDavProviderProfile::ProviderType>(status.providerType)).supportsWrite;
+        const int calendarCount = query.value("calendarCount").toInt();
+        const int writableCalendarCount = query.value("writableCalendarCount").toInt();
+        status.supportsWrite = providerSupportsWrite
+            && (calendarCount == 0 || writableCalendarCount > 0);
+        status.pendingOperationCount = query.value("pendingOperationCount").toInt();
+        status.pendingDeleteCount = query.value("pendingDeleteCount").toInt();
+        status.conflictCount = query.value("conflictCount").toInt();
+        status.nextRetryAt = QDateTime::fromString(
+            query.value("nextRetryAt").toString(), Qt::ISODate);
+        statusList.append(status);
+    }
+    return DCalDavAccountStatus::toJsonListString(statusList);
+}
+
+bool DAccountManagerDataBase::getCalDavAccountInfo(const QString &accountID, DCalDavAccountInfo &accountInfo)
+{
+    accountInfo = DCalDavAccountInfo();
+    if (accountID.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("SELECT accountID, providerType, serverUrl, username, credentialRef, accountColor, "
+                       "retryCount, nextRetryAt FROM caldavAccount WHERE accountID = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV account query:" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(accountID);
+    if (!query.exec() || !query.next()) {
+        if (query.lastError().isValid()) {
+            qCWarning(ServiceLogger) << "Failed to query CalDAV account:" << query.lastError().text();
+        }
+        return false;
+    }
+
+    accountInfo.accountId = query.value("accountID").toString();
+    accountInfo.serverUrl = query.value("serverUrl").toString();
+    const auto storedProviderType = static_cast<DCalDavProviderProfile::ProviderType>(
+        query.value("providerType").toInt());
+    accountInfo.providerType = DCalDavProviderProfile::providerTypeForServerUrl(
+        accountInfo.serverUrl, storedProviderType);
+    accountInfo.username = query.value("username").toString();
+    accountInfo.credentialRef = query.value("credentialRef").toString();
+    accountInfo.accountColor = query.value("accountColor").toString();
+    accountInfo.retryCount = query.value("retryCount").toInt();
+    accountInfo.nextRetryAt = QDateTime::fromString(query.value("nextRetryAt").toString(), Qt::ISODate);
+    return true;
+}
+
+bool DAccountManagerDataBase::upsertCalDavAccountInfo(const DCalDavAccountInfo &accountInfo)
+{
+    const QUrl serverUrl(accountInfo.serverUrl);
+    if (accountInfo.accountId.isEmpty() || accountInfo.username.isEmpty()
+        || accountInfo.credentialRef.isEmpty() || serverUrl.scheme() != QStringLiteral("https")
+        || serverUrl.host().isEmpty() || !DCalDavCredentialReference::isValid(accountInfo.credentialRef)) {
+        qCWarning(ServiceLogger) << "Rejected invalid CalDAV account configuration.";
+        return false;
+    }
+
+    SqliteQuery updateQuery(m_database);
+    if (!updateQuery.prepare("UPDATE caldavAccount SET providerType = ?, serverUrl = ?, username = ?, "
+                             "credentialRef = ?, accountColor = ?, retryCount = 0, nextRetryAt = NULL WHERE accountID = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV account update:" << updateQuery.lastError().text();
+        return false;
+    }
+    updateQuery.addBindValue(accountInfo.providerType);
+    updateQuery.addBindValue(accountInfo.serverUrl);
+    updateQuery.addBindValue(accountInfo.username);
+    updateQuery.addBindValue(accountInfo.credentialRef);
+    updateQuery.addBindValue(accountInfo.accountColor);
+    updateQuery.addBindValue(accountInfo.accountId);
+    if (!updateQuery.exec()) {
+        qCWarning(ServiceLogger) << "Failed to update CalDAV account configuration:" << updateQuery.lastError().text();
+        return false;
+    }
+    if (updateQuery.numRowsAffected() == 1) {
+        return true;
+    }
+
+    SqliteQuery insertQuery(m_database);
+    if (!insertQuery.prepare("INSERT INTO caldavAccount "
+                             "(accountID, providerType, serverUrl, username, credentialRef, accountColor) "
+                             "VALUES (?, ?, ?, ?, ?, ?)")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV account insert:" << insertQuery.lastError().text();
+        return false;
+    }
+    insertQuery.addBindValue(accountInfo.accountId);
+    insertQuery.addBindValue(accountInfo.providerType);
+    insertQuery.addBindValue(accountInfo.serverUrl);
+    insertQuery.addBindValue(accountInfo.username);
+    insertQuery.addBindValue(accountInfo.credentialRef);
+    insertQuery.addBindValue(accountInfo.accountColor);
+    if (!insertQuery.exec()) {
+        qCWarning(ServiceLogger) << "Failed to insert CalDAV account configuration:" << insertQuery.lastError().text();
+        return false;
+    }
+    return true;
+}
+
+bool DAccountManagerDataBase::deleteCalDavAccountInfo(const QString &accountID)
+{
+    if (accountID.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("DELETE FROM caldavAccount WHERE accountID = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV account deletion:" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(accountID);
+    if (!query.exec()) {
+        qCWarning(ServiceLogger) << "Failed to delete CalDAV account configuration:" << query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() == 1;
+}
+
+DCalDavOutboxItem DAccountManagerDataBase::getCalDavOutboxItem(const QString &accountID,
+                                                                  const QString &localScheduleID)
+{
+    DCalDavOutboxItem item;
+    if (accountID.isEmpty() || localScheduleID.isEmpty()) {
+        return item;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("SELECT operationID, accountID, localScheduleID, operationType, baseEtag, conflictIcs, serverIcs, retryCount, "
+                       "nextRetryAt, failureType FROM caldavOutbox "
+                       "WHERE accountID = ? AND localScheduleID = ? ORDER BY operationID LIMIT 1")) {
+        return item;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(localScheduleID);
+    if (!query.exec() || !query.next()) {
+        return item;
+    }
+    item.operationID = query.value("operationID").toString();
+    item.accountID = query.value("accountID").toString();
+    item.localScheduleID = query.value("localScheduleID").toString();
+    item.operationType = static_cast<DCalDavOutboxItem::OperationType>(
+        query.value("operationType").toInt());
+    item.baseEtag = query.value("baseEtag").toString();
+    item.conflictIcs = query.value("conflictIcs").toString();
+        item.serverIcs = query.value("serverIcs").toString();
+    item.retryCount = query.value("retryCount").toInt();
+    item.nextRetryAt = QDateTime::fromString(query.value("nextRetryAt").toString(), Qt::ISODate);
+    item.failureType = static_cast<DCalDavOutboxItem::FailureType>(
+        query.value("failureType").toInt());
+    return item;
+}
+
+bool DAccountManagerDataBase::hasCalDavOutboxItems(const QString &accountID) const
+{
+    if (accountID.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "SELECT 1 FROM caldavOutbox WHERE accountID = ? LIMIT 1"))) {
+        return false;
+    }
+    query.addBindValue(accountID);
+    return query.exec() && query.next();
+}
+
+DCalDavOutboxItem::List DAccountManagerDataBase::getCalDavConflictItems(
+    const QString &accountID)
+{
+    DCalDavOutboxItem::List items;
+    if (accountID.isEmpty()) {
+        return items;
+    }
+    SqliteQuery query(m_database);
+    if (!query.prepare("SELECT operationID, accountID, localScheduleID, operationType, baseEtag, conflictIcs, serverIcs, "
+                       "retryCount, nextRetryAt, failureType FROM caldavOutbox "
+                       "WHERE accountID = ? AND failureType = 4 ORDER BY operationID")) {
+        return items;
+    }
+    query.addBindValue(accountID);
+    if (!query.exec()) {
+        return items;
+    }
+    while (query.next()) {
+        DCalDavOutboxItem item;
+        item.operationID = query.value("operationID").toString();
+        item.accountID = query.value("accountID").toString();
+        item.localScheduleID = query.value("localScheduleID").toString();
+        item.operationType = static_cast<DCalDavOutboxItem::OperationType>(
+            query.value("operationType").toInt());
+        item.baseEtag = query.value("baseEtag").toString();
+    item.conflictIcs = query.value("conflictIcs").toString();
+    item.serverIcs = query.value("serverIcs").toString();
+        item.retryCount = query.value("retryCount").toInt();
+        item.nextRetryAt = QDateTime::fromString(query.value("nextRetryAt").toString(), Qt::ISODate);
+        item.failureType = DCalDavOutboxItem::ConflictFailure;
+        items.append(item);
+    }
+    return items;
+}
+
+DCalDavOutboxItem::List DAccountManagerDataBase::getCalDavBlockedOutboxItems(
+    const QString &accountID)
+{
+    DCalDavOutboxItem::List items;
+    if (accountID.isEmpty()) {
+        return items;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare(
+            "SELECT operationID, accountID, localScheduleID, operationType, baseEtag, conflictIcs, serverIcs, "
+            "retryCount, nextRetryAt, failureType FROM caldavOutbox "
+            "WHERE accountID = ? AND failureType NOT IN (?, ?) ORDER BY operationID")) {
+        return items;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(static_cast<int>(DCalDavOutboxItem::NoFailure));
+    query.addBindValue(static_cast<int>(DCalDavOutboxItem::NetworkFailure));
+    if (!query.exec()) {
+        return items;
+    }
+    while (query.next()) {
+        DCalDavOutboxItem item;
+        item.operationID = query.value("operationID").toString();
+        item.accountID = query.value("accountID").toString();
+        item.localScheduleID = query.value("localScheduleID").toString();
+        item.operationType = static_cast<DCalDavOutboxItem::OperationType>(
+            query.value("operationType").toInt());
+        item.baseEtag = query.value("baseEtag").toString();
+    item.conflictIcs = query.value("conflictIcs").toString();
+    item.serverIcs = query.value("serverIcs").toString();
+        item.retryCount = query.value("retryCount").toInt();
+        item.nextRetryAt = QDateTime::fromString(query.value("nextRetryAt").toString(), Qt::ISODate);
+        item.failureType = static_cast<DCalDavOutboxItem::FailureType>(
+            query.value("failureType").toInt());
+        items.append(item);
+    }
+    return items;
+}
+
+DCalDavOutboxItem::List DAccountManagerDataBase::getCalDavRetryScheduledOutboxItems(
+    const QString &accountID, const QDateTime &now) const
+{
+    DCalDavOutboxItem::List items;
+    if (accountID.isEmpty() || !now.isValid()) {
+        return items;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare(
+            "SELECT operationID, accountID, localScheduleID, operationType, baseEtag, conflictIcs, serverIcs, "
+            "retryCount, nextRetryAt, failureType FROM caldavOutbox "
+            "WHERE accountID = ? AND failureType = ? AND nextRetryAt IS NOT NULL "
+            "AND nextRetryAt != '' AND nextRetryAt > ? ORDER BY operationID")) {
+        return items;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(static_cast<int>(DCalDavOutboxItem::NetworkFailure));
+    query.addBindValue(now.toUTC().toString(Qt::ISODate));
+    if (!query.exec()) {
+        return items;
+    }
+    while (query.next()) {
+        DCalDavOutboxItem item;
+        item.operationID = query.value("operationID").toString();
+        item.accountID = query.value("accountID").toString();
+        item.localScheduleID = query.value("localScheduleID").toString();
+        item.operationType = static_cast<DCalDavOutboxItem::OperationType>(
+            query.value("operationType").toInt());
+        item.baseEtag = query.value("baseEtag").toString();
+    item.conflictIcs = query.value("conflictIcs").toString();
+    item.serverIcs = query.value("serverIcs").toString();
+        item.retryCount = query.value("retryCount").toInt();
+        item.nextRetryAt = QDateTime::fromString(query.value("nextRetryAt").toString(), Qt::ISODate);
+        item.failureType = DCalDavOutboxItem::NetworkFailure;
+        items.append(item);
+    }
+    return items;
+}
+
+DCalDavOutboxItem::List DAccountManagerDataBase::getDueCalDavOutboxItems(
+    const QString &accountID, const QDateTime &now, bool ignoreRetryAt)
+{
+    DCalDavOutboxItem::List items;
+    if (accountID.isEmpty()) {
+        return items;
+    }
+
+    SqliteQuery query(m_database);
+    const QString sql = ignoreRetryAt
+        ? QStringLiteral("SELECT operationID, accountID, localScheduleID, operationType, baseEtag, conflictIcs, serverIcs, retryCount, "
+                        "nextRetryAt, failureType FROM caldavOutbox "
+                        "WHERE accountID = ? AND failureType IN (0, 1, 2, 3, 5) ORDER BY operationID")
+        : QStringLiteral("SELECT operationID, accountID, localScheduleID, operationType, baseEtag, conflictIcs, serverIcs, retryCount, "
+                        "nextRetryAt, failureType FROM caldavOutbox "
+                        "WHERE accountID = ? AND failureType IN (0, 1) "
+                        "AND (nextRetryAt IS NULL OR nextRetryAt = '' OR nextRetryAt <= ?) "
+                        "ORDER BY operationID");
+    if (!query.prepare(sql)) {
+        return items;
+    }
+    query.addBindValue(accountID);
+    if (!ignoreRetryAt) {
+        query.addBindValue(now.toString(Qt::ISODate));
+    }
+    if (!query.exec()) {
+        return items;
+    }
+    while (query.next()) {
+        DCalDavOutboxItem item;
+        item.operationID = query.value("operationID").toString();
+        item.accountID = query.value("accountID").toString();
+        item.localScheduleID = query.value("localScheduleID").toString();
+        item.operationType = static_cast<DCalDavOutboxItem::OperationType>(
+            query.value("operationType").toInt());
+            item.baseEtag = query.value("baseEtag").toString();
+    item.conflictIcs = query.value("conflictIcs").toString();
+    item.serverIcs = query.value("serverIcs").toString();
+        item.retryCount = query.value("retryCount").toInt();
+        item.nextRetryAt = QDateTime::fromString(query.value("nextRetryAt").toString(), Qt::ISODate);
+        item.failureType = static_cast<DCalDavOutboxItem::FailureType>(
+            query.value("failureType").toInt());
+        items.append(item);
+    }
+    return items;
+}
+
+QDateTime DAccountManagerDataBase::earliestCalDavOutboxRetryAt() const
+{
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "SELECT MIN(nextRetryAt) FROM caldavOutbox "
+            "WHERE failureType = ? AND nextRetryAt IS NOT NULL AND nextRetryAt != ''"))) {
+        return QDateTime();
+    }
+    query.addBindValue(static_cast<int>(DCalDavOutboxItem::NetworkFailure));
+    if (!query.exec() || !query.next()) {
+        return QDateTime();
+    }
+    return QDateTime::fromString(query.value(0).toString(), Qt::ISODate);
+}
+
+bool DAccountManagerDataBase::upsertCalDavOutboxItem(const DCalDavOutboxItem &item)
+{
+    if (item.operationID.isEmpty() || item.accountID.isEmpty() || item.localScheduleID.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery updateQuery(m_database);
+    if (!updateQuery.prepare("UPDATE caldavOutbox SET operationType = ?, baseEtag = ?, conflictIcs = ?, serverIcs = ?, retryCount = ?, "
+                             "nextRetryAt = ?, failureType = ? WHERE operationID = ?")) {
+        return false;
+    }
+    updateQuery.addBindValue(static_cast<int>(item.operationType));
+    updateQuery.addBindValue(item.baseEtag);
+    updateQuery.addBindValue(item.conflictIcs);
+    updateQuery.addBindValue(item.serverIcs);
+    updateQuery.addBindValue(item.retryCount);
+    updateQuery.addBindValue(item.nextRetryAt.isValid() ? item.nextRetryAt.toString(Qt::ISODate) : QString());
+    updateQuery.addBindValue(static_cast<int>(item.failureType));
+    updateQuery.addBindValue(item.operationID);
+    if (!updateQuery.exec()) {
+        return false;
+    }
+    if (updateQuery.numRowsAffected() == 1) {
+        return true;
+    }
+
+    SqliteQuery insertQuery(m_database);
+    if (!insertQuery.prepare("INSERT INTO caldavOutbox "
+                             "(operationID, accountID, localScheduleID, operationType, baseEtag, conflictIcs, serverIcs, retryCount, "
+                             "nextRetryAt, failureType) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+        return false;
+    }
+    insertQuery.addBindValue(item.operationID);
+    insertQuery.addBindValue(item.accountID);
+    insertQuery.addBindValue(item.localScheduleID);
+    insertQuery.addBindValue(static_cast<int>(item.operationType));
+    insertQuery.addBindValue(item.baseEtag);
+    insertQuery.addBindValue(item.conflictIcs);
+    insertQuery.addBindValue(item.serverIcs);
+    insertQuery.addBindValue(item.retryCount);
+    insertQuery.addBindValue(item.nextRetryAt.isValid() ? item.nextRetryAt.toString(Qt::ISODate) : QString());
+    insertQuery.addBindValue(static_cast<int>(item.failureType));
+    return insertQuery.exec();
+}
+
+bool DAccountManagerDataBase::deleteCalDavOutboxItem(const QString &accountID,
+                                                      const QString &localScheduleID)
+{
+    if (accountID.isEmpty() || localScheduleID.isEmpty()) {
+        return false;
+    }
+    SqliteQuery query(m_database);
+    if (!query.prepare("DELETE FROM caldavOutbox WHERE accountID = ? AND localScheduleID = ?")) {
+        return false;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(localScheduleID);
+    return query.exec();
+}
+
+bool DAccountManagerDataBase::deleteCalDavOutboxItemIfCurrent(const DCalDavOutboxItem &item)
+{
+    if (item.operationID.isEmpty() || item.accountID.isEmpty() || item.localScheduleID.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("DELETE FROM caldavOutbox WHERE operationID = ? AND accountID = ? "
+                       "AND localScheduleID = ?")) {
+        return false;
+    }
+    query.addBindValue(item.operationID);
+    query.addBindValue(item.accountID);
+    query.addBindValue(item.localScheduleID);
+    return query.exec() && query.numRowsAffected() == 1;
+}
+
+bool DAccountManagerDataBase::deleteCalDavAccountData(const QString &accountID)
+{
+    if (accountID.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.transaction()) {
+        return false;
+    }
+    const QStringList statements = {
+        QStringLiteral("DELETE FROM caldavEventMapping WHERE accountID = ?"),
+        QStringLiteral("DELETE FROM caldavCategoryMapping WHERE accountID = ?"),
+        QStringLiteral("DELETE FROM caldavOutbox WHERE accountID = ?"),
+        QStringLiteral("DELETE FROM caldavCalendar WHERE accountID = ?"),
+        QStringLiteral("DELETE FROM caldavAccount WHERE accountID = ?"),
+        QStringLiteral("DELETE FROM accountManager WHERE accountID = ?"),
+    };
+    for (const QString &statement : statements) {
+        if (!query.prepare(statement)) {
+            query.rollback();
+            return false;
+        }
+        query.addBindValue(accountID);
+        if (!query.exec()) {
+            query.rollback();
+            return false;
+        }
+    }
+    if (!query.commit()) {
+        query.rollback();
+        return false;
+    }
+    return true;
+}
+
+bool DAccountManagerDataBase::upsertCalDavAccountDeletionCleanup(
+    const QString &accountID, const QString &sourceDbName)
+{
+    if (accountID.isEmpty() || sourceDbName.isEmpty()) {
+        return false;
+    }
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "INSERT OR REPLACE INTO caldavAccountDeletionCleanup (accountID, sourceDbName) VALUES (?, ?)"))) {
+        return false;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(sourceDbName);
+    return query.exec();
+}
+
+QMap<QString, QString> DAccountManagerDataBase::getCalDavAccountDeletionCleanups() const
+{
+    QMap<QString, QString> cleanups;
+    SqliteQuery query(m_database);
+    if (!query.exec(QStringLiteral(
+            "SELECT accountID, sourceDbName FROM caldavAccountDeletionCleanup"))) {
+        return cleanups;
+    }
+    while (query.next()) {
+        cleanups.insert(query.value(0).toString(), query.value(1).toString());
+    }
+    return cleanups;
+}
+
+bool DAccountManagerDataBase::deleteCalDavAccountDeletionCleanup(const QString &accountID)
+{
+    if (accountID.isEmpty()) {
+        return false;
+    }
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "DELETE FROM caldavAccountDeletionCleanup WHERE accountID = ?"))) {
+        return false;
+    }
+    query.addBindValue(accountID);
+    return query.exec();
+}
+
+DCalDavCategoryInfo DAccountManagerDataBase::getCalDavCategoryMapping(
+    const QString &accountID, const QString &calendarID, const QString &categoryKey) const
+{
+    DCalDavCategoryInfo mapping;
+    if (accountID.isEmpty() || calendarID.isEmpty() || categoryKey.isEmpty()) {
+        return mapping;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "SELECT accountID, calendarID, categoryKey, scheduleTypeID "
+            "FROM caldavCategoryMapping WHERE accountID = ? AND calendarID = ? AND categoryKey = ?"))) {
+        return mapping;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(calendarID);
+    query.addBindValue(categoryKey);
+    if (!query.exec() || !query.next()) {
+        return mapping;
+    }
+    mapping.accountId = query.value("accountID").toString();
+    mapping.calendarId = query.value("calendarID").toString();
+    mapping.categoryKey = query.value("categoryKey").toString();
+    mapping.scheduleTypeId = query.value("scheduleTypeID").toString();
+    return mapping;
+}
+
+DCalDavCategoryInfo::List DAccountManagerDataBase::getCalDavCategoryMappings(
+    const QString &accountID, const QString &calendarID) const
+{
+    DCalDavCategoryInfo::List mappings;
+    if (accountID.isEmpty() || calendarID.isEmpty()) {
+        return mappings;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "SELECT accountID, calendarID, categoryKey, scheduleTypeID "
+            "FROM caldavCategoryMapping WHERE accountID = ? AND calendarID = ? "
+            "ORDER BY categoryKey"))) {
+        return mappings;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(calendarID);
+    if (!query.exec()) {
+        return mappings;
+    }
+    while (query.next()) {
+        DCalDavCategoryInfo mapping;
+        mapping.accountId = query.value("accountID").toString();
+        mapping.calendarId = query.value("calendarID").toString();
+        mapping.categoryKey = query.value("categoryKey").toString();
+        mapping.scheduleTypeId = query.value("scheduleTypeID").toString();
+        mappings.append(mapping);
+    }
+    return mappings;
+}
+
+DCalDavCategoryInfo DAccountManagerDataBase::getCalDavCategoryMappingByScheduleTypeID(
+    const QString &accountID, const QString &scheduleTypeID) const
+{
+    DCalDavCategoryInfo mapping;
+    if (accountID.isEmpty() || scheduleTypeID.isEmpty()) {
+        return mapping;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "SELECT accountID, calendarID, categoryKey, scheduleTypeID "
+            "FROM caldavCategoryMapping WHERE accountID = ? AND scheduleTypeID = ?"))) {
+        return mapping;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(scheduleTypeID);
+    if (!query.exec() || !query.next()) {
+        return mapping;
+    }
+    mapping.accountId = query.value("accountID").toString();
+    mapping.calendarId = query.value("calendarID").toString();
+    mapping.categoryKey = query.value("categoryKey").toString();
+    mapping.scheduleTypeId = query.value("scheduleTypeID").toString();
+    return mapping;
+}
+
+bool DAccountManagerDataBase::deleteCalDavCategoryMappingByScheduleTypeID(
+    const QString &accountID, const QString &scheduleTypeID)
+{
+    if (accountID.isEmpty() || scheduleTypeID.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "DELETE FROM caldavCategoryMapping WHERE accountID = ? AND scheduleTypeID = ?"))) {
+        return false;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(scheduleTypeID);
+    return query.exec();
+}
+
+bool DAccountManagerDataBase::upsertCalDavCategoryMapping(
+    const DCalDavCategoryInfo &mapping)
+{
+    if (mapping.accountId.isEmpty() || mapping.calendarId.isEmpty()
+        || mapping.categoryKey.isEmpty() || mapping.scheduleTypeId.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "INSERT OR REPLACE INTO caldavCategoryMapping "
+            "(accountID, calendarID, categoryKey, scheduleTypeID) VALUES (?, ?, ?, ?)"))) {
+        return false;
+    }
+    query.addBindValue(mapping.accountId);
+    query.addBindValue(mapping.calendarId);
+    query.addBindValue(mapping.categoryKey);
+    query.addBindValue(mapping.scheduleTypeId);
+    return query.exec();
+}
+
+bool DAccountManagerDataBase::updateCalDavCredentialReference(const QString &accountID, const QString &credentialRef)
+{
+    if (accountID.isEmpty() || !DCalDavCredentialReference::isValid(credentialRef)) {
+        qCWarning(ServiceLogger) << "Rejected invalid CalDAV credential reference update";
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("UPDATE caldavAccount SET credentialRef = ? WHERE accountID = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV credential reference update:" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(credentialRef);
+    query.addBindValue(accountID);
+    if (!query.exec()) {
+        qCWarning(ServiceLogger) << "Failed to update CalDAV credential reference:" << query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() == 1;
+}
+
+
+DCalDavCalendarInfo::List DAccountManagerDataBase::getCalDavCalendarList(const QString &accountID)
+{
+    DCalDavCalendarInfo::List calendars;
+    if (accountID.isEmpty()) {
+        return calendars;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("SELECT calendarID, accountID, href, displayName, color, scheduleTypeID, privileges, syncToken, "
+                       "initialSyncCompleted, enabled "
+                       "FROM caldavCalendar WHERE accountID = ? ORDER BY calendarID")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV calendar query:" << query.lastError().text();
+        return calendars;
+    }
+    query.addBindValue(accountID);
+    if (!query.exec()) {
+        qCWarning(ServiceLogger) << "Failed to query CalDAV calendars:" << query.lastError().text();
+        return calendars;
+    }
+
+    while (query.next()) {
+        DCalDavCalendarInfo calendar;
+        calendar.calendarId = query.value("calendarID").toString();
+        calendar.accountId = query.value("accountID").toString();
+        calendar.href = query.value("href").toString();
+        calendar.displayName = query.value("displayName").toString();
+        calendar.color = query.value("color").toString();
+        calendar.scheduleTypeID = query.value("scheduleTypeID").toString();
+        calendar.privileges = query.value("privileges").toInt();
+        calendar.syncToken = query.value("syncToken").toString();
+        calendar.initialSyncCompleted = query.value("initialSyncCompleted").toBool();
+        calendar.enabled = query.value("enabled").toBool();
+        calendars.append(calendar);
+    }
+    return calendars;
+}
+
+DCalDavCalendarInfo DAccountManagerDataBase::getCalDavCalendarByScheduleTypeID(
+    const QString &accountID, const QString &scheduleTypeID)
+{
+    DCalDavCalendarInfo calendar;
+    if (accountID.isEmpty() || scheduleTypeID.isEmpty()) {
+        return calendar;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("SELECT calendarID, accountID, href, displayName, color, scheduleTypeID, privileges, "
+                       "syncToken, initialSyncCompleted, enabled FROM caldavCalendar "
+                       "WHERE accountID = ? AND scheduleTypeID = ? AND enabled = 1")) {
+        return calendar;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(scheduleTypeID);
+    if (!query.exec() || !query.next()) {
+        return calendar;
+    }
+    calendar.calendarId = query.value("calendarID").toString();
+    calendar.accountId = query.value("accountID").toString();
+    calendar.href = query.value("href").toString();
+    calendar.displayName = query.value("displayName").toString();
+    calendar.color = query.value("color").toString();
+    calendar.scheduleTypeID = query.value("scheduleTypeID").toString();
+    calendar.privileges = query.value("privileges").toInt();
+    calendar.syncToken = query.value("syncToken").toString();
+    calendar.initialSyncCompleted = query.value("initialSyncCompleted").toBool();
+    calendar.enabled = query.value("enabled").toBool();
+    return calendar;
+}
+
+bool DAccountManagerDataBase::upsertCalDavCalendar(const DCalDavCalendarInfo &calendar)
+{
+    if (calendar.calendarId.isEmpty() || calendar.accountId.isEmpty() || calendar.href.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery updateQuery(m_database);
+    if (!updateQuery.prepare("UPDATE caldavCalendar SET accountID = ?, href = ?, displayName = ?, color = ?, scheduleTypeID = ?, "
+                             "privileges = ?, syncToken = ?, initialSyncCompleted = ?, enabled = ? WHERE calendarID = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV calendar update:" << updateQuery.lastError().text();
+        return false;
+    }
+    updateQuery.addBindValue(calendar.accountId);
+    updateQuery.addBindValue(calendar.href);
+    updateQuery.addBindValue(calendar.displayName);
+    updateQuery.addBindValue(calendar.color);
+    updateQuery.addBindValue(calendar.scheduleTypeID);
+    updateQuery.addBindValue(calendar.privileges);
+    updateQuery.addBindValue(calendar.syncToken);
+    updateQuery.addBindValue(calendar.initialSyncCompleted ? 1 : 0);
+    updateQuery.addBindValue(calendar.enabled ? 1 : 0);
+    updateQuery.addBindValue(calendar.calendarId);
+    if (!updateQuery.exec()) {
+        qCWarning(ServiceLogger) << "Failed to update CalDAV calendar:" << updateQuery.lastError().text();
+        return false;
+    }
+    if (updateQuery.numRowsAffected() == 1) {
+        return true;
+    }
+
+    SqliteQuery insertQuery(m_database);
+    if (!insertQuery.prepare("INSERT INTO caldavCalendar "
+                             "(calendarID, accountID, href, displayName, color, scheduleTypeID, privileges, syncToken, "
+                             "initialSyncCompleted, enabled) "
+                             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV calendar insert:" << insertQuery.lastError().text();
+        return false;
+    }
+    insertQuery.addBindValue(calendar.calendarId);
+    insertQuery.addBindValue(calendar.accountId);
+    insertQuery.addBindValue(calendar.href);
+    insertQuery.addBindValue(calendar.displayName);
+    insertQuery.addBindValue(calendar.color);
+    insertQuery.addBindValue(calendar.scheduleTypeID);
+    insertQuery.addBindValue(calendar.privileges);
+    insertQuery.addBindValue(calendar.syncToken);
+    insertQuery.addBindValue(calendar.initialSyncCompleted ? 1 : 0);
+    insertQuery.addBindValue(calendar.enabled ? 1 : 0);
+    if (!insertQuery.exec()) {
+        qCWarning(ServiceLogger) << "Failed to insert CalDAV calendar:" << insertQuery.lastError().text();
+        return false;
+    }
+    return true;
+}
+
+bool DAccountManagerDataBase::updateCalDavCalendarSyncToken(const QString &calendarID, const QString &syncToken)
+{
+    if (calendarID.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("UPDATE caldavCalendar SET syncToken = ? WHERE calendarID = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV sync token update:" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(syncToken);
+    query.addBindValue(calendarID);
+    if (!query.exec()) {
+        qCWarning(ServiceLogger) << "Failed to update CalDAV sync token:" << query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() == 1;
+}
+
+bool DAccountManagerDataBase::updateCalDavRetryState(const QString &accountID, int retryCount,
+                                                      const QDateTime &nextRetryAt,
+                                                      const QString &failureReason,
+                                                      DCalDavErrorCode failureCode)
+{
+    if (accountID.isEmpty() || retryCount < 0 || !nextRetryAt.isValid()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("UPDATE caldavAccount SET retryCount = ?, nextRetryAt = ?, "
+                      "syncStatus = ?, failureReason = ?, failureCode = ? WHERE accountID = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV retry state update:" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(retryCount);
+    query.addBindValue(nextRetryAt.toUTC().toString(Qt::ISODate));
+    query.addBindValue(DCalDavSyncStatus::RetryScheduled);
+    query.addBindValue(failureReason);
+    query.addBindValue(static_cast<int>(failureCode));
+    query.addBindValue(accountID);
+    if (!query.exec()) {
+        qCWarning(ServiceLogger) << "Failed to update CalDAV retry state:" << query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() == 1;
+}
+
+bool DAccountManagerDataBase::clearCalDavRetryState(const QString &accountID)
+{
+    if (accountID.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("UPDATE caldavAccount SET retryCount = 0, nextRetryAt = NULL WHERE accountID = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV retry state clear:" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(accountID);
+    if (!query.exec()) {
+        qCWarning(ServiceLogger) << "Failed to clear CalDAV retry state:" << query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() == 1;
+}
+
+QStringList DAccountManagerDataBase::dueCalDavAccountRetryIDs(const QDateTime &now) const
+{
+    QStringList accountIDs;
+    if (!now.isValid()) {
+        return accountIDs;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("SELECT accountID FROM caldavAccount WHERE nextRetryAt IS NOT NULL "
+                      "AND nextRetryAt != '' AND nextRetryAt <= ?")) {
+        return accountIDs;
+    }
+    query.addBindValue(now.toUTC().toString(Qt::ISODate));
+    if (!query.exec()) {
+        return accountIDs;
+    }
+    while (query.next()) {
+        accountIDs.append(query.value(0).toString());
+    }
+    return accountIDs;
+}
+
+QStringList DAccountManagerDataBase::dueCalDavOutboxAccountIDs(const QDateTime &now) const
+{
+    QStringList accountIDs;
+    if (!now.isValid()) {
+        return accountIDs;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("SELECT DISTINCT accountID FROM caldavOutbox WHERE failureType = ? "
+                      "AND nextRetryAt IS NOT NULL AND nextRetryAt != '' AND nextRetryAt <= ?")) {
+        return accountIDs;
+    }
+    query.addBindValue(static_cast<int>(DCalDavOutboxItem::NetworkFailure));
+    query.addBindValue(now.toUTC().toString(Qt::ISODate));
+    if (!query.exec()) {
+        return accountIDs;
+    }
+    while (query.next()) {
+        accountIDs.append(query.value(0).toString());
+    }
+    return accountIDs;
+}
+
+QDateTime DAccountManagerDataBase::earliestCalDavRetryAt() const
+{
+    SqliteQuery query(m_database);
+    if (!query.prepare("SELECT MIN(retryAt) FROM ("
+                      "SELECT nextRetryAt AS retryAt FROM caldavAccount "
+                      "WHERE nextRetryAt IS NOT NULL AND nextRetryAt != '' "
+                      "UNION ALL "
+                      "SELECT nextRetryAt AS retryAt FROM caldavOutbox "
+                      "WHERE failureType = ? AND nextRetryAt IS NOT NULL AND nextRetryAt != '')")) {
+        return QDateTime();
+    }
+    query.addBindValue(static_cast<int>(DCalDavOutboxItem::NetworkFailure));
+    if (!query.exec() || !query.next()) {
+        return QDateTime();
+    }
+    return QDateTime::fromString(query.value(0).toString(), Qt::ISODate);
+}
+
+bool DAccountManagerDataBase::updateCalDavCalendarInitialSyncCompleted(
+    const QString &calendarID, bool completed)
+{
+    if (calendarID.isEmpty()) {
+        return false;
+    }
+    SqliteQuery query(m_database);
+    if (!query.prepare(QStringLiteral(
+            "UPDATE caldavCalendar SET initialSyncCompleted = ? WHERE calendarID = ?"))) {
+        return false;
+    }
+    query.addBindValue(completed ? 1 : 0);
+    query.addBindValue(calendarID);
+    return query.exec();
+}
+
+bool DAccountManagerDataBase::updateCalDavSyncStatus(const QString &accountID, int syncStatus,
+                                                     const QDateTime &lastSuccessfulSync,
+                                                     const QString &failureReason,
+                                                     DCalDavErrorCode failureCode)
+{
+    if (accountID.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("UPDATE caldavAccount SET syncStatus = ?, lastSuccessfulSync = ?, failureReason = ?, failureCode = ? "
+                       "WHERE accountID = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV status update:" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(syncStatus);
+    query.addBindValue(lastSuccessfulSync.isValid() ? lastSuccessfulSync.toString(Qt::ISODate) : QString());
+    query.addBindValue(failureReason);
+    query.addBindValue(static_cast<int>(failureCode));
+    query.addBindValue(accountID);
+    if (!query.exec()) {
+        qCWarning(ServiceLogger) << "Failed to update CalDAV sync status:" << query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() == 1;
+}
+
+
+DCalDavEventMappingInfo DAccountManagerDataBase::getCalDavEventMapping(const QString &accountID,
+                                                                       const QString &href)
+{
+    DCalDavEventMappingInfo mapping;
+    if (accountID.isEmpty() || href.isEmpty()) {
+        return mapping;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("SELECT localScheduleID, accountID, calendarID, uid, href, etag, originalIcs "
+                       "FROM caldavEventMapping WHERE accountID = ? AND href = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV event mapping query:" << query.lastError().text();
+        return mapping;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(href);
+    if (query.exec() && query.next()) {
+        mapping.localScheduleID = query.value("localScheduleID").toString();
+        mapping.accountID = query.value("accountID").toString();
+        mapping.calendarID = query.value("calendarID").toString();
+        mapping.uid = query.value("uid").toString();
+        mapping.href = query.value("href").toString();
+        mapping.etag = query.value("etag").toString();
+        mapping.originalIcs = query.value("originalIcs").toString();
+    }
+    return mapping;
+}
+
+DCalDavEventMappingInfo DAccountManagerDataBase::getCalDavEventMappingByLocalScheduleID(
+    const QString &accountID, const QString &localScheduleID)
+{
+    DCalDavEventMappingInfo mapping;
+    if (accountID.isEmpty() || localScheduleID.isEmpty()) {
+        return mapping;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("SELECT localScheduleID, accountID, calendarID, uid, href, etag, originalIcs "
+                       "FROM caldavEventMapping WHERE accountID = ? AND localScheduleID = ?")) {
+        return mapping;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(localScheduleID);
+    if (!query.exec() || !query.next()) {
+        return mapping;
+    }
+    mapping.localScheduleID = query.value("localScheduleID").toString();
+    mapping.accountID = query.value("accountID").toString();
+    mapping.calendarID = query.value("calendarID").toString();
+    mapping.uid = query.value("uid").toString();
+    mapping.href = query.value("href").toString();
+    mapping.etag = query.value("etag").toString();
+    mapping.originalIcs = query.value("originalIcs").toString();
+    return mapping;
+}
+
+DCalDavEventMappingInfo::List DAccountManagerDataBase::getCalDavEventMappingList(const QString &accountID,
+                                                                                       const QString &calendarID)
+{
+    DCalDavEventMappingInfo::List mappings;
+    if (accountID.isEmpty() || calendarID.isEmpty()) {
+        return mappings;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("SELECT localScheduleID, accountID, calendarID, uid, href, etag, originalIcs "
+                       "FROM caldavEventMapping WHERE accountID = ? AND calendarID = ? ORDER BY href")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV event mapping list query:" << query.lastError().text();
+        return mappings;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(calendarID);
+    if (!query.exec()) {
+        qCWarning(ServiceLogger) << "Failed to query CalDAV event mappings:" << query.lastError().text();
+        return mappings;
+    }
+
+    while (query.next()) {
+        DCalDavEventMappingInfo mapping;
+        mapping.localScheduleID = query.value("localScheduleID").toString();
+        mapping.accountID = query.value("accountID").toString();
+        mapping.calendarID = query.value("calendarID").toString();
+        mapping.uid = query.value("uid").toString();
+        mapping.href = query.value("href").toString();
+        mapping.etag = query.value("etag").toString();
+        mapping.originalIcs = query.value("originalIcs").toString();
+        mappings.append(mapping);
+    }
+    return mappings;
+}
+
+bool DAccountManagerDataBase::upsertCalDavEventMapping(const DCalDavEventMappingInfo &mapping)
+{
+    if (mapping.localScheduleID.isEmpty() || mapping.accountID.isEmpty() || mapping.calendarID.isEmpty()
+        || mapping.uid.isEmpty() || mapping.href.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery staleQuery(m_database);
+    if (!staleQuery.prepare("DELETE FROM caldavEventMapping WHERE accountID = ? AND localScheduleID = ? AND href != ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare stale CalDAV event mapping cleanup:" << staleQuery.lastError().text();
+        return false;
+    }
+    staleQuery.addBindValue(mapping.accountID);
+    staleQuery.addBindValue(mapping.localScheduleID);
+    staleQuery.addBindValue(mapping.href);
+    if (!staleQuery.exec()) {
+        qCWarning(ServiceLogger) << "Failed to clean stale CalDAV event mappings:" << staleQuery.lastError().text();
+        return false;
+    }
+
+    SqliteQuery updateQuery(m_database);
+    if (!updateQuery.prepare("UPDATE caldavEventMapping SET localScheduleID = ?, calendarID = ?, uid = ?, "
+                             "etag = ?, originalIcs = ? WHERE accountID = ? AND href = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV event mapping update:" << updateQuery.lastError().text();
+        return false;
+    }
+    updateQuery.addBindValue(mapping.localScheduleID);
+    updateQuery.addBindValue(mapping.calendarID);
+    updateQuery.addBindValue(mapping.uid);
+    updateQuery.addBindValue(mapping.etag);
+    updateQuery.addBindValue(mapping.originalIcs);
+    updateQuery.addBindValue(mapping.accountID);
+    updateQuery.addBindValue(mapping.href);
+    if (!updateQuery.exec()) {
+        qCWarning(ServiceLogger) << "Failed to update CalDAV event mapping:" << updateQuery.lastError().text();
+        return false;
+    }
+    if (updateQuery.numRowsAffected() == 1) {
+        return true;
+    }
+
+    SqliteQuery insertQuery(m_database);
+    if (!insertQuery.prepare("INSERT INTO caldavEventMapping "
+                             "(localScheduleID, accountID, calendarID, uid, href, etag, originalIcs) "
+                             "VALUES (?, ?, ?, ?, ?, ?, ?)")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV event mapping insert:" << insertQuery.lastError().text();
+        return false;
+    }
+    insertQuery.addBindValue(mapping.localScheduleID);
+    insertQuery.addBindValue(mapping.accountID);
+    insertQuery.addBindValue(mapping.calendarID);
+    insertQuery.addBindValue(mapping.uid);
+    insertQuery.addBindValue(mapping.href);
+    insertQuery.addBindValue(mapping.etag);
+    insertQuery.addBindValue(mapping.originalIcs);
+    if (!insertQuery.exec()) {
+        qCWarning(ServiceLogger) << "Failed to insert CalDAV event mapping:" << insertQuery.lastError().text();
+        return false;
+    }
+    return true;
+}
+
+bool DAccountManagerDataBase::deleteCalDavEventMapping(const QString &accountID, const QString &href)
+{
+    if (accountID.isEmpty() || href.isEmpty()) {
+        return false;
+    }
+
+    SqliteQuery query(m_database);
+    if (!query.prepare("DELETE FROM caldavEventMapping WHERE accountID = ? AND href = ?")) {
+        qCWarning(ServiceLogger) << "Failed to prepare CalDAV event mapping deletion:" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(accountID);
+    query.addBindValue(href);
+    if (!query.exec()) {
+        qCWarning(ServiceLogger) << "Failed to delete CalDAV event mapping:" << query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() == 1;
+}
+
 void DAccountManagerDataBase::createDB()
 {
     qCDebug(ServiceLogger) << "Creating account manager database";
@@ -243,6 +1423,118 @@ void DAccountManagerDataBase::createDB()
         res = query.exec(sql_create_accountManager);
         if (!res) {
             qCWarning(ServiceLogger) << "Failed to create accountManager table:" << query.lastError().text();
+        }
+
+        res = query.exec(sql_create_caldavAccount);
+        if (!res) {
+            qCWarning(ServiceLogger) << "Failed to create caldavAccount table:" << query.lastError().text();
+        } else {
+            QSet<QString> calDavAccountColumns;
+            SqliteQuery columnQuery(m_database);
+            if (columnQuery.exec("PRAGMA table_info(caldavAccount)")) {
+                while (columnQuery.next()) {
+                    calDavAccountColumns.insert(columnQuery.value("name").toString());
+                }
+            }
+            if (!calDavAccountColumns.contains(QStringLiteral("retryCount"))
+                && !columnQuery.exec(
+                    "ALTER TABLE caldavAccount ADD COLUMN retryCount INTEGER NOT NULL DEFAULT 0")) {
+                qCWarning(ServiceLogger) << "Failed to migrate CalDAV account retry count column:"
+                                          << columnQuery.lastError().text();
+            }
+            if (!calDavAccountColumns.contains(QStringLiteral("nextRetryAt"))
+                && !columnQuery.exec("ALTER TABLE caldavAccount ADD COLUMN nextRetryAt DATETIME")) {
+                qCWarning(ServiceLogger) << "Failed to migrate CalDAV account retry time column:"
+                                          << columnQuery.lastError().text();
+            }
+            if (!calDavAccountColumns.contains(QStringLiteral("accountColor"))
+                && !columnQuery.exec("ALTER TABLE caldavAccount ADD COLUMN accountColor TEXT")) {
+                qCWarning(ServiceLogger) << "Failed to migrate CalDAV account color column:"
+                                          << columnQuery.lastError().text();
+            }
+            if (!calDavAccountColumns.contains(QStringLiteral("failureCode"))
+                && !columnQuery.exec(
+                    "ALTER TABLE caldavAccount ADD COLUMN failureCode INTEGER NOT NULL DEFAULT 0")) {
+                qCWarning(ServiceLogger) << "Failed to migrate CalDAV account failure code column:"
+                                          << columnQuery.lastError().text();
+            }
+        }
+
+        res = query.exec(sql_create_caldavCalendar);
+        if (!res) {
+            qCWarning(ServiceLogger) << "Failed to create caldavCalendar table:" << query.lastError().text();
+        } else {
+            bool hasScheduleTypeID = false;
+            SqliteQuery columnQuery(m_database);
+            if (columnQuery.exec("PRAGMA table_info(caldavCalendar)")) {
+                while (columnQuery.next()) {
+                    if (columnQuery.value("name").toString() == QStringLiteral("scheduleTypeID")) {
+                        hasScheduleTypeID = true;
+                        break;
+                    }
+                }
+            }
+            if (!hasScheduleTypeID && !columnQuery.exec(
+                    "ALTER TABLE caldavCalendar ADD COLUMN scheduleTypeID TEXT")) {
+                qCWarning(ServiceLogger) << "Failed to migrate caldavCalendar schedule type column:"
+                                          << columnQuery.lastError().text();
+            }
+            bool hasInitialSyncCompleted = false;
+            SqliteQuery initialSyncColumnQuery(m_database);
+            if (initialSyncColumnQuery.exec("PRAGMA table_info(caldavCalendar)")) {
+                while (initialSyncColumnQuery.next()) {
+                    if (initialSyncColumnQuery.value("name").toString()
+                        == QStringLiteral("initialSyncCompleted")) {
+                        hasInitialSyncCompleted = true;
+                        break;
+                    }
+                }
+            }
+            if (!hasInitialSyncCompleted && !initialSyncColumnQuery.exec(
+                    "ALTER TABLE caldavCalendar ADD COLUMN initialSyncCompleted INTEGER NOT NULL DEFAULT 0")) {
+                qCWarning(ServiceLogger) << "Failed to migrate CalDAV initial sync column:"
+                                          << initialSyncColumnQuery.lastError().text();
+            }
+        }
+
+        res = query.exec(sql_create_caldavEventMapping);
+        if (!res) {
+            qCWarning(ServiceLogger) << "Failed to create caldavEventMapping table:" << query.lastError().text();
+        }
+
+        res = query.exec(sql_create_caldavCategoryMapping);
+        if (!res) {
+            qCWarning(ServiceLogger) << "Failed to create caldavCategoryMapping table:" << query.lastError().text();
+        }
+
+        res = query.exec(sql_create_caldavOutbox);
+        if (res) {
+            QSet<QString> outboxColumns;
+            SqliteQuery outboxColumnQuery(m_database);
+            if (outboxColumnQuery.exec("PRAGMA table_info(caldavOutbox)")) {
+                while (outboxColumnQuery.next()) {
+                    outboxColumns.insert(outboxColumnQuery.value("name").toString());
+                }
+            }
+            if (!outboxColumns.contains(QStringLiteral("conflictIcs"))
+                && !outboxColumnQuery.exec("ALTER TABLE caldavOutbox ADD COLUMN conflictIcs TEXT")) {
+                qCWarning(ServiceLogger) << "Failed to migrate CalDAV conflict snapshot column:"
+                                          << outboxColumnQuery.lastError().text();
+            }
+            if (!outboxColumns.contains(QStringLiteral("serverIcs"))
+                && !outboxColumnQuery.exec("ALTER TABLE caldavOutbox ADD COLUMN serverIcs TEXT")) {
+                qCWarning(ServiceLogger) << "Failed to migrate CalDAV server snapshot column:"
+                                          << outboxColumnQuery.lastError().text();
+            }
+        }
+        if (!res) {
+            qCWarning(ServiceLogger) << "Failed to create caldavOutbox table:" << query.lastError().text();
+        }
+
+        res = query.exec(sql_create_caldavAccountDeletionCleanup);
+        if (!res) {
+            qCWarning(ServiceLogger) << "Failed to create CalDAV deletion cleanup table:"
+                                     << query.lastError().text();
         }
 
         //日历通用设置

--- a/src/calendar-service/src/dbmanager/daccountmanagerdatabase.h
+++ b/src/calendar-service/src/dbmanager/daccountmanagerdatabase.h
@@ -9,9 +9,16 @@
 #include "dschedule.h"
 #include "ddatabase.h"
 #include "dcalendargeneralsettings.h"
+#include "dcaldavaccountinfo.h"
+#include "dcaldaverrorcode.h"
+#include "dcaldavcalendarinfo.h"
+#include "dcaldavcategoryinfo.h"
+#include "dcaldaveventmappinginfo.h"
+#include "dcaldavoutboxitem.h"
 
 #include <QObject>
 #include <QSharedPointer>
+#include <QMap>
 
 class DAccountManagerDataBase : public DDataBase
 {
@@ -23,6 +30,8 @@ public:
 
     //初始化数据库数据，只有在创建表的时候才需要
     void initDBData() override;
+    //确保已存在账户库补齐最新表结构，不初始化账户数据。
+    void ensureSchema();
 
     ///////////////帐户
     //获取所有帐户信息
@@ -36,6 +45,64 @@ public:
     bool updateAccountInfo(const DAccount::Ptr &accountInfo);
     //根据帐户id删除对应帐户
     bool deleteAccountInfo(const QString &accountID);
+
+    ///////////////CalDAV 帐户
+    QString getCalDavAccountStatusList();
+    bool getCalDavAccountInfo(const QString &accountID, DCalDavAccountInfo &accountInfo);
+    bool upsertCalDavAccountInfo(const DCalDavAccountInfo &accountInfo);
+    bool deleteCalDavAccountInfo(const QString &accountID);
+    bool deleteCalDavAccountData(const QString &accountID);
+    bool upsertCalDavAccountDeletionCleanup(const QString &accountID, const QString &sourceDbName);
+    QMap<QString, QString> getCalDavAccountDeletionCleanups() const;
+    bool deleteCalDavAccountDeletionCleanup(const QString &accountID);
+    DCalDavCategoryInfo getCalDavCategoryMapping(const QString &accountID,
+                                                  const QString &calendarID,
+                                                  const QString &categoryKey) const;
+    DCalDavCategoryInfo::List getCalDavCategoryMappings(const QString &accountID,
+                                                         const QString &calendarID) const;
+    DCalDavCategoryInfo getCalDavCategoryMappingByScheduleTypeID(
+        const QString &accountID, const QString &scheduleTypeID) const;
+    bool upsertCalDavCategoryMapping(const DCalDavCategoryInfo &mapping);
+    bool deleteCalDavCategoryMappingByScheduleTypeID(const QString &accountID,
+                                                      const QString &scheduleTypeID);
+    bool updateCalDavCredentialReference(const QString &accountID, const QString &credentialRef);
+    DCalDavCalendarInfo::List getCalDavCalendarList(const QString &accountID);
+    DCalDavCalendarInfo getCalDavCalendarByScheduleTypeID(const QString &accountID,
+                                                           const QString &scheduleTypeID);
+    bool upsertCalDavCalendar(const DCalDavCalendarInfo &calendar);
+    bool updateCalDavCalendarSyncToken(const QString &calendarID, const QString &syncToken);
+    bool updateCalDavCalendarInitialSyncCompleted(const QString &calendarID, bool completed);
+    bool updateCalDavSyncStatus(const QString &accountID, int syncStatus,
+                                const QDateTime &lastSuccessfulSync, const QString &failureReason,
+                                DCalDavErrorCode failureCode = DCalDavErrorCode::NoError);
+    bool updateCalDavRetryState(const QString &accountID, int retryCount,
+                                 const QDateTime &nextRetryAt, const QString &failureReason,
+                                 DCalDavErrorCode failureCode = DCalDavErrorCode::NoError);
+    bool clearCalDavRetryState(const QString &accountID);
+    QStringList dueCalDavAccountRetryIDs(const QDateTime &now) const;
+    QStringList dueCalDavOutboxAccountIDs(const QDateTime &now) const;
+    QDateTime earliestCalDavRetryAt() const;
+    DCalDavEventMappingInfo getCalDavEventMapping(const QString &accountID, const QString &href);
+    DCalDavEventMappingInfo getCalDavEventMappingByLocalScheduleID(const QString &accountID,
+                                                                     const QString &localScheduleID);
+    DCalDavEventMappingInfo::List getCalDavEventMappingList(const QString &accountID,
+                                                            const QString &calendarID);
+    bool upsertCalDavEventMapping(const DCalDavEventMappingInfo &mapping);
+    bool deleteCalDavEventMapping(const QString &accountID, const QString &href);
+    DCalDavOutboxItem getCalDavOutboxItem(const QString &accountID,
+                                           const QString &localScheduleID);
+    bool hasCalDavOutboxItems(const QString &accountID) const;
+    DCalDavOutboxItem::List getCalDavConflictItems(const QString &accountID);
+    DCalDavOutboxItem::List getCalDavBlockedOutboxItems(const QString &accountID);
+    DCalDavOutboxItem::List getCalDavRetryScheduledOutboxItems(
+        const QString &accountID, const QDateTime &now) const;
+    DCalDavOutboxItem::List getDueCalDavOutboxItems(const QString &accountID,
+                                                     const QDateTime &now,
+                                                     bool ignoreRetryAt = false);
+    QDateTime earliestCalDavOutboxRetryAt() const;
+    bool upsertCalDavOutboxItem(const DCalDavOutboxItem &item);
+    bool deleteCalDavOutboxItem(const QString &accountID, const QString &localScheduleID);
+    bool deleteCalDavOutboxItemIfCurrent(const DCalDavOutboxItem &item);
 
     ///////////////通用设置
 

--- a/src/calendar-service/src/dbmanager/ddatabase.cpp
+++ b/src/calendar-service/src/dbmanager/ddatabase.cpp
@@ -132,6 +132,89 @@ const QString DDataBase::sql_create_accountManager =
     " expandStatus  integer,               "
     " isDeleted INTEGER not null)";
 
+//CalDAV 账户配置
+const QString DDataBase::sql_create_caldavAccount =
+    " CREATE TABLE if not exists caldavAccount ("
+    " accountID TEXT NOT NULL PRIMARY KEY,"
+    " providerType INTEGER NOT NULL,"
+    " serverUrl TEXT NOT NULL,"
+    " username TEXT NOT NULL,"
+    " credentialRef TEXT,"
+    " accountColor TEXT,"
+    " lastSuccessfulSync DATETIME,"
+    " syncStatus INTEGER NOT NULL DEFAULT 0,"
+    " failureReason TEXT,"
+    " failureCode INTEGER NOT NULL DEFAULT 0,"
+    " retryCount INTEGER NOT NULL DEFAULT 0,"
+    " nextRetryAt DATETIME)";
+
+//CalDAV 日历集合
+const QString DDataBase::sql_create_caldavCalendar =
+    " CREATE TABLE if not exists caldavCalendar ("
+    " calendarID TEXT NOT NULL PRIMARY KEY,"
+    " accountID TEXT NOT NULL,"
+    " href TEXT NOT NULL,"
+    " displayName TEXT,"
+    " color TEXT,"
+    " scheduleTypeID TEXT,"
+    " privileges INTEGER NOT NULL DEFAULT 0,"
+    " syncToken TEXT,"
+    " initialSyncCompleted INTEGER NOT NULL DEFAULT 0,"
+    " enabled INTEGER NOT NULL DEFAULT 1,"
+    " UNIQUE(accountID, href))";
+
+//CalDAV 远端日程映射
+const QString DDataBase::sql_create_caldavEventMapping =
+    " CREATE TABLE if not exists caldavEventMapping ("
+    " localScheduleID TEXT NOT NULL,"
+    " accountID TEXT NOT NULL,"
+    " calendarID TEXT NOT NULL,"
+    " uid TEXT NOT NULL,"
+    " href TEXT NOT NULL,"
+    " etag TEXT,"
+    " originalIcs TEXT,"
+    " PRIMARY KEY(accountID, href))";
+
+//CalDAV 待处理写回操作
+const QString DDataBase::sql_create_caldavCategoryMapping =
+    " CREATE TABLE if not exists caldavCategoryMapping ("
+    " accountID TEXT NOT NULL,"
+    " calendarID TEXT NOT NULL,"
+    " categoryKey TEXT NOT NULL,"
+    " scheduleTypeID TEXT NOT NULL,"
+    " PRIMARY KEY(accountID, calendarID, categoryKey))";
+
+const QString DDataBase::sql_create_caldavOutbox =
+    " CREATE TABLE if not exists caldavOutbox ("
+    " operationID TEXT NOT NULL PRIMARY KEY,"
+    " accountID TEXT NOT NULL,"
+    " localScheduleID TEXT NOT NULL,"
+    " operationType INTEGER NOT NULL,"
+    " baseEtag TEXT,"
+    " conflictIcs TEXT,"
+    " serverIcs TEXT,"
+    " retryCount INTEGER NOT NULL DEFAULT 0,"
+    " nextRetryAt DATETIME,"
+    " failureType INTEGER NOT NULL DEFAULT 0)";
+
+const QString DDataBase::sql_create_caldavRecovery =
+    " CREATE TABLE if not exists caldavRecovery ("
+    " accountID TEXT NOT NULL,"
+    " localScheduleID TEXT NOT NULL,"
+    " operationType INTEGER NOT NULL,"
+    " scheduleIcs TEXT NOT NULL,"
+    " calendarID TEXT,"
+    " href TEXT,"
+    " etag TEXT,"
+    " originalIcs TEXT,"
+    " createdAt TEXT NOT NULL,"
+    " PRIMARY KEY(accountID, localScheduleID))";
+
+const QString DDataBase::sql_create_caldavAccountDeletionCleanup =
+    " CREATE TABLE if not exists caldavAccountDeletionCleanup ("
+    " accountID TEXT NOT NULL PRIMARY KEY,"
+    " sourceDbName TEXT NOT NULL)";
+
 //日历通用设置
 const QString DDataBase::sql_create_calendargeneralsettings =
     " CREATE TABLE  if not exists calendargeneralsettings(     "
@@ -223,10 +306,18 @@ bool DDataBase::dbFileExists()
     return exists;
 }
 
-void DDataBase::removeDB()
+bool DDataBase::removeDB()
 {
-    qCDebug(ServiceLogger) << "Removing database file:" << getDBPath();
-    QFile::remove(getDBPath());
+    const QString databasePath = getDBPath();
+    qCDebug(ServiceLogger) << "Removing database file:" << databasePath;
+    if (databasePath.isEmpty() || !QFile::exists(databasePath)) {
+        return true;
+    }
+    if (QFile::remove(databasePath)) {
+        return true;
+    }
+    qCWarning(ServiceLogger) << "Failed to remove database file:" << databasePath;
+    return false;
 }
 
 void SqliteMutex::lock()
@@ -309,18 +400,26 @@ bool SqliteQuery::exec()
     return f;
 }
 
-void SqliteQuery::transaction()
+bool SqliteQuery::transaction()
 {
     qCDebug(ServiceLogger) << "Starting database transaction";
     getDbMutexRef(_db.databaseName()).transactionLock();
-    _db.transaction();
+    if (!_db.transaction()) {
+        getDbMutexRef(_db.databaseName()).transactionUnlock();
+        return false;
+    }
+    return true;
 }
 
-void SqliteQuery::commit()
+bool SqliteQuery::commit()
 {
     qCDebug(ServiceLogger) << "Committing database transaction";
-    _db.commit();
+    const bool success = _db.commit();
+    if (!success) {
+        _db.rollback();
+    }
     getDbMutexRef(_db.databaseName()).transactionUnlock();
+    return success;
 }
 
 void SqliteQuery::rollback()

--- a/src/calendar-service/src/dbmanager/ddatabase.h
+++ b/src/calendar-service/src/dbmanager/ddatabase.h
@@ -12,6 +12,7 @@
 #include <QVector>
 #include <QMutex>
 #include <QMap>
+#include <QStringList>
 
 //账户数据库的实例
 #define DBAccountManager QSqlDatabase::database(DDataBase::NameAccountManager)
@@ -40,6 +41,19 @@ public:
     static const QString sql_create_remindTask;
     //创建帐户管理表
     static const QString sql_create_accountManager;
+    //CalDAV 账户配置
+    static const QString sql_create_caldavAccount;
+    //CalDAV 日历集合
+    static const QString sql_create_caldavCalendar;
+    //CalDAV 远端日程映射
+    static const QString sql_create_caldavEventMapping;
+    //CalDAV 日程分类与本地类型映射
+    static const QString sql_create_caldavCategoryMapping;
+    //CalDAV 待处理写回操作
+    static const QString sql_create_caldavOutbox;
+    //CalDAV 跨数据库操作恢复记录（保存在账户本地数据库）
+    static const QString sql_create_caldavRecovery;
+    static const QString sql_create_caldavAccountDeletionCleanup;
     //日历通用设置
     static const QString sql_create_calendargeneralsettings;
 
@@ -71,7 +85,7 @@ public:
     bool dbFileExists();
 
     //删除db数据库文件
-    void removeDB();
+    bool removeDB();
 
 protected:
     //创建数据库
@@ -138,12 +152,99 @@ public:
     bool exec(QString sql);
     bool exec();
 
-    void transaction();
-    void commit();
+    bool transaction();
+    bool commit();
     void rollback();
 
 private:
     QSqlDatabase _db;
+};
+
+/**
+ * @brief SqlTransactionLocker coordinates transactions across SQLite connections.
+ *
+ * SQLite commits each connection independently, so this class cannot provide
+ * atomicity across multiple database files. Callers must handle partial commits
+ * when hasPartialCommit() returns true.
+ */
+class SqlTransactionLocker
+{
+public:
+    explicit SqlTransactionLocker(const QStringList &connectionNames)
+    {
+        for (const QString &name : connectionNames) {
+            if (SqliteQuery(name).transaction()) {
+                m_activeConnectionNames.append(name);
+            } else {
+                rollbackActiveTransactions();
+                m_valid = false;
+                return;
+            }
+        }
+    }
+
+    ~SqlTransactionLocker()
+    {
+        if (!m_committed) {
+            rollback();
+        }
+    }
+
+    bool commit()
+    {
+        if (m_committed) {
+            return m_valid;
+        }
+        if (!m_valid) {
+            m_committed = true;
+            return false;
+        }
+
+        while (!m_activeConnectionNames.isEmpty()) {
+            const QString name = m_activeConnectionNames.first();
+            if (!SqliteQuery(name).commit()) {
+                m_activeConnectionNames.removeFirst();
+                m_partialCommit = !m_committedConnectionNames.isEmpty();
+                rollbackActiveTransactions();
+                m_committed = true;
+                return false;
+            }
+            m_activeConnectionNames.removeFirst();
+            m_committedConnectionNames.append(name);
+        }
+        m_committed = true;
+        return true;
+    }
+
+    bool isValid() const { return m_valid; }
+    bool hasPartialCommit() const { return m_partialCommit; }
+    const QStringList &committedConnectionNames() const
+    {
+        return m_committedConnectionNames;
+    }
+
+    void rollback()
+    {
+        if (m_committed) {
+            return;
+        }
+        rollbackActiveTransactions();
+        m_committed = true;
+    }
+
+private:
+    void rollbackActiveTransactions()
+    {
+        while (!m_activeConnectionNames.isEmpty()) {
+            SqliteQuery(m_activeConnectionNames.takeLast()).rollback();
+        }
+    }
+
+    QStringList m_activeConnectionNames;
+    QStringList m_committedConnectionNames;
+    bool m_valid = true;
+    bool m_committed = false;
+    bool m_partialCommit = false;
 };
 
 #endif // DDATABASE_H

--- a/src/calendar-service/src/dbmanager/ddatabasemanagement.cpp
+++ b/src/calendar-service/src/dbmanager/ddatabasemanagement.cpp
@@ -17,6 +17,7 @@
 
 #include <QStandardPaths>
 #include <QDir>
+#include <QFileInfo>
 #include <QDebug>
 #include <QSqlQuery>
 #include <QSqlError>
@@ -39,9 +40,13 @@ DDataBaseManagement::DDataBaseManagement()
     setNewDatabasePath(newDbPath);
     QString newDB(newDatabasePath() + "/" + m_newDatabaseName);
     qCDebug(ServiceLogger) << "New database path:" << newDB;
-    //如果新数据库不存在
-    if (!databaseExists(newDatabasePath())) {
-        qCDebug(ServiceLogger) << "New database does not exist, creating initial setup";
+    // 确保数据库目录存在；不能仅将目录存在视为账户库已经初始化。
+    databaseExists(newDatabasePath());
+    // 账户管理数据库不存在或为空时，创建本地账户及其数据库。
+    // 不能只检查目录，因为删除数据库文件后配置目录仍然存在。
+    const QFileInfo accountManagerFile(newDB);
+    if (!accountManagerFile.isFile() || accountManagerFile.size() == 0) {
+        qCDebug(ServiceLogger) << "Account manager database is missing or empty, creating initial setup";
         QString localAccountDB(newDatabasePath() + "/" + localDBName);
         qCDebug(ServiceLogger) << "Initializing account manager database";
         DAccountManagerDataBase accountManager;

--- a/src/calendar-service/src/unionIDDav/dunioniddav.cpp
+++ b/src/calendar-service/src/unionIDDav/dunioniddav.cpp
@@ -234,7 +234,16 @@ void DUIDSynDataWorker::startUpdate()
 
     if (errCode == 0) {
         qCInfo(ServiceLogger) << "Committing transaction for sync.";
-        transactionLocker.commit();
+        if (!transactionLocker.commit()) {
+            errCode = -1;
+            if (transactionLocker.hasPartialCommit()) {
+                qCWarning(ServiceLogger)
+                    << "Sync transaction partially committed; forcing reconciliation on retry."
+                    << "Committed connections:" << transactionLocker.committedConnectionNames();
+            } else {
+                qCWarning(ServiceLogger) << "Sync transaction commit failed and was rolled back.";
+            }
+        }
     } else {
         qCWarning(ServiceLogger) << "Rolling back transaction for sync. Error code:" << errCode;
         transactionLocker.rollback();

--- a/src/calendar-service/src/unionIDDav/dunioniddav_p.h
+++ b/src/calendar-service/src/unionIDDav/dunioniddav_p.h
@@ -103,45 +103,6 @@ struct SyncAccount {
 };
 
 /**
- * @brief The SqlTransactionLocker class 用于数据库事务
- */
-class SqlTransactionLocker
-{
-public:
-    explicit SqlTransactionLocker(const QStringList &connectionNames)
-        : _connectionNames(connectionNames)
-    {
-        for (auto name : _connectionNames) {
-            SqliteQuery(name).transaction();
-        }
-    }
-    ~SqlTransactionLocker()
-    {
-        if (hasCommited)
-            return;
-
-        for (auto name : _connectionNames)
-            SqliteQuery(name).rollback();
-    }
-    void commit()
-    {
-        hasCommited = true;
-        for (auto name : _connectionNames)
-            SqliteQuery(name).commit();
-    }
-    void rollback()
-    {
-        hasCommited = true;
-        for (auto name : _connectionNames)
-            SqliteQuery(name).rollback();
-    }
-
-private:
-    QStringList _connectionNames;
-    bool hasCommited = false;
-};
-
-/**
  * @brief The DUIDSynDataWorker class 用于多线程上传下载
  */
 class DUIDSynDataWorker : public QObject


### PR DESCRIPTION
Implement CalDAV account, calendar, category, outbox, and recovery storage. Persist schedule deletion state and stable schedule IDs across updates. Move shared transaction locking into the database layer.

增加 CalDAV 账户、日历、分类、Outbox 和恢复数据存储。
保存日程删除状态，并在更新过程中保持稳定的日程 ID。
将共享事务锁统一移动到数据库层。

Log: 增加 CalDAV 数据库持久化能力
PMS: TASK-393989
Influence: 为账户管理、日程同步和删除恢复提供数据库支持

## Summary by Sourcery

Add CalDAV persistence and migration support while improving schedule identity, deletion recovery, and database transaction management.

New Features:
- Add persistent CalDAV storage for accounts, calendars, event mappings, category mappings, outbox operations, recovery records, and account-deletion cleanup state.

Bug Fixes:
- Preserve existing schedule IDs during updates and retain schedule deletion state for synchronization and recovery.

Enhancements:
- Expose CalDAV sync status, retry scheduling, conflict handling, and calendar synchronization state through the database layer.
- Improve database initialization and schema migration for existing CalDAV databases.
- Centralize SQLite transaction coordination and report failed or partially committed multi-database transactions.

Chores:
- Strengthen database file removal and account database initialization handling.