### PR TITLE
feat(sync): add CalDAV synchronization core

### DIFF
--- a/src/calendar-service/src/caldav/dcaldavaccountsync.cpp
+++ b/src/calendar-service/src/caldav/dcaldavaccountsync.cpp
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavaccountsync.h"
+
+#include "daccountdatabase.h"
+#include "daccountmanagerdatabase.h"
+#include "dcaldavaccountstatus.h"
+#include "dcaldaveventreconciler.h"
+#include "dcaldavretrypolicy.h"
+#include "dcaldavsyncstatusmapper.h"
+#include "commondef.h"
+
+DCalDavAccountSync::DCalDavAccountSync(QObject *parent)
+    : QObject(parent)
+    , m_calendarSync()
+    , m_outboxProcessor()
+{
+}
+
+DCalDavAccountSync::~DCalDavAccountSync()
+{
+    cancel(false);
+}
+
+void DCalDavAccountSync::cancel(bool notifyCallback)
+{
+    if (!m_running) {
+        return;
+    }
+    m_outboxProcessor.cancel();
+    m_calendarSync.cancel();
+    m_request.password.clear();
+    Callback callback = m_callback;
+    m_callback = Callback();
+    m_running = false;
+    if (notifyCallback && callback) {
+        m_result.success = false;
+        m_result.errorMessage = QStringLiteral("CalDAV synchronization cancelled.");
+        callback(m_result);
+    }
+}
+
+void DCalDavAccountSync::start(const Request &request, const Callback &callback)
+{
+    if (m_running) {
+        return;
+    }
+
+    m_request = request;
+    m_callback = callback;
+    m_result = Result();
+    m_calendarIndex = 0;
+    m_successfulCalendarCount = 0;
+    m_permissionDeniedCalendarCount = 0;
+    m_lastPermissionDeniedError.clear();
+    m_running = true;
+
+    if (request.accountID.isEmpty() || request.username.isEmpty() || request.localDatabase == nullptr
+        || request.accountManagerDatabase == nullptr) {
+        finish(false, QStringLiteral("CalDAV account sync request is incomplete."));
+        return;
+    }
+
+    DCalDavAccountInfo accountInfo;
+    if (request.accountManagerDatabase->getCalDavAccountInfo(request.accountID, accountInfo)) {
+        m_request.retryCount = accountInfo.retryCount;
+    }
+
+    if (!request.accountManagerDatabase->updateCalDavSyncStatus(
+            request.accountID, DCalDavSyncStatus::Running, QDateTime(), QString())) {
+        finish(false, QStringLiteral("Failed to mark CalDAV account as syncing."));
+        return;
+    }
+    qCDebug(ServiceLogger) << "CalDAV account sync started"
+                             << "account:" << request.accountID
+                             << "calendarCount:" << request.calendars.size();
+    flushOutbox();
+}
+
+void DCalDavAccountSync::flushOutbox()
+{
+    DCalDavOutboxProcessor::Request outboxRequest;
+    outboxRequest.accountID = m_request.accountID;
+    outboxRequest.username = m_request.username;
+    outboxRequest.password = m_request.password;
+    outboxRequest.localDatabase = m_request.localDatabase;
+    outboxRequest.accountManagerDatabase = m_request.accountManagerDatabase;
+    outboxRequest.forceRetry = m_request.forceOutboxRetry;
+    m_outboxProcessor.start(outboxRequest, [this](const DCalDavOutboxProcessor::Result &result) {
+        m_result.failureResponse = result.failureResponse;
+        m_result.failureCode = DCalDavSyncStatusMapper::errorCodeForFailure(m_result.failureResponse);
+        m_result.createFailure = result.createFailure;
+        if (!result.success) {
+            if (result.retryScheduledCount > 0 && result.permanentFailureCount == 0) {
+                m_request.accountManagerDatabase->updateCalDavSyncStatus(
+                    m_request.accountID, DCalDavSyncStatus::RetryScheduled, QDateTime(),
+                    result.errorMessage, m_result.failureCode);
+                finish(false, result.errorMessage);
+            } else {
+                fail(result.errorMessage);
+            }
+            return;
+        }
+        syncNextCalendar();
+    });
+}
+
+void DCalDavAccountSync::syncNextCalendar()
+{
+    if (m_calendarIndex >= m_request.calendars.size()) {
+        if (m_successfulCalendarCount == 0 && m_permissionDeniedCalendarCount > 0) {
+            fail(m_lastPermissionDeniedError);
+            return;
+        }
+        if (!m_request.accountManagerDatabase->clearCalDavRetryState(m_request.accountID)
+            || !m_request.accountManagerDatabase->updateCalDavSyncStatus(
+                m_request.accountID, DCalDavSyncStatus::Succeeded, QDateTime::currentDateTimeUtc(), QString())) {
+            finish(false, QStringLiteral("CalDAV sync succeeded but status update failed."));
+            return;
+        }
+        m_result.failureResponse = DCalDavTransport::Response();
+        finish(true);
+        return;
+    }
+
+    const CalendarRequest &calendar = m_request.calendars.at(m_calendarIndex);
+    qCDebug(ServiceLogger) << "CalDAV calendar sync started"
+                             << "account:" << m_request.accountID
+                             << "calendar:" << calendar.calendar.displayName
+                             << "endpoint:" << DCalDavTransport::urlForLog(QUrl(calendar.calendar.href));
+    DCalDavIncrementalSync::Request syncRequest;
+    syncRequest.calendarUrl = QUrl(calendar.calendar.href);
+    syncRequest.username = m_request.username;
+    syncRequest.password = m_request.password;
+    syncRequest.syncToken = calendar.calendar.syncToken;
+    syncRequest.initialSyncCompleted = calendar.calendar.initialSyncCompleted;
+    const DCalDavEventMappingInfo::List existingMappings =
+        m_request.accountManagerDatabase->getCalDavEventMappingList(
+            m_request.accountID, calendar.calendar.calendarId);
+    syncRequest.existingMappings = existingMappings;
+    m_calendarSync.start(syncRequest, [this, calendar, existingMappings](
+                                        const DCalDavIncrementalSync::Result &syncResult) {
+        if (!syncResult.success) {
+            qCWarning(ServiceLogger) << "CalDAV calendar sync failed"
+                                     << "account:" << m_request.accountID
+                                     << "calendar:" << calendar.calendar.displayName
+                                     << "endpoint:" << DCalDavTransport::urlForLog(QUrl(calendar.calendar.href))
+                                     << "httpStatus:" << syncResult.failureResponse.httpStatus
+                                     << "transportError:" << static_cast<int>(syncResult.failureResponse.error)
+                                     << "errorPresent:" << !syncResult.errorMessage.isEmpty();
+            m_result.failureResponse = syncResult.failureResponse;
+            m_result.failureCode = DCalDavSyncStatusMapper::errorCodeForFailure(m_result.failureResponse);
+            const bool permissionDenied = syncResult.failureResponse.httpStatus == 403
+                || syncResult.failureResponse.error == DCalDavTransport::PermissionDenied;
+            if (permissionDenied) {
+                DCalDavCalendarInfo inaccessibleCalendar = calendar.calendar;
+                inaccessibleCalendar.enabled = false;
+                if (!m_request.accountManagerDatabase->upsertCalDavCalendar(inaccessibleCalendar)) {
+                    fail(QStringLiteral("Failed to disable inaccessible CalDAV calendar."));
+                    return;
+                }
+                ++m_permissionDeniedCalendarCount;
+                m_lastPermissionDeniedError = syncResult.errorMessage;
+                qCWarning(ServiceLogger) << "Skipping inaccessible CalDAV calendar"
+                                         << "account:" << m_request.accountID
+                                         << "calendar:" << calendar.calendar.displayName;
+                ++m_calendarIndex;
+                syncNextCalendar();
+                return;
+            }
+            fail(syncResult.errorMessage);
+            return;
+        }
+
+        qCDebug(ServiceLogger) << "CalDAV calendar sync succeeded"
+                                 << "account:" << m_request.accountID
+                                 << "calendar:" << calendar.calendar.displayName
+                                 << "endpoint:" << DCalDavTransport::urlForLog(QUrl(calendar.calendar.href))
+                                 << "remoteEventCount:" << syncResult.remoteEvents.size();
+
+        DCalDavEventReconciler::ActionList actions;
+        QString errorMessage;
+        if (!DCalDavEventReconciler::buildActions(
+                syncResult.remoteEvents, existingMappings, actions, &errorMessage)) {
+            fail(errorMessage);
+            return;
+        }
+
+        DCalDavEventScheduleApplier::Request applyRequest;
+        applyRequest.accountID = m_request.accountID;
+        applyRequest.calendarID = calendar.calendar.calendarId;
+        applyRequest.scheduleTypeID = calendar.scheduleTypeID;
+        applyRequest.calendarPrivileges = calendar.calendar.privileges;
+        applyRequest.actions = actions;
+        applyRequest.localDatabase = m_request.localDatabase;
+        applyRequest.accountManagerDatabase = m_request.accountManagerDatabase;
+        const DCalDavEventScheduleApplier::Result applyResult = DCalDavEventScheduleApplier::apply(applyRequest);
+        if (!applyResult.success) {
+            fail(applyResult.errorMessage);
+            return;
+        }
+
+        m_result.createdCount += applyResult.createdCount;
+        m_result.updatedCount += applyResult.updatedCount;
+        m_result.deletedCount += applyResult.deletedCount;
+        if (syncResult.usedFullRangeFallback) {
+            ++m_result.fullRangeFallbackCount;
+        }
+
+        if (syncResult.usedFullRangeFallback || !syncResult.syncToken.isEmpty()) {
+            const QString nextToken = syncResult.usedFullRangeFallback ? QString() : syncResult.syncToken;
+            if (!m_request.accountManagerDatabase->updateCalDavCalendarSyncToken(
+                    calendar.calendar.calendarId, nextToken)) {
+                fail(QStringLiteral("Failed to save CalDAV calendar sync token."));
+                return;
+            }
+        }
+        if (!calendar.calendar.initialSyncCompleted
+            && !m_request.accountManagerDatabase->updateCalDavCalendarInitialSyncCompleted(
+                calendar.calendar.calendarId, true)) {
+            fail(QStringLiteral("Failed to save CalDAV initial sync state."));
+            return;
+        }
+
+        ++m_successfulCalendarCount;
+        ++m_calendarIndex;
+        syncNextCalendar();
+    });
+}
+
+void DCalDavAccountSync::fail(const QString &errorMessage)
+{
+    if (m_result.failureResponse.error != DCalDavTransport::NoError) {
+        const DCalDavRetryPolicy::Decision retry = DCalDavRetryPolicy::decide(
+            m_result.failureResponse, m_request.retryCount);
+        if (retry.retry) {
+            m_request.accountManagerDatabase->updateCalDavRetryState(
+                m_request.accountID, m_request.retryCount + 1,
+                QDateTime::currentDateTimeUtc().addSecs(retry.delaySeconds), errorMessage,
+                m_result.failureCode);
+        } else {
+            m_request.accountManagerDatabase->updateCalDavSyncStatus(
+                m_request.accountID, DCalDavSyncStatus::fromErrorCode(m_result.failureCode), QDateTime(), errorMessage,
+                    m_result.failureCode);
+        }
+    } else {
+        m_request.accountManagerDatabase->updateCalDavSyncStatus(
+            m_request.accountID, DCalDavSyncStatus::fromErrorCode(m_result.failureCode), QDateTime(), errorMessage,
+                m_result.failureCode);
+    }
+    finish(false, errorMessage);
+}
+
+void DCalDavAccountSync::finish(bool success, const QString &errorMessage)
+{
+    if (!m_running) {
+        return;
+    }
+
+    m_result.success = success;
+    m_result.errorMessage = errorMessage;
+    m_request.password.clear();
+    m_running = false;
+    if (m_callback) {
+        const Callback callback = m_callback;
+        m_callback = Callback();
+        callback(m_result);
+    }
+}

--- a/src/calendar-service/src/caldav/dcaldavaccountsync.h
+++ b/src/calendar-service/src/caldav/dcaldavaccountsync.h
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVACCOUNTSYNC_H
+#define DCALDAVACCOUNTSYNC_H
+
+#include "dcaldavcalendarinfo.h"
+#include "dcaldaverrorcode.h"
+#include "dcaldavincrementalsync.h"
+#include "dcaldaveventscheduleapplier.h"
+#include "dcaldavoutboxprocessor.h"
+#include "dcaldavvalidationerror.h"
+
+#include <QObject>
+#include <QVector>
+
+#include <functional>
+
+class DAccountDataBase;
+class DAccountManagerDataBase;
+
+class DCalDavAccountSync : public QObject
+{
+    Q_OBJECT
+public:
+    struct CalendarRequest {
+        DCalDavCalendarInfo calendar;
+        QString scheduleTypeID;
+    };
+
+    struct Request {
+        QString accountID;
+        QString username;
+        QString password;
+        QVector<CalendarRequest> calendars;
+        DAccountDataBase *localDatabase = nullptr;
+        DAccountManagerDataBase *accountManagerDatabase = nullptr;
+        bool forceOutboxRetry = false;
+        int retryCount = 0;
+    };
+
+    struct Result {
+        bool success = false;
+        QString errorMessage;
+        DCalDavTransport::Response failureResponse;
+        DCalDavErrorCode failureCode = DCalDavErrorCode::NoError;
+        int createdCount = 0;
+        int updatedCount = 0;
+        int deletedCount = 0;
+        int fullRangeFallbackCount = 0;
+        DCalDavScheduleCreateError::Type createFailure = DCalDavScheduleCreateError::NoError;
+    };
+
+    typedef std::function<void(const Result &)> Callback;
+
+    explicit DCalDavAccountSync(QObject *parent = nullptr);
+    ~DCalDavAccountSync() override;
+
+    /**
+     * @brief Starts the account-wide Outbox flush and incremental calendar sync.
+     * @param request Account credentials, target calendars, and local databases.
+     * @param callback Invoked exactly once when synchronization completes or is cancelled.
+     */
+    void start(const Request &request, const Callback &callback);
+    /**
+     * @brief Cancels pending requests and optionally completes the callback.
+     * @param notifyCallback Whether to report cancellation to the active caller.
+     */
+    void cancel(bool notifyCallback = true);
+
+private:
+    void flushOutbox();
+    void syncNextCalendar();
+    void finish(bool success, const QString &errorMessage = QString());
+    void fail(const QString &errorMessage);
+
+    DCalDavIncrementalSync m_calendarSync;
+    DCalDavOutboxProcessor m_outboxProcessor;
+    Request m_request;
+    Callback m_callback;
+    Result m_result;
+    int m_calendarIndex = 0;
+    int m_successfulCalendarCount = 0;
+    int m_permissionDeniedCalendarCount = 0;
+    QString m_lastPermissionDeniedError;
+    bool m_running = false;
+};
+
+#endif // DCALDAVACCOUNTSYNC_H

--- a/src/calendar-service/src/caldav/dcaldavcolorallocator.cpp
+++ b/src/calendar-service/src/caldav/dcaldavcolorallocator.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavcolorallocator.h"
+
+#include "daccountdatabase.h"
+#include "dscheduletype.h"
+#include "units.h"
+
+#include <QSet>
+
+namespace {
+
+QStringList availableColors(const QSet<QString> &usedColors)
+{
+    QStringList colors;
+    for (const QString &color : GCalDavTypeColors) {
+        if (!usedColors.contains(color.toLower())) {
+            colors.append(color);
+        }
+    }
+    return colors;
+}
+
+QSet<QString> usedAccountColors(DAccountDataBase *database)
+{
+    QSet<QString> usedColors;
+    if (database == nullptr) {
+        return usedColors;
+    }
+
+    const DScheduleType::List types = database->getScheduleTypeList();
+    for (const DScheduleType::Ptr &type : types) {
+        if (!type.isNull() && !type->typePath().isEmpty()) {
+            usedColors.insert(type->getColorCode().trimmed().toLower());
+        }
+    }
+    return usedColors;
+}
+
+} // namespace
+
+QString DCalDavColorAllocator::nextColor(DAccountDataBase *database)
+{
+    const QSet<QString> usedColors = usedAccountColors(database);
+    const QStringList available = availableColors(usedColors);
+    if (!available.isEmpty()) {
+        return available.first();
+    }
+
+    // Keep allocation stable and follow the documented nine-color order.
+    return GCalDavTypeColors.at(usedColors.size() % GCalDavTypeColors.size());
+}

--- a/src/calendar-service/src/caldav/dcaldavcolorallocator.h
+++ b/src/calendar-service/src/caldav/dcaldavcolorallocator.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVCOLORALLOCATOR_H
+#define DCALDAVCOLORALLOCATOR_H
+
+#include <QString>
+
+class DAccountDataBase;
+
+class DCalDavColorAllocator
+{
+public:
+    static QString nextColor(DAccountDataBase *database);
+};
+
+#endif // DCALDAVCOLORALLOCATOR_H

--- a/src/calendar-service/src/caldav/dcaldaveventmapper.cpp
+++ b/src/calendar-service/src/caldav/dcaldaveventmapper.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldaveventmapper.h"
+
+bool DCalDavEventMapper::toSchedule(const DCalDavCalendarQuery::RemoteEvent &remoteEvent,
+                                    DSchedule::Ptr &schedule, QString *errorMessage)
+{
+    if (remoteEvent.uid.isEmpty() || remoteEvent.calendarData.isEmpty()) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("Remote event is missing UID or calendar data.");
+        }
+        return false;
+    }
+
+    DSchedule::Ptr parsed;
+    if (!DSchedule::fromIcsString(parsed, remoteEvent.calendarData)) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("Failed to parse remote calendar data.");
+        }
+        return false;
+    }
+
+    if (parsed->uid() != remoteEvent.uid) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("Remote event UID does not match calendar data.");
+        }
+        return false;
+    }
+
+    schedule = parsed;
+    return true;
+}

--- a/src/calendar-service/src/caldav/dcaldaveventmapper.h
+++ b/src/calendar-service/src/caldav/dcaldaveventmapper.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVEVENTMAPPER_H
+#define DCALDAVEVENTMAPPER_H
+
+#include "dcaldavcalendarquery.h"
+
+#include <dschedule.h>
+
+class DCalDavEventMapper
+{
+public:
+    static bool toSchedule(const DCalDavCalendarQuery::RemoteEvent &remoteEvent,
+                           DSchedule::Ptr &schedule, QString *errorMessage = nullptr);
+};
+
+#endif // DCALDAVEVENTMAPPER_H

--- a/src/calendar-service/src/caldav/dcaldaveventreconciler.cpp
+++ b/src/calendar-service/src/caldav/dcaldaveventreconciler.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldaveventreconciler.h"
+
+#include <QSet>
+
+namespace {
+
+QHash<QString, DCalDavEventMappingInfo> mappingByHref(const DCalDavEventMappingInfo::List &mappings)
+{
+    QHash<QString, DCalDavEventMappingInfo> result;
+    for (const DCalDavEventMappingInfo &mapping : mappings) {
+        if (!mapping.href.isEmpty()) {
+            result.insert(mapping.href, mapping);
+        }
+    }
+    return result;
+}
+
+QHash<QString, DCalDavEventMappingInfo> mappingByUid(const DCalDavEventMappingInfo::List &mappings)
+{
+    QHash<QString, DCalDavEventMappingInfo> result;
+    QSet<QString> duplicateUids;
+    for (const DCalDavEventMappingInfo &mapping : mappings) {
+        if (mapping.uid.isEmpty() || duplicateUids.contains(mapping.uid)) {
+            continue;
+        }
+        if (result.contains(mapping.uid)) {
+            result.remove(mapping.uid);
+            duplicateUids.insert(mapping.uid);
+            continue;
+        }
+        result.insert(mapping.uid, mapping);
+    }
+    return result;
+}
+
+} // namespace
+
+bool DCalDavEventReconciler::buildActions(const DCalDavCalendarQuery::RemoteEventList &remoteEvents,
+                                          const DCalDavEventMappingInfo::List &existingMappings,
+                                          ActionList &actions, QString *errorMessage)
+{
+    QSet<QString> remoteHrefs;
+    const QHash<QString, DCalDavEventMappingInfo> mappings = mappingByHref(existingMappings);
+    const QHash<QString, DCalDavEventMappingInfo> mappingsByRemoteUid = mappingByUid(existingMappings);
+    QSet<QString> matchedMappingHrefs;
+    ActionList parsedActions;
+    for (const DCalDavCalendarQuery::RemoteEvent &remoteEvent : remoteEvents) {
+        if (remoteEvent.href.isEmpty() || remoteHrefs.contains(remoteEvent.href)) {
+            if (errorMessage != nullptr) {
+                *errorMessage = QStringLiteral("Remote event href is empty or duplicated.");
+            }
+            return false;
+        }
+        remoteHrefs.insert(remoteEvent.href);
+
+        auto mapping = mappings.constFind(remoteEvent.href);
+        if (mapping == mappings.constEnd() && !remoteEvent.uid.isEmpty()) {
+            const auto uidMapping = mappingsByRemoteUid.constFind(remoteEvent.uid);
+            if (uidMapping != mappingsByRemoteUid.constEnd()) {
+                mapping = mappings.constFind(uidMapping->href);
+            }
+        }
+        if (remoteEvent.deleted) {
+            if (mapping != mappings.constEnd() && !matchedMappingHrefs.contains(mapping->href)) {
+                parsedActions.append({DeleteAction, remoteEvent, mapping.value()});
+                matchedMappingHrefs.insert(mapping->href);
+            }
+            continue;
+        }
+
+        if (mapping == mappings.constEnd()) {
+            parsedActions.append({CreateAction, remoteEvent, DCalDavEventMappingInfo()});
+        } else {
+            parsedActions.append({UpdateAction, remoteEvent, mapping.value()});
+            matchedMappingHrefs.insert(mapping->href);
+        }
+    }
+
+    actions = parsedActions;
+    return true;
+}

--- a/src/calendar-service/src/caldav/dcaldaveventreconciler.h
+++ b/src/calendar-service/src/caldav/dcaldaveventreconciler.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVEVENTRECONCILER_H
+#define DCALDAVEVENTRECONCILER_H
+
+#include "dcaldavcalendarquery.h"
+#include "dcaldaveventmappinginfo.h"
+
+#include <QHash>
+#include <QString>
+#include <QVector>
+
+class DCalDavEventReconciler
+{
+public:
+    enum ActionType {
+        CreateAction,
+        UpdateAction,
+        DeleteAction,
+    };
+
+    struct Action {
+        ActionType type;
+        DCalDavCalendarQuery::RemoteEvent remoteEvent;
+        DCalDavEventMappingInfo existingMapping;
+    };
+
+    typedef QVector<Action> ActionList;
+
+    /**
+     * @brief Reconciles remote events with persisted mappings into local actions.
+     * @param remoteEvents Events returned by the CalDAV server.
+     * @param existingMappings Locally persisted remote-event mappings.
+     * @param actions Output list of create, update, or delete actions.
+     * @param errorMessage Optional validation or duplicate-event error output.
+     * @return true when all remote events are valid and actions were generated.
+     */
+    static bool buildActions(const DCalDavCalendarQuery::RemoteEventList &remoteEvents,
+                             const DCalDavEventMappingInfo::List &existingMappings,
+                             ActionList &actions, QString *errorMessage = nullptr);
+};
+
+#endif // DCALDAVEVENTRECONCILER_H

--- a/src/calendar-service/src/caldav/dcaldaveventscheduleapplier.cpp
+++ b/src/calendar-service/src/caldav/dcaldaveventscheduleapplier.cpp
@@ -1,0 +1,315 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldaveventscheduleapplier.h"
+
+#include "daccountdatabase.h"
+#include "daccountmanagerdatabase.h"
+#include "dcaldaveventmapper.h"
+#include "dcaldavcategoryinfo.h"
+#include "dcaldavcolorallocator.h"
+#include "dcaldavxmlreader.h"
+#include "ddatabase.h"
+#include "dscheduletype.h"
+#include "units.h"
+
+#include <QDateTime>
+#include <QJsonArray>
+#include <QJsonDocument>
+
+
+namespace {
+
+QStringList normalizedCategories(const DSchedule &schedule)
+{
+    QStringList categories;
+    categories.reserve(schedule.categories().size());
+    for (const QString &category : schedule.categories()) {
+        const QString normalized = category.trimmed();
+        if (!normalized.isEmpty()) {
+            categories.append(normalized);
+        }
+    }
+    return categories;
+}
+
+QString categoryKey(const QStringList &categories)
+{
+    QJsonArray array;
+    for (const QString &category : categories) {
+        array.append(category);
+    }
+    return QString::fromUtf8(QJsonDocument(array).toJson(QJsonDocument::Compact));
+}
+
+QString categoryDisplayName(const QStringList &categories)
+{
+    return categories.join(QStringLiteral(", "));
+}
+
+
+QString scheduleTypeForRemoteEvent(const DCalDavEventScheduleApplier::Request &request,
+                                    const DSchedule::Ptr &schedule,
+                                    QString *errorMessage)
+{
+    const QStringList categories = normalizedCategories(*schedule);
+    const DScheduleType::Privileges privileges = request.calendarPrivileges
+            & DCalDavXmlReader::WritePrivilege
+        ? DScheduleType::Privileges(DScheduleType::Read | DScheduleType::Write | DScheduleType::Delete)
+        : DScheduleType::Read;
+
+    // An event without CATEGORIES belongs to the remote calendar itself. Use
+    // the local type created from that calendar's display name instead of
+    // creating a synthetic "Other" type for every calendar.
+    if (categories.isEmpty() && !request.scheduleTypeID.isEmpty()) {
+        const DScheduleType::Ptr calendarType = request.localDatabase->getScheduleTypeByID(
+            request.scheduleTypeID);
+        if (calendarType.isNull()) {
+            if (errorMessage != nullptr) {
+                *errorMessage = QStringLiteral("Failed to load local CalDAV calendar type.");
+            }
+            return QString();
+        }
+        if (calendarType->privilege() != privileges) {
+            calendarType->setPrivilege(privileges);
+            if (!request.localDatabase->updateScheduleType(calendarType)) {
+                if (errorMessage != nullptr) {
+                    *errorMessage = QStringLiteral("Failed to update CalDAV calendar permissions.");
+                }
+                return QString();
+            }
+        }
+        return request.scheduleTypeID;
+    }
+
+    const QString key = categoryKey(categories);
+    const DCalDavCategoryInfo existing = request.accountManagerDatabase->getCalDavCategoryMapping(
+        request.accountID, request.calendarID, key);
+    if (!existing.scheduleTypeId.isEmpty()) {
+        const DScheduleType::Ptr type = request.localDatabase->getScheduleTypeByID(existing.scheduleTypeId);
+        if (type.isNull()) {
+            if (errorMessage != nullptr) {
+                *errorMessage = QStringLiteral("Failed to load local CalDAV category type.");
+            }
+            return QString();
+        }
+        if (type->privilege() != privileges) {
+            type->setPrivilege(privileges);
+            if (!request.localDatabase->updateScheduleType(type)) {
+                if (errorMessage != nullptr) {
+                    *errorMessage = QStringLiteral("Failed to update CalDAV category permissions.");
+                }
+                return QString();
+            }
+        }
+        return existing.scheduleTypeId;
+    }
+
+    DScheduleType::Ptr type(new DScheduleType(request.accountID));
+    DTypeColor color;
+    color.setColorID(DDataBase::createUuid());
+    color.setColorCode(DCalDavColorAllocator::nextColor(request.localDatabase));
+    color.setPrivilege(DTypeColor::PriSystem);
+    color.setDtCreate(QDateTime::currentDateTime());
+    type->setTypeName(categoryDisplayName(categories));
+    type->setDisplayName(categoryDisplayName(categories));
+    type->setTypePath(request.calendarID);
+    type->setTypeColor(color);
+    type->setDescription(QStringLiteral("CalDAV category"));
+    type->setPrivilege(privileges);
+    type->setShowState(DScheduleType::Show);
+    type->setDtCreate(QDateTime::currentDateTime());
+    type->setDeleted(0);
+    if (!request.localDatabase->addTypeColor(color)
+        || request.localDatabase->createScheduleType(type).isEmpty()) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("Failed to create local CalDAV category type.");
+        }
+        return QString();
+    }
+
+    DCalDavCategoryInfo mapping;
+    mapping.accountId = request.accountID;
+    mapping.calendarId = request.calendarID;
+    mapping.categoryKey = key;
+    mapping.scheduleTypeId = type->typeID();
+    if (!request.accountManagerDatabase->upsertCalDavCategoryMapping(mapping)) {
+        request.localDatabase->deleteScheduleTypeByID(type->typeID(), 1);
+        request.localDatabase->deleteTypeColor(type->typeColor().colorID());
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("Failed to persist local CalDAV category mapping.");
+        }
+        return QString();
+    }
+    return type->typeID();
+}
+
+bool hasRequiredDatabases(const DCalDavEventScheduleApplier::Request &request)
+{
+    return !request.accountID.isEmpty() && !request.calendarID.isEmpty() && request.localDatabase != nullptr
+        && request.accountManagerDatabase != nullptr;
+}
+
+void setError(DCalDavEventScheduleApplier::Result &result, const QString &errorMessage)
+{
+    if (result.errorMessage.isEmpty()) {
+        result.errorMessage = errorMessage;
+    }
+}
+
+} // namespace
+
+DCalDavEventScheduleApplier::Result DCalDavEventScheduleApplier::apply(const Request &request)
+{
+    Result result;
+    if (!hasRequiredDatabases(request)) {
+        result.errorMessage = QStringLiteral("CalDAV schedule apply request is incomplete.");
+        return result;
+    }
+    for (const DCalDavEventReconciler::Action &action : request.actions) {
+        bool applied = false;
+        switch (action.type) {
+        case DCalDavEventReconciler::CreateAction:
+            applied = applyCreate(request, action, result);
+            break;
+        case DCalDavEventReconciler::UpdateAction:
+            applied = applyUpdate(request, action, result);
+            break;
+        case DCalDavEventReconciler::DeleteAction:
+            applied = applyDelete(request, action, result);
+            break;
+        }
+        if (!applied) {
+            return result;
+        }
+    }
+
+    result.success = true;
+    return result;
+}
+
+bool DCalDavEventScheduleApplier::applyCreate(const Request &request,
+                                              const DCalDavEventReconciler::Action &action,
+                                              Result &result)
+{
+    DSchedule::Ptr schedule;
+    if (!DCalDavEventMapper::toSchedule(action.remoteEvent, schedule, &result.errorMessage)) {
+        return false;
+    }
+    const QString scheduleTypeID = scheduleTypeForRemoteEvent(request, schedule, &result.errorMessage);
+    if (scheduleTypeID.isEmpty()) {
+        return false;
+    }
+    schedule->setScheduleTypeID(scheduleTypeID);
+    schedule->setCreated(QDateTime::currentDateTime());
+
+    const QString localScheduleID = request.localDatabase->createSchedule(schedule);
+    if (localScheduleID.isEmpty()) {
+        setError(result, QStringLiteral("Failed to create local CalDAV schedule."));
+        return false;
+    }
+    if (!mapSchedule(request, action, localScheduleID, result)) {
+        request.localDatabase->deleteScheduleByScheduleID(localScheduleID, 1);
+        return false;
+    }
+
+    ++result.createdCount;
+    return true;
+}
+
+bool DCalDavEventScheduleApplier::applyUpdate(const Request &request,
+                                              const DCalDavEventReconciler::Action &action,
+                                              Result &result)
+{
+    if (action.existingMapping.localScheduleID.isEmpty()) {
+        setError(result, QStringLiteral("CalDAV update mapping has no local schedule ID."));
+        return false;
+    }
+
+    DSchedule::Ptr localSchedule = request.localDatabase->getScheduleByScheduleID(
+        action.existingMapping.localScheduleID);
+    if (localSchedule.isNull() || localSchedule->uid().isEmpty()) {
+        setError(result, QStringLiteral("Local schedule for CalDAV update was not found."));
+        return false;
+    }
+
+    DSchedule::Ptr remoteSchedule;
+    if (!DCalDavEventMapper::toSchedule(action.remoteEvent, remoteSchedule, &result.errorMessage)) {
+        return false;
+    }
+    remoteSchedule->setUid(action.existingMapping.localScheduleID);
+    const QString scheduleTypeID = scheduleTypeForRemoteEvent(request, remoteSchedule, &result.errorMessage);
+    if (scheduleTypeID.isEmpty()) {
+        return false;
+    }
+    remoteSchedule->setScheduleTypeID(scheduleTypeID);
+    remoteSchedule->setCreated(localSchedule->created());
+    if (!request.localDatabase->updateSchedule(remoteSchedule)) {
+        setError(result, QStringLiteral("Failed to update local CalDAV schedule."));
+        return false;
+    }
+    if (!mapSchedule(request, action, action.existingMapping.localScheduleID, result)) {
+        if (!request.localDatabase->updateSchedule(localSchedule)) {
+            result.errorMessage.append(QStringLiteral(" Failed to restore the local schedule."));
+        }
+        return false;
+    }
+
+    ++result.updatedCount;
+    return true;
+}
+
+bool DCalDavEventScheduleApplier::applyDelete(const Request &request,
+                                              const DCalDavEventReconciler::Action &action,
+                                              Result &result)
+{
+    const QString localScheduleID = action.existingMapping.localScheduleID;
+    if (localScheduleID.isEmpty()) {
+        setError(result, QStringLiteral("CalDAV delete mapping has no local schedule ID."));
+        return false;
+    }
+    const QString mappingHref = action.existingMapping.href.isEmpty()
+        ? action.remoteEvent.href : action.existingMapping.href;
+    if (!request.accountManagerDatabase->deleteCalDavEventMapping(request.accountID, mappingHref)) {
+        setError(result, QStringLiteral("Failed to delete CalDAV event mapping."));
+        return false;
+    }
+    if (!request.localDatabase->deleteScheduleByScheduleID(localScheduleID)) {
+        if (!request.accountManagerDatabase->upsertCalDavEventMapping(action.existingMapping)) {
+            result.errorMessage = QStringLiteral("Failed to delete local CalDAV schedule and restore its mapping.");
+        } else {
+            setError(result, QStringLiteral("Failed to delete local CalDAV schedule."));
+        }
+        return false;
+    }
+
+    ++result.deletedCount;
+    return true;
+}
+
+bool DCalDavEventScheduleApplier::mapSchedule(const Request &request,
+                                              const DCalDavEventReconciler::Action &action,
+                                              const QString &localScheduleID, Result &result)
+{
+    DCalDavEventMappingInfo mapping;
+    mapping.localScheduleID = localScheduleID;
+    mapping.accountID = request.accountID;
+    mapping.calendarID = request.calendarID;
+    mapping.uid = action.remoteEvent.uid;
+    mapping.href = action.remoteEvent.href;
+    mapping.etag = action.remoteEvent.etag;
+    mapping.originalIcs = action.remoteEvent.calendarData;
+    if (!action.existingMapping.href.isEmpty()
+        && action.existingMapping.href != mapping.href
+        && !request.accountManagerDatabase->deleteCalDavEventMapping(
+            request.accountID, action.existingMapping.href)) {
+        setError(result, QStringLiteral("Failed to remove stale CalDAV event mapping."));
+        return false;
+    }
+    if (!request.accountManagerDatabase->upsertCalDavEventMapping(mapping)) {
+        setError(result, QStringLiteral("Failed to save CalDAV event mapping."));
+        return false;
+    }
+    return true;
+}

--- a/src/calendar-service/src/caldav/dcaldaveventscheduleapplier.h
+++ b/src/calendar-service/src/caldav/dcaldaveventscheduleapplier.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVEVENTSCHEDULEAPPLIER_H
+#define DCALDAVEVENTSCHEDULEAPPLIER_H
+
+#include "dcaldaveventreconciler.h"
+
+#include <QDateTime>
+#include <QString>
+
+class DAccountDataBase;
+class DAccountManagerDataBase;
+
+class DCalDavEventScheduleApplier
+{
+public:
+    struct Request {
+        QString accountID;
+        QString calendarID;
+        QString scheduleTypeID;
+        int calendarPrivileges = 0;
+        DCalDavEventReconciler::ActionList actions;
+        DAccountDataBase *localDatabase = nullptr;
+        DAccountManagerDataBase *accountManagerDatabase = nullptr;
+    };
+
+    struct Result {
+        bool success = false;
+        int createdCount = 0;
+        int updatedCount = 0;
+        int deletedCount = 0;
+        QString errorMessage;
+    };
+
+    /**
+     * @brief Applies reconciled remote-event actions to the local databases.
+     * @param request Databases, calendar metadata, privileges, and actions to apply.
+     * @return Counts of applied operations and an error when an action fails.
+     */
+    static Result apply(const Request &request);
+
+private:
+    static bool applyCreate(const Request &request, const DCalDavEventReconciler::Action &action,
+                            Result &result);
+    static bool applyUpdate(const Request &request, const DCalDavEventReconciler::Action &action,
+                            Result &result);
+    static bool applyDelete(const Request &request, const DCalDavEventReconciler::Action &action,
+                            Result &result);
+    static bool mapSchedule(const Request &request, const DCalDavEventReconciler::Action &action,
+                            const QString &localScheduleID, Result &result);
+};
+
+#endif // DCALDAVEVENTSCHEDULEAPPLIER_H

--- a/src/calendar-service/src/caldav/dcaldavincrementalsync.cpp
+++ b/src/calendar-service/src/caldav/dcaldavincrementalsync.cpp
@@ -1,0 +1,560 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavincrementalsync.h"
+
+#include "dcaldavdiscovery.h"
+#include "dcaldavutils.h"
+#include "commondef.h"
+
+
+namespace {
+
+const QString kNoSyncTokenMarker = QStringLiteral("dde-calendar:no-sync-token");
+
+
+QString uidFromCalendarData(const QString &calendarData)
+{
+    QString logicalLine;
+    const auto uidFromLogicalLine = [](const QString &line) {
+        const int separator = line.indexOf(QLatin1Char(':'));
+        if (separator < 1) {
+            return QString();
+        }
+        const QString propertyName = line.left(separator);
+        if (propertyName.compare(QStringLiteral("UID"), Qt::CaseInsensitive) == 0
+            || propertyName.startsWith(QStringLiteral("UID;"), Qt::CaseInsensitive)) {
+            return line.mid(separator + 1);
+        }
+        return QString();
+    };
+
+    int lineStart = 0;
+    while (lineStart <= calendarData.size()) {
+        int lineEnd = calendarData.indexOf(QLatin1Char('\n'), lineStart);
+        if (lineEnd < 0) {
+            lineEnd = calendarData.size();
+        }
+        int lineLength = lineEnd - lineStart;
+        if (lineLength > 0 && calendarData.at(lineEnd - 1) == QLatin1Char('\r')) {
+            --lineLength;
+        }
+        const QStringView line = QStringView(calendarData).mid(lineStart, lineLength);
+        const bool foldedLine = !line.isEmpty()
+            && (line.at(0) == QLatin1Char(' ') || line.at(0) == QLatin1Char('\t'));
+        if (foldedLine && !logicalLine.isEmpty()) {
+            logicalLine.append(line.mid(1));
+        } else {
+            if (!logicalLine.isEmpty()) {
+                const QString uid = uidFromLogicalLine(logicalLine);
+                if (!uid.isEmpty()) {
+                    return uid;
+                }
+            }
+            logicalLine = line.toString();
+        }
+
+        if (lineEnd == calendarData.size()) {
+            break;
+        }
+        lineStart = lineEnd + 1;
+    }
+
+    return uidFromLogicalLine(logicalLine);
+}
+
+bool isEventResource(const DCalDavCalendarQuery::Resource &resource)
+{
+    if (resource.contentType.contains(QStringLiteral("vevent"), Qt::CaseInsensitive)) {
+        return true;
+    }
+    return resource.contentType.isEmpty()
+        && resource.href.endsWith(QStringLiteral(".ics"), Qt::CaseInsensitive);
+}
+
+bool hasEventComponent(const QString &calendarData)
+{
+    return calendarData.contains(QStringLiteral("BEGIN:VEVENT"), Qt::CaseInsensitive);
+}
+
+bool overlapsInitialSyncRange(const DSchedule::Ptr &schedule, const QDateTime &referenceTime)
+{
+    if (schedule.isNull()) {
+        return false;
+    }
+    const QDateTime rangeStart = referenceTime.addMonths(-1);
+    const QDateTime rangeEnd = referenceTime.addMonths(6);
+    const QDateTime scheduleStart = schedule->dtStart();
+    const QDateTime scheduleEnd = schedule->dtEnd();
+    if (scheduleStart.isValid() && scheduleEnd.isValid()
+        && !(scheduleEnd < rangeStart || scheduleStart > rangeEnd)) {
+        return true;
+    }
+    if (!schedule->recurs() || schedule->recurrence() == nullptr) {
+        return false;
+    }
+
+    qint64 duration = 0;
+    if (scheduleStart.isValid() && scheduleEnd.isValid()) {
+        duration = qMax<qint64>(0, scheduleStart.secsTo(scheduleEnd));
+    }
+    const QList<QDateTime> occurrences = schedule->recurrence()->timesInInterval(
+        rangeStart.addSecs(-duration), rangeEnd);
+    for (const QDateTime &occurrence : occurrences) {
+        if (occurrence.isValid() && occurrence <= rangeEnd
+            && occurrence.addSecs(duration) >= rangeStart) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+DCalDavIncrementalSync::DCalDavIncrementalSync(QObject *parent)
+    : QObject(parent)
+    , m_transport()
+{
+}
+
+void DCalDavIncrementalSync::cancel()
+{
+    if (!m_running) {
+        return;
+    }
+    m_transport.cancel();
+    m_request.password.clear();
+    m_callback = Callback();
+    m_running = false;
+}
+
+void DCalDavIncrementalSync::start(const Request &request, const Callback &callback)
+{
+    if (m_running) {
+        return;
+    }
+
+    m_request = request;
+    m_callback = callback;
+    m_result = Result();
+    m_pendingResources.clear();
+    m_mappingByHref.clear();
+    m_remoteHrefs.clear();
+    m_resourceIndex = 0;
+    m_fallbackAttempted = false;
+    m_resourceListHasEventFilter = false;
+    m_syncCollectionMode = false;
+    m_running = true;
+
+    if (!DCalDavTransport::isSecureUrl(request.calendarUrl) || request.username.isEmpty()) {
+        finish(false, QStringLiteral("Invalid CalDAV calendar URL or username."));
+        return;
+    }
+
+    for (const DCalDavEventMappingInfo &mapping : request.existingMappings) {
+        if (!mapping.href.isEmpty()) {
+            m_mappingByHref.insert(mapping.href, mapping);
+        }
+    }
+
+    // The first sync must use the product-defined range. Some providers return
+    // empty calendar-data for that query, so matching resources are fetched by GET.
+    const bool firstSync = !request.initialSyncCompleted;
+    const bool providerHasNoSyncToken = request.syncToken == kNoSyncTokenMarker;
+    if (firstSync) {
+        sendResourceListRequest(true);
+    } else if (request.syncToken.isEmpty() || providerHasNoSyncToken) {
+        // Some providers, including WeCom, return only resource metadata for an
+        // unbounded REPORT and reject the subsequent event GET. Reuse the
+        // product-defined range query so calendar-data is returned inline.
+        sendResourceListRequest(true);
+    } else {
+        sendRequest(false);
+    }
+}
+
+void DCalDavIncrementalSync::sendResourceListRequest(bool firstSync)
+{
+    m_resourceListHasEventFilter = firstSync;
+    const QDateTime referenceTime = m_request.referenceTime.isValid()
+        ? m_request.referenceTime
+        : QDateTime::currentDateTimeUtc();
+    const DCalDavTransport::Request request = firstSync
+        ? DCalDavCalendarQuery::firstSyncRequest(
+              m_request.calendarUrl, m_request.username, m_request.password, referenceTime)
+        : DCalDavCalendarQuery::resourceListRequest(
+              m_request.calendarUrl, m_request.username, m_request.password);
+    m_transport.send(request, [this](const DCalDavTransport::Response &response) {
+        if (response.error != DCalDavTransport::NoError) {
+            qCWarning(ServiceLogger) << "CalDAV resource list request failed"
+                                     << "endpoint:" << DCalDavTransport::urlForLog(m_request.calendarUrl)
+                                     << "httpStatus:" << response.httpStatus
+                                     << "transportError:" << static_cast<int>(response.error);
+            m_result.failureResponse = response;
+            finish(false, DCalDavUtils::transportErrorText(response));
+            return;
+        }
+
+        DCalDavCalendarQuery::ResourceList resources;
+        QString errorMessage;
+        if (!DCalDavCalendarQuery::parseResourceList(response.body, resources, &errorMessage)) {
+            finish(false, errorMessage);
+            return;
+        }
+
+        const QUrl baseUrl = response.finalUrl.isValid() ? response.finalUrl : m_request.calendarUrl;
+        int collectionResourceCount = 0;
+        int metadataOnlyResourceCount = 0;
+        int pendingResourceCount = 0;
+        for (DCalDavCalendarQuery::Resource resource : resources) {
+            resource.href = DCalDavDiscovery::resolveHref(baseUrl, resource.href).toString();
+            if (resource.href.isEmpty()) {
+                continue;
+            }
+            const QUrl resourceUrl(resource.href);
+            if (resourceUrl == m_request.calendarUrl || resourceUrl.path().endsWith(QLatin1Char('/'))) {
+                ++collectionResourceCount;
+                continue;
+            }
+            if (resource.calendarData.isEmpty()) {
+                ++metadataOnlyResourceCount;
+            }
+            m_remoteHrefs.insert(resource.href);
+            if (!m_resourceListHasEventFilter && !isEventResource(resource)) {
+                continue;
+            }
+            const auto mapping = m_mappingByHref.constFind(resource.href);
+            if (mapping == m_mappingByHref.constEnd() || mapping->etag != resource.etag) {
+                m_pendingResources.append(resource);
+                ++pendingResourceCount;
+            }
+        }
+
+        qCDebug(ServiceLogger) << "CalDAV resource list processed"
+                               << "calendarEndpoint:" << DCalDavTransport::urlForLog(m_request.calendarUrl)
+                               << "responseResourceCount:" << resources.size()
+                               << "collectionResourceCount:" << collectionResourceCount
+                               << "metadataOnlyResourceCount:" << metadataOnlyResourceCount
+                               << "pendingResourceCount:" << pendingResourceCount;
+        fetchNextResource();
+    });
+}
+
+bool DCalDavIncrementalSync::appendResourceCalendarData(
+    const DCalDavCalendarQuery::Resource &resource, const QString &calendarData,
+    QString *errorMessage)
+{
+    DCalDavCalendarQuery::RemoteEvent event;
+    event.href = resource.href;
+    event.etag = resource.etag;
+    event.contentType = resource.contentType;
+    event.calendarData = calendarData;
+    event.uid = uidFromCalendarData(event.calendarData);
+    if (event.calendarData.isEmpty() || !hasEventComponent(event.calendarData)
+        || event.uid.isEmpty()) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("Remote CalDAV resource is missing a valid VEVENT UID.");
+        }
+        return false;
+    }
+
+    DSchedule::Ptr schedule;
+    if (!DCalDavEventMapper::toSchedule(event, schedule, errorMessage)) {
+        return false;
+    }
+    if (m_resourceListHasEventFilter) {
+        const QDateTime referenceTime = m_request.referenceTime.isValid()
+            ? m_request.referenceTime
+            : QDateTime::currentDateTimeUtc();
+        if (!overlapsInitialSyncRange(schedule, referenceTime)) {
+            return true;
+        }
+    }
+    m_result.remoteEvents.append(event);
+    m_result.schedules.append(schedule);
+    return true;
+}
+
+void DCalDavIncrementalSync::fetchNextResource()
+{
+    if (m_resourceIndex >= m_pendingResources.size()) {
+        if (!m_resourceListHasEventFilter && !m_syncCollectionMode) {
+            appendDeletedResources();
+        }
+        if (m_result.syncToken.isEmpty()) {
+            m_result.syncToken = kNoSyncTokenMarker;
+        }
+        finish(true);
+        return;
+    }
+
+    constexpr int kMultiGetBatchSize = 50;
+    DCalDavCalendarQuery::ResourceList resourcesForMultiGet;
+    while (m_resourceIndex < m_pendingResources.size()
+           && resourcesForMultiGet.size() < kMultiGetBatchSize) {
+        const DCalDavCalendarQuery::Resource resource = m_pendingResources.at(m_resourceIndex++);
+        if (resource.calendarData.isEmpty()) {
+            resourcesForMultiGet.append(resource);
+            continue;
+        }
+
+        QString errorMessage;
+        if (!appendResourceCalendarData(resource, resource.calendarData, &errorMessage)) {
+            finish(false, errorMessage);
+            return;
+        }
+    }
+
+    if (resourcesForMultiGet.isEmpty()) {
+        fetchNextResource();
+        return;
+    }
+    requestCalendarDataBatch(resourcesForMultiGet);
+}
+
+void DCalDavIncrementalSync::requestCalendarDataBatch(
+    const DCalDavCalendarQuery::ResourceList &resources)
+{
+    QStringList resourceHrefs;
+    resourceHrefs.reserve(resources.size());
+    for (const DCalDavCalendarQuery::Resource &resource : resources) {
+        resourceHrefs.append(resource.href);
+    }
+
+    qCDebug(ServiceLogger) << "CalDAV fetching event data with calendar-multiget"
+                             << "calendarEndpoint:" << DCalDavTransport::urlForLog(m_request.calendarUrl)
+                             << "resourceCount:" << resources.size();
+    const DCalDavTransport::Request request = DCalDavCalendarQuery::resourceMultiGetRequest(
+        m_request.calendarUrl, m_request.username, m_request.password, resourceHrefs);
+    m_transport.send(request, [this, resources](const DCalDavTransport::Response &response) {
+        if (response.error != DCalDavTransport::NoError) {
+            qCWarning(ServiceLogger) << "CalDAV calendar-multiget request failed"
+                                     << "calendarEndpoint:" << DCalDavTransport::urlForLog(m_request.calendarUrl)
+                                     << "resourceCount:" << resources.size()
+                                     << "httpStatus:" << response.httpStatus
+                                     << "transportError:" << static_cast<int>(response.error);
+            if (response.httpStatus == 403 || response.httpStatus == 405 || response.httpStatus == 501) {
+                qCWarning(ServiceLogger) << "CalDAV calendar-multiget is unavailable; using GET fallback"
+                                         << "calendarEndpoint:" << DCalDavTransport::urlForLog(m_request.calendarUrl)
+                                         << "resourceCount:" << resources.size()
+                                         << "httpStatus:" << response.httpStatus;
+                m_result.failureResponse = DCalDavTransport::Response();
+                fetchResourceByGet(resources, 0);
+                return;
+            }
+            m_result.failureResponse = response;
+            finish(false, DCalDavUtils::transportErrorText(response));
+            return;
+        }
+
+        DCalDavCalendarQuery::RemoteEventList events;
+        QString errorMessage;
+        if (!DCalDavCalendarQuery::parseResponse(response.body, events, &errorMessage)) {
+            finish(false, errorMessage);
+            return;
+        }
+
+        const QUrl baseUrl = response.finalUrl.isValid() ? response.finalUrl : m_request.calendarUrl;
+        QHash<QString, DCalDavCalendarQuery::RemoteEvent> eventByHref;
+        for (DCalDavCalendarQuery::RemoteEvent event : events) {
+            event.href = DCalDavDiscovery::resolveHref(baseUrl, event.href).toString();
+            if (!event.href.isEmpty()) {
+                eventByHref.insert(event.href, event);
+            }
+        }
+
+        DCalDavCalendarQuery::ResourceList fallbackResources;
+        int fetchedCount = 0;
+        for (DCalDavCalendarQuery::Resource resource : resources) {
+            const auto eventIt = eventByHref.constFind(resource.href);
+            if (eventIt == eventByHref.constEnd() || eventIt->deleted
+                || eventIt->calendarData.isEmpty()) {
+                fallbackResources.append(resource);
+                continue;
+            }
+
+            const DCalDavCalendarQuery::RemoteEvent &event = eventIt.value();
+            if (!event.etag.isEmpty()) {
+                resource.etag = event.etag;
+            }
+            if (!event.contentType.isEmpty()) {
+                resource.contentType = event.contentType;
+            }
+            if (!appendResourceCalendarData(resource, event.calendarData, &errorMessage)) {
+                finish(false, errorMessage);
+                return;
+            }
+            ++fetchedCount;
+        }
+
+        qCDebug(ServiceLogger) << "CalDAV calendar-multiget response processed"
+                               << "calendarEndpoint:" << DCalDavTransport::urlForLog(m_request.calendarUrl)
+                               << "requestedResourceCount:" << resources.size()
+                               << "calendarDataCount:" << fetchedCount
+                               << "getFallbackCount:" << fallbackResources.size();
+        if (!fallbackResources.isEmpty()) {
+            fetchResourceByGet(fallbackResources, 0);
+            return;
+        }
+        fetchNextResource();
+    });
+}
+
+void DCalDavIncrementalSync::fetchResourceByGet(
+    const DCalDavCalendarQuery::ResourceList &resources, int index)
+{
+    if (index >= resources.size()) {
+        fetchNextResource();
+        return;
+    }
+
+    const DCalDavCalendarQuery::Resource resource = resources.at(index);
+    qCDebug(ServiceLogger) << "CalDAV event requires GET fallback after calendar-multiget"
+                             << "calendarEndpoint:" << DCalDavTransport::urlForLog(m_request.calendarUrl)
+                             << "resourcePresent:" << !resource.href.isEmpty()
+                             << "contentType:" << resource.contentType
+                             << "etagPresent:" << !resource.etag.isEmpty();
+    const DCalDavTransport::Request request = DCalDavCalendarQuery::resourceGetRequest(
+        QUrl(resource.href), m_request.username, m_request.password);
+    m_transport.send(request, [this, resources, index, resource](const DCalDavTransport::Response &response) {
+        if (response.error != DCalDavTransport::NoError) {
+            qCWarning(ServiceLogger) << "CalDAV event GET fallback failed"
+                                     << "calendarEndpoint:" << DCalDavTransport::urlForLog(m_request.calendarUrl)
+                                     << "resourcePresent:" << !resource.href.isEmpty()
+                                     << "httpStatus:" << response.httpStatus
+                                     << "transportError:" << static_cast<int>(response.error);
+            m_result.failureResponse = response;
+            finish(false, DCalDavUtils::transportErrorText(response));
+            return;
+        }
+
+        QString errorMessage;
+        if (!appendResourceCalendarData(resource, QString::fromUtf8(response.body), &errorMessage)) {
+            finish(false, errorMessage);
+            return;
+        }
+        fetchResourceByGet(resources, index + 1);
+    });
+}
+
+void DCalDavIncrementalSync::appendDeletedResources()
+{
+    for (auto it = m_mappingByHref.constBegin(); it != m_mappingByHref.constEnd(); ++it) {
+        if (m_remoteHrefs.contains(it.key())) {
+            continue;
+        }
+        DCalDavCalendarQuery::RemoteEvent event;
+        event.href = it.key();
+        event.uid = it->uid;
+        event.deleted = true;
+        m_result.remoteEvents.append(event);
+    }
+}
+
+void DCalDavIncrementalSync::sendRequest(bool fullRange)
+{
+    DCalDavTransport::Request request;
+    if (fullRange) {
+        const QDateTime referenceTime = m_request.referenceTime.isValid()
+            ? m_request.referenceTime
+            : QDateTime::currentDateTimeUtc();
+        request = DCalDavCalendarQuery::firstSyncRequest(
+            m_request.calendarUrl, m_request.username, m_request.password, referenceTime);
+    } else {
+        request = DCalDavCalendarQuery::incrementalSyncRequest(
+            m_request.calendarUrl, m_request.username, m_request.password, m_request.syncToken);
+    }
+
+    m_transport.send(request, [this, fullRange](const DCalDavTransport::Response &response) {
+        if (response.error != DCalDavTransport::NoError) {
+            if (!fullRange && shouldFallbackToFullRange(response)) {
+                m_fallbackAttempted = true;
+                m_result.usedFullRangeFallback = true;
+                sendResourceListRequest(false);
+            } else {
+                m_result.failureResponse = response;
+                finish(false, DCalDavUtils::transportErrorText(response));
+            }
+            return;
+        }
+
+        if (!fullRange && response.body.contains("valid-sync-token")) {
+            m_fallbackAttempted = true;
+            m_result.usedFullRangeFallback = true;
+            sendResourceListRequest(false);
+            return;
+        }
+
+        DCalDavCalendarQuery::RemoteEventList events;
+        QString syncToken;
+        QString errorMessage;
+        if (!DCalDavCalendarQuery::parseResponseWithSyncToken(
+                response.body, events, &syncToken, &errorMessage)) {
+            finish(false, errorMessage);
+            return;
+        }
+
+        const QUrl baseUrl = response.finalUrl.isValid() ? response.finalUrl : m_request.calendarUrl;
+        m_syncCollectionMode = true;
+        m_result.syncToken = syncToken;
+        for (DCalDavCalendarQuery::RemoteEvent event : events) {
+            event.href = DCalDavDiscovery::resolveHref(baseUrl, event.href).toString();
+            if (event.href.isEmpty()) {
+                continue;
+            }
+            if (event.deleted) {
+                m_result.remoteEvents.append(event);
+                continue;
+            }
+            if (event.calendarData.isEmpty()) {
+                DCalDavCalendarQuery::Resource resource;
+                resource.href = event.href;
+                resource.etag = event.etag;
+                resource.contentType = event.contentType;
+                m_pendingResources.append(resource);
+                continue;
+            }
+            if (!hasEventComponent(event.calendarData)) {
+                continue;
+            }
+            event.uid = uidFromCalendarData(event.calendarData);
+            DSchedule::Ptr schedule;
+            if (!DCalDavEventMapper::toSchedule(event, schedule, &errorMessage)) {
+                finish(false, errorMessage);
+                return;
+            }
+            m_result.remoteEvents.append(event);
+            m_result.schedules.append(schedule);
+        }
+        fetchNextResource();
+    });
+}
+
+void DCalDavIncrementalSync::finish(bool success, const QString &errorMessage)
+{
+    if (!m_running) {
+        return;
+    }
+
+    m_result.success = success;
+    m_result.errorMessage = errorMessage;
+    m_request.password.clear();
+    m_running = false;
+    if (m_callback) {
+        const Callback callback = m_callback;
+        m_callback = Callback();
+        callback(m_result);
+    }
+}
+
+bool DCalDavIncrementalSync::shouldFallbackToFullRange(const DCalDavTransport::Response &response) const
+{
+    if (m_fallbackAttempted) {
+        return false;
+    }
+    if (response.httpStatus == 409) {
+        return true;
+    }
+    return response.httpStatus == 403 && response.body.contains("valid-sync-token");
+}

--- a/src/calendar-service/src/caldav/dcaldavincrementalsync.h
+++ b/src/calendar-service/src/caldav/dcaldavincrementalsync.h
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVINCREMENTALSYNC_H
+#define DCALDAVINCREMENTALSYNC_H
+
+#include "dcaldavcalendarquery.h"
+#include "dcaldaveventmappinginfo.h"
+#include "dcaldaveventmapper.h"
+
+#include <QObject>
+#include <QDateTime>
+#include <QHash>
+#include <QSet>
+#include <QUrl>
+
+#include <functional>
+
+class DCalDavIncrementalSync : public QObject
+{
+    Q_OBJECT
+public:
+    struct Request {
+        QUrl calendarUrl;
+        QString username;
+        QString password;
+        QString syncToken;
+        QDateTime referenceTime;
+        bool initialSyncCompleted = false;
+        DCalDavEventMappingInfo::List existingMappings;
+    };
+
+    struct Result {
+        bool success = false;
+        bool usedFullRangeFallback = false;
+        QString errorMessage;
+        QString syncToken;
+        DCalDavTransport::Response failureResponse;
+        DCalDavCalendarQuery::RemoteEventList remoteEvents;
+        DSchedule::List schedules;
+    };
+
+    typedef std::function<void(const Result &)> Callback;
+
+    explicit DCalDavIncrementalSync(QObject *parent = nullptr);
+
+    /**
+     * @brief Fetches and reconciles one remote CalDAV calendar incrementally.
+     * @param request Calendar endpoint, credentials, and persisted sync token.
+     * @param callback Invoked exactly once with remote changes or a failure.
+     */
+    void start(const Request &request, const Callback &callback);
+    void cancel();
+
+private:
+    void sendRequest(bool fullRange);
+    void sendResourceListRequest(bool firstSync);
+    void fetchNextResource();
+    void requestCalendarDataBatch(const DCalDavCalendarQuery::ResourceList &resources);
+    void fetchResourceByGet(const DCalDavCalendarQuery::ResourceList &resources, int index);
+    bool appendResourceCalendarData(const DCalDavCalendarQuery::Resource &resource,
+                                    const QString &calendarData, QString *errorMessage);
+    void appendDeletedResources();
+    void finish(bool success, const QString &errorMessage = QString());
+    bool shouldFallbackToFullRange(const DCalDavTransport::Response &response) const;
+
+    DCalDavTransport m_transport;
+    Request m_request;
+    Callback m_callback;
+    Result m_result;
+    DCalDavCalendarQuery::ResourceList m_pendingResources;
+    QHash<QString, DCalDavEventMappingInfo> m_mappingByHref;
+    QSet<QString> m_remoteHrefs;
+    int m_resourceIndex = 0;
+    bool m_running = false;
+    bool m_fallbackAttempted = false;
+    bool m_resourceListHasEventFilter = false;
+    bool m_syncCollectionMode = false;
+};
+
+#endif // DCALDAVINCREMENTALSYNC_H

--- a/src/calendar-service/src/caldav/dcaldavoutboxenqueuer.cpp
+++ b/src/calendar-service/src/caldav/dcaldavoutboxenqueuer.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavoutboxenqueuer.h"
+
+#include "daccountmanagerdatabase.h"
+#include "dcaldavprofile.h"
+#include "dcaldavxmlreader.h"
+#include "ddatabase.h"
+#include "dschedule.h"
+
+namespace {
+
+bool supportsWrite(DAccountManagerDataBase *database, const QString &accountID,
+                   const QString &scheduleTypeID, DCalDavEventMappingInfo &mapping)
+{
+    DCalDavAccountInfo accountInfo;
+    if (!database->getCalDavAccountInfo(accountID, accountInfo)
+        || !DCalDavProviderProfile::forProvider(
+               static_cast<DCalDavProviderProfile::ProviderType>(accountInfo.providerType)).supportsWrite) {
+        return false;
+    }
+
+    mapping = database->getCalDavEventMappingByLocalScheduleID(accountID, mapping.localScheduleID);
+    DCalDavCalendarInfo calendar;
+    if (!mapping.calendarID.isEmpty()) {
+        const DCalDavCalendarInfo::List calendars = database->getCalDavCalendarList(accountID);
+        for (const DCalDavCalendarInfo &candidate : calendars) {
+            if (candidate.enabled && candidate.calendarId == mapping.calendarID) {
+                calendar = candidate;
+                break;
+            }
+        }
+    } else {
+        calendar = database->getCalDavCalendarByScheduleTypeID(accountID, scheduleTypeID);
+        if (calendar.calendarId.isEmpty()) {
+            const DCalDavCategoryInfo category =
+                database->getCalDavCategoryMappingByScheduleTypeID(accountID, scheduleTypeID);
+            if (!category.calendarId.isEmpty()) {
+                const DCalDavCalendarInfo::List calendars = database->getCalDavCalendarList(accountID);
+                for (const DCalDavCalendarInfo &candidate : calendars) {
+                    if (candidate.enabled && candidate.calendarId == category.calendarId) {
+                        calendar = candidate;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    return !calendar.calendarId.isEmpty()
+        && (calendar.privileges & DCalDavXmlReader::WritePrivilege);
+}
+
+DCalDavOutboxItem::OperationType operationFor(DCalDavOutboxItem::OperationType existing,
+                                              DCalDavOutboxEnqueuer::ChangeType change,
+                                              bool hasRemoteMapping)
+{
+    if (existing == DCalDavOutboxItem::CreateOperation) {
+        // Once a remote mapping exists, a local edit must update the resource
+        // instead of replaying an If-None-Match create.
+        if (change == DCalDavOutboxEnqueuer::ModifyChange && hasRemoteMapping) {
+            return DCalDavOutboxItem::ModifyOperation;
+        }
+        return DCalDavOutboxItem::CreateOperation;
+    }
+    if (change == DCalDavOutboxEnqueuer::DeleteChange) {
+        return DCalDavOutboxItem::DeleteOperation;
+    }
+    if (existing == DCalDavOutboxItem::DeleteOperation) {
+        return hasRemoteMapping ? DCalDavOutboxItem::ModifyOperation
+                                : DCalDavOutboxItem::CreateOperation;
+    }
+    return DCalDavOutboxItem::ModifyOperation;
+}
+
+} // namespace
+
+bool DCalDavOutboxEnqueuer::enqueue(DAccountManagerDataBase *database, const QString &accountID,
+                                    const DSchedule::Ptr &schedule, ChangeType change)
+{
+    if (database == nullptr || schedule.isNull() || accountID.isEmpty() || schedule->uid().isEmpty()) {
+        return false;
+    }
+
+    DCalDavEventMappingInfo mapping;
+    mapping.localScheduleID = schedule->uid();
+    // A delete must remain queued even when discovery temporarily marks the
+    // collection disabled or no longer exposes its current permissions. The
+    // persisted mapping is enough to address the remote resource; the
+    // processor will retry the DELETE until the server confirms it.
+    if (change == DeleteChange) {
+        DCalDavAccountInfo accountInfo;
+        if (!database->getCalDavAccountInfo(accountID, accountInfo)
+            || !DCalDavProviderProfile::forProvider(
+                   static_cast<DCalDavProviderProfile::ProviderType>(accountInfo.providerType)).supportsWrite) {
+            return false;
+        }
+        mapping = database->getCalDavEventMappingByLocalScheduleID(accountID, schedule->uid());
+    } else if (!supportsWrite(database, accountID, schedule->scheduleTypeID(), mapping)) {
+        return false;
+    }
+
+    DCalDavOutboxItem current = database->getCalDavOutboxItem(accountID, schedule->uid());
+    if (change == DeleteChange && mapping.href.isEmpty()
+        && (current.operationID.isEmpty() || current.operationType != DCalDavOutboxItem::CreateOperation)) {
+        // Do not persist a DELETE that cannot be addressed remotely. A caller
+        // can roll back its local deletion and report the inconsistent mapping.
+        return false;
+    }
+    if (!current.operationID.isEmpty() && current.operationType == DCalDavOutboxItem::CreateOperation
+        && change == DeleteChange) {
+        return database->deleteCalDavOutboxItem(accountID, schedule->uid());
+    }
+
+    DCalDavOutboxItem item = current;
+    if (item.operationID.isEmpty()) {
+        item.operationID = DDataBase::createUuid();
+        item.accountID = accountID;
+        item.localScheduleID = schedule->uid();
+        item.baseEtag = mapping.etag;
+        item.operationType = change == DeleteChange ? DCalDavOutboxItem::DeleteOperation
+            : (change == CreateChange || mapping.href.isEmpty()
+               ? DCalDavOutboxItem::CreateOperation
+               : DCalDavOutboxItem::ModifyOperation);
+    } else {
+        item.operationType = operationFor(item.operationType, change, !mapping.href.isEmpty());
+        if (item.baseEtag.isEmpty()) {
+            item.baseEtag = mapping.etag;
+        }
+        item.retryCount = 0;
+        item.nextRetryAt = QDateTime();
+        item.failureType = DCalDavOutboxItem::NoFailure;
+    }
+    return database->upsertCalDavOutboxItem(item);
+}

--- a/src/calendar-service/src/caldav/dcaldavoutboxenqueuer.h
+++ b/src/calendar-service/src/caldav/dcaldavoutboxenqueuer.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVOUTBOXENQUEUER_H
+#define DCALDAVOUTBOXENQUEUER_H
+
+#include "dschedule.h"
+
+#include <QString>
+
+class DAccountManagerDataBase;
+
+class DCalDavOutboxEnqueuer
+{
+public:
+    enum ChangeType {
+        CreateChange,
+        ModifyChange,
+        DeleteChange,
+    };
+
+    static bool enqueue(DAccountManagerDataBase *database, const QString &accountID,
+                        const DSchedule::Ptr &schedule, ChangeType change);
+};
+
+#endif // DCALDAVOUTBOXENQUEUER_H

--- a/src/calendar-service/src/caldav/dcaldavoutboxprocessor.cpp
+++ b/src/calendar-service/src/caldav/dcaldavoutboxprocessor.cpp
@@ -1,0 +1,699 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavoutboxprocessor.h"
+
+#include "daccountdatabase.h"
+#include "daccountmanagerdatabase.h"
+#include "dcaldavprofile.h"
+#include "dcaldavretrypolicy.h"
+#include "dcaldavutils.h"
+#include "dcaldavxmlreader.h"
+#include "dschedule.h"
+
+
+#include <QDateTime>
+
+#include <algorithm>
+#include <QUrl>
+#include <QXmlStreamReader>
+#include <QRegularExpression>
+
+namespace {
+
+bool isSuccessful(int httpStatus)
+{
+    return httpStatus >= 200 && httpStatus < 300;
+}
+
+QString responseError(const DCalDavOutboxItem &item, const DCalDavTransport::Response &response)
+{
+    QString operation;
+    switch (item.operationType) {
+    case DCalDavOutboxItem::CreateOperation:
+        operation = QStringLiteral("create");
+        break;
+    case DCalDavOutboxItem::ModifyOperation:
+        operation = QStringLiteral("modify");
+        break;
+    case DCalDavOutboxItem::DeleteOperation:
+        operation = QStringLiteral("delete");
+        break;
+    }
+    return QStringLiteral("CalDAV %1 failed (HTTP %2, error %3).")
+        .arg(operation)
+        .arg(response.httpStatus)
+        .arg(static_cast<int>(response.error));
+}
+
+DCalDavCalendarInfo calendarFor(const DCalDavOutboxItem &item, const DSchedule::Ptr &schedule,
+                                DAccountManagerDataBase *database)
+{
+    const DCalDavEventMappingInfo mapping = database->getCalDavEventMappingByLocalScheduleID(
+        item.accountID, item.localScheduleID);
+    if (!mapping.calendarID.isEmpty()) {
+        const DCalDavCalendarInfo::List calendars = database->getCalDavCalendarList(item.accountID);
+        for (const DCalDavCalendarInfo &calendar : calendars) {
+            if (calendar.enabled && calendar.calendarId == mapping.calendarID) {
+                return calendar;
+            }
+        }
+        // A persisted event mapping must never silently move to a different
+        // collection just because its original collection is unavailable.
+        return DCalDavCalendarInfo();
+    }
+    return schedule.isNull() ? DCalDavCalendarInfo()
+                             : database->getCalDavCalendarByScheduleTypeID(
+                                   item.accountID, schedule->scheduleTypeID());
+}
+
+
+QString parseEtag(const QByteArray &xml)
+{
+    QXmlStreamReader reader(xml);
+    while (!reader.atEnd()) {
+        reader.readNext();
+        if (reader.isStartElement() && reader.name() == QStringLiteral("getetag")) {
+            return reader.readElementText(QXmlStreamReader::SkipChildElements);
+        }
+    }
+    return QString();
+}
+
+QString icsForRemoteWrite(const DSchedule::Ptr &schedule,
+                          const DCalDavEventMappingInfo &mapping)
+{
+    QString localIcs = DSchedule::toIcsString(schedule);
+    if (mapping.originalIcs.isEmpty()) {
+        return localIcs;
+    }
+
+    const QRegularExpression eventExpression(
+        QStringLiteral("BEGIN:VEVENT\\r?\\n.*?END:VEVENT"),
+        QRegularExpression::DotMatchesEverythingOption | QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpression uidExpression(
+        QStringLiteral("(?:^|\\r?\\n)UID:([^\\r\\n]+)"),
+        QRegularExpression::CaseInsensitiveOption);
+    QStringList detachedEvents;
+    auto match = eventExpression.globalMatch(mapping.originalIcs);
+    while (match.hasNext()) {
+        const QString event = match.next().captured(0);
+        if (!event.contains(QStringLiteral("RECURRENCE-ID:"), Qt::CaseInsensitive)) {
+            continue;
+        }
+        const QRegularExpressionMatch uidMatch = uidExpression.match(event);
+        if (uidMatch.hasMatch() && uidMatch.captured(1).trimmed() == schedule->uid()) {
+            detachedEvents.append(event);
+        }
+    }
+    if (detachedEvents.isEmpty()) {
+        return localIcs;
+    }
+
+    const int calendarEnd = localIcs.lastIndexOf(QStringLiteral("END:VCALENDAR"));
+    if (calendarEnd < 0) {
+        return localIcs;
+    }
+    localIcs.insert(calendarEnd, detachedEvents.join(QStringLiteral("\r\n"))
+                    + QStringLiteral("\r\n"));
+    return localIcs;
+}
+
+} // namespace
+
+DCalDavOutboxProcessor::DCalDavOutboxProcessor(QObject *parent)
+    : QObject(parent)
+    , m_transport(this)
+{
+}
+
+void DCalDavOutboxProcessor::cancel()
+{
+    if (!m_running) {
+        return;
+    }
+    m_transport.cancel();
+    m_request.password.clear();
+    m_callback = Callback();
+    m_running = false;
+}
+
+void DCalDavOutboxProcessor::start(const Request &request, const Callback &callback)
+{
+    if (m_running) {
+        return;
+    }
+
+    m_request = request;
+    m_callback = callback;
+    m_result = Result();
+    m_itemIndex = 0;
+    m_running = true;
+    if (request.accountID.isEmpty() || request.username.isEmpty() || request.localDatabase == nullptr
+        || request.accountManagerDatabase == nullptr) {
+        finish(false, QStringLiteral("CalDAV Outbox request is incomplete."));
+        return;
+    }
+
+    DCalDavAccountInfo accountInfo;
+    if (!request.accountManagerDatabase->getCalDavAccountInfo(request.accountID, accountInfo)
+        || !DCalDavProviderProfile::forProvider(
+               static_cast<DCalDavProviderProfile::ProviderType>(accountInfo.providerType)).supportsWrite) {
+        finish(true);
+        return;
+    }
+
+    const QDateTime now = QDateTime::currentDateTimeUtc();
+    const DCalDavOutboxItem::List blockedItems =
+        request.accountManagerDatabase->getCalDavBlockedOutboxItems(request.accountID);
+    const bool hasConflict = std::any_of(
+        blockedItems.cbegin(), blockedItems.cend(), [](const DCalDavOutboxItem &item) {
+            return item.failureType == DCalDavOutboxItem::ConflictFailure;
+        });
+    if (hasConflict || (!request.forceRetry && !blockedItems.isEmpty())) {
+        m_result.permanentFailureCount = blockedItems.size();
+        for (const DCalDavOutboxItem &item : blockedItems) {
+            switch (item.failureType) {
+            case DCalDavOutboxItem::AuthenticationFailure:
+                m_result.errorMessage = QStringLiteral(
+                    "CalDAV synchronization failed (HTTP 401, error 0).");
+                break;
+            case DCalDavOutboxItem::PermissionFailure:
+                m_result.errorMessage = QStringLiteral(
+                    "CalDAV synchronization failed (HTTP 403, error 0).");
+                break;
+            case DCalDavOutboxItem::ConflictFailure:
+                m_result.errorMessage = QStringLiteral(
+                    "CalDAV synchronization conflict requires resolution.");
+                break;
+            default:
+                m_result.errorMessage = QStringLiteral(
+                    "CalDAV synchronization failure requires manual retry.");
+                break;
+            }
+            if (item.failureType == DCalDavOutboxItem::ConflictFailure) {
+                break;
+            }
+        }
+        finish(false, m_result.errorMessage);
+        return;
+    }
+
+    const DCalDavOutboxItem::List retryScheduledItems =
+        request.accountManagerDatabase->getCalDavRetryScheduledOutboxItems(
+            request.accountID, now);
+    if (!request.forceRetry && !retryScheduledItems.isEmpty()) {
+        m_result.retryScheduledCount = retryScheduledItems.size();
+        m_result.errorMessage = QStringLiteral(
+            "CalDAV synchronization retry is scheduled.");
+        finish(false, m_result.errorMessage);
+        return;
+    }
+
+    m_items = request.accountManagerDatabase->getDueCalDavOutboxItems(
+        request.accountID, now, request.forceRetry);
+    processNext();
+}
+
+void DCalDavOutboxProcessor::processNext()
+{
+    if (m_itemIndex >= m_items.size()) {
+        finish(m_result.permanentFailureCount == 0 && m_result.retryScheduledCount == 0,
+               m_result.errorMessage);
+        return;
+    }
+    processItem(m_items.at(m_itemIndex));
+}
+
+void DCalDavOutboxProcessor::processMissingSchedule(
+    const DCalDavOutboxItem &item, const DCalDavEventMappingInfo &mapping)
+{
+    // A local row can disappear while its durable outbox item is still
+    // pending (for example after a partial database commit or a cleanup on
+    // restart). If the mapping is known, turn the item into an idempotent
+    // remote DELETE instead of replaying a create/update with no payload.
+    if (!mapping.href.isEmpty()) {
+        DCalDavOutboxItem cleanup = item;
+        cleanup.operationType = DCalDavOutboxItem::DeleteOperation;
+        cleanup.baseEtag = mapping.etag;
+        cleanup.conflictIcs.clear();
+        cleanup.serverIcs.clear();
+        cleanup.retryCount = 0;
+        cleanup.nextRetryAt = QDateTime();
+        cleanup.failureType = DCalDavOutboxItem::NoFailure;
+        if (m_request.accountManagerDatabase->upsertCalDavOutboxItem(cleanup)) {
+            processItem(cleanup);
+        } else {
+            recordFailure(item, DCalDavTransport::Response());
+        }
+        return;
+    }
+
+    // Without a local payload or a persisted remote href there is no safe URL
+    // to call. Keep the item visible as a permanent failure rather than
+    // silently losing a potentially remote event.
+    DCalDavTransport::Response response;
+    response.httpStatus = 500;
+    recordFailure(item, response);
+}
+
+void DCalDavOutboxProcessor::repairCreateOperation(
+    const DCalDavOutboxItem &item, const DCalDavEventMappingInfo &mapping)
+{
+    DCalDavOutboxItem repaired = item;
+    repaired.operationType = DCalDavOutboxItem::ModifyOperation;
+    repaired.baseEtag = mapping.etag;
+    if (m_request.accountManagerDatabase->upsertCalDavOutboxItem(repaired)) {
+        processItem(repaired);
+    } else {
+        recordFailure(item, DCalDavTransport::Response());
+    }
+}
+
+void DCalDavOutboxProcessor::sendDeleteRequest(const DCalDavOutboxItem &item,
+                                                const DCalDavEventMappingInfo &mapping)
+{
+    const QUrl resourceUrl(mapping.href);
+    if (mapping.href.isEmpty() || !resourceUrl.isValid() || resourceUrl.scheme().isEmpty()
+        || resourceUrl.host().isEmpty()) {
+        DCalDavTransport::Response response;
+        response.httpStatus = 412;
+        recordFailure(item, response);
+        return;
+    }
+
+    DCalDavTransport::Request request;
+    request.url = resourceUrl;
+    request.method = "DELETE";
+    request.username = m_request.username;
+    request.password = m_request.password;
+    if (!item.baseEtag.isEmpty()) {
+        request.headers.insert("If-Match", item.baseEtag.toUtf8());
+    }
+    m_transport.send(request, [this, item, resourceUrl](const DCalDavTransport::Response &response) {
+        handleWriteResponse(item, resourceUrl, response);
+    });
+}
+
+void DCalDavOutboxProcessor::processItem(const DCalDavOutboxItem &item)
+{
+    const DSchedule::Ptr schedule = m_request.localDatabase->getScheduleByScheduleID(item.localScheduleID);
+    const DCalDavEventMappingInfo mapping = m_request.accountManagerDatabase
+        ->getCalDavEventMappingByLocalScheduleID(item.accountID, item.localScheduleID);
+    if (schedule.isNull() && item.operationType != DCalDavOutboxItem::DeleteOperation) {
+        processMissingSchedule(item, mapping);
+        return;
+    }
+
+    if (!schedule.isNull() && !mapping.href.isEmpty()
+        && item.operationType == DCalDavOutboxItem::CreateOperation) {
+        repairCreateOperation(item, mapping);
+        return;
+    }
+
+    if (item.operationType == DCalDavOutboxItem::DeleteOperation) {
+        sendDeleteRequest(item, mapping);
+        return;
+    }
+
+    const DCalDavCalendarInfo calendar = calendarFor(item, schedule, m_request.accountManagerDatabase);
+    if (calendar.calendarId.isEmpty() || !(calendar.privileges & DCalDavXmlReader::WritePrivilege)) {
+        DCalDavTransport::Response response;
+        response.httpStatus = 403;
+        response.error = DCalDavTransport::PermissionDenied;
+        recordFailure(item, response);
+        return;
+    }
+
+    if (schedule.isNull() || schedule->uid().isEmpty()) {
+        DCalDavTransport::Response response;
+        response.httpStatus = 412;
+        recordFailure(item, response);
+        return;
+    }
+    const QUrl resourceUrl = item.operationType == DCalDavOutboxItem::CreateOperation
+        ? DCalDavUtils::eventUrl(calendar, schedule->uid())
+        : (mapping.href.isEmpty() ? DCalDavUtils::eventUrl(calendar, schedule->uid()) : QUrl(mapping.href));
+    if (!resourceUrl.isValid()) {
+        DCalDavTransport::Response response;
+        response.httpStatus = 412;
+        recordFailure(item, response);
+        return;
+    }
+
+    if (item.operationType == DCalDavOutboxItem::ModifyOperation && item.baseEtag.isEmpty()) {
+        fetchWriteEtag(item, resourceUrl);
+        return;
+    }
+
+    sendWriteRequest(item, resourceUrl, item.baseEtag.toUtf8());
+}
+
+void DCalDavOutboxProcessor::fetchWriteEtag(const DCalDavOutboxItem &item, const QUrl &resourceUrl)
+{
+    DCalDavTransport::Request request;
+    request.url = resourceUrl;
+    request.method = "PROPFIND";
+    request.contentType = "application/xml; charset=utf-8";
+    request.username = m_request.username;
+    request.password = m_request.password;
+    request.headers.insert("Depth", "0");
+    request.body = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                   "<d:propfind xmlns:d=\"DAV:\"><d:prop><d:getetag/>"
+                   "</d:prop></d:propfind>";
+    m_transport.send(request, [this, item, resourceUrl](const DCalDavTransport::Response &response) {
+        if (!isCurrentItem(item)) {
+            processCurrentItemOrAdvance(item);
+            return;
+        }
+        const QByteArray etag = isSuccessful(response.httpStatus)
+            ? parseEtag(response.body).trimmed().toUtf8() : QByteArray();
+        if (etag.isEmpty()) {
+            DCalDavTransport::Response failure = response;
+            if (failure.httpStatus == 0) {
+                failure.httpStatus = 412;
+            }
+            recordFailure(item, failure);
+            return;
+        }
+        sendWriteRequest(item, resourceUrl, etag);
+    });
+}
+
+void DCalDavOutboxProcessor::sendWriteRequest(const DCalDavOutboxItem &item,
+                                               const QUrl &resourceUrl,
+                                               const QByteArray &etag)
+{
+    if (!isCurrentItem(item)) {
+        processCurrentItemOrAdvance(item);
+        return;
+    }
+
+    const DSchedule::Ptr schedule = m_request.localDatabase->getScheduleByScheduleID(item.localScheduleID);
+    const DCalDavEventMappingInfo mapping = m_request.accountManagerDatabase
+        ->getCalDavEventMappingByLocalScheduleID(item.accountID, item.localScheduleID);
+    if (schedule.isNull() || schedule->uid().isEmpty()) {
+        DCalDavTransport::Response response;
+        response.httpStatus = 412;
+        recordFailure(item, response);
+        return;
+    }
+    if (item.operationType == DCalDavOutboxItem::ModifyOperation && etag.isEmpty()) {
+        DCalDavTransport::Response response;
+        response.httpStatus = 412;
+        recordFailure(item, response);
+        return;
+    }
+
+    DSchedule::Ptr remoteSchedule(new DSchedule(*schedule));
+    if (!mapping.uid.isEmpty()) {
+        remoteSchedule->setUid(mapping.uid);
+    }
+    DCalDavTransport::Request request;
+    request.url = resourceUrl;
+    request.method = "PUT";
+    request.contentType = "text/calendar; charset=utf-8";
+    request.username = m_request.username;
+    request.password = m_request.password;
+    request.body = icsForRemoteWrite(remoteSchedule, mapping).toUtf8();
+    if (item.operationType == DCalDavOutboxItem::CreateOperation) {
+        request.headers.insert("If-None-Match", "*");
+    } else {
+        request.headers.insert("If-Match", etag);
+    }
+
+    m_transport.send(request, [this, item, resourceUrl](const DCalDavTransport::Response &response) {
+        handleWriteResponse(item, resourceUrl, response);
+    });
+}
+
+void DCalDavOutboxProcessor::handleWriteResponse(const DCalDavOutboxItem &item, const QUrl &resourceUrl,
+                                                  const DCalDavTransport::Response &response)
+{
+    if (!isCurrentItem(item)) {
+        processCurrentItemOrAdvance(item);
+        return;
+    }
+    if (isSuccessful(response.httpStatus)
+        || (item.operationType == DCalDavOutboxItem::DeleteOperation && response.httpStatus == 404)) {
+        if (item.operationType == DCalDavOutboxItem::DeleteOperation || !response.etag.isEmpty()) {
+            completeSuccess(item, resourceUrl, response.etag);
+        } else {
+            fetchEtag(item, resourceUrl);
+        }
+        return;
+    }
+    if (response.httpStatus == 409 || response.httpStatus == 412) {
+        fetchConflictSnapshot(item, resourceUrl);
+        return;
+    }
+    recordFailure(item, response);
+}
+
+void DCalDavOutboxProcessor::fetchEtag(const DCalDavOutboxItem &item, const QUrl &resourceUrl)
+{
+    DCalDavTransport::Request request;
+    request.url = resourceUrl;
+    request.method = "PROPFIND";
+    request.contentType = "application/xml; charset=utf-8";
+    request.username = m_request.username;
+    request.password = m_request.password;
+    request.headers.insert("Depth", "0");
+    request.body = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                   "<d:propfind xmlns:d=\"DAV:\"><d:prop><d:getetag/>"
+                   "</d:prop></d:propfind>";
+    m_transport.send(request, [this, item, resourceUrl](const DCalDavTransport::Response &response) {
+        if (isSuccessful(response.httpStatus)) {
+            completeSuccess(item, resourceUrl, parseEtag(response.body).toUtf8());
+        } else {
+            // The remote write already succeeded. Keep the mapping with an empty
+            // ETag rather than replaying a potentially duplicate PUT.
+            completeSuccess(item, resourceUrl, QByteArray());
+        }
+    });
+}
+
+void DCalDavOutboxProcessor::fetchConflictSnapshot(const DCalDavOutboxItem &item,
+                                                   const QUrl &resourceUrl)
+{
+    DCalDavTransport::Request request;
+    request.url = resourceUrl;
+    request.method = "GET";
+    request.username = m_request.username;
+    request.password = m_request.password;
+    m_transport.send(request, [this, item](const DCalDavTransport::Response &response) {
+        if (!isCurrentItem(item)) {
+            processCurrentItemOrAdvance(item);
+            return;
+        }
+
+        // The snapshot request is part of the same synchronization attempt.
+        // A transient failure here must use the normal retry policy; turning
+        // it into a conflict with an empty server snapshot would permanently
+        // block the item and leave the user without a server-version choice.
+        if (!isSuccessful(response.httpStatus)) {
+            recordFailure(item, response);
+            return;
+        }
+
+        DCalDavOutboxItem updated = item;
+        updated.failureType = DCalDavOutboxItem::ConflictFailure;
+        updated.retryCount = 0;
+        updated.nextRetryAt = QDateTime();
+        const DSchedule::Ptr localSchedule = m_request.localDatabase->getScheduleByScheduleID(
+            item.localScheduleID);
+        updated.conflictIcs = localSchedule.isNull() ? QString() : DSchedule::toIcsString(localSchedule);
+        updated.serverIcs = QString::fromUtf8(response.body).trimmed();
+        DSchedule::Ptr serverSchedule;
+        if (!updated.serverIcs.isEmpty()
+            && !DSchedule::fromIcsString(serverSchedule, updated.serverIcs)) {
+            updated.serverIcs.clear();
+        }
+        const bool hasServerSnapshot = !updated.serverIcs.isEmpty();
+        if (!hasServerSnapshot) {
+            // Keep this as a resolvable conflict so the user can still choose
+            // the local version when the server returned no usable object.
+            // The server-version action remains unavailable without a snapshot.
+            updated.failureType = DCalDavOutboxItem::ConflictFailure;
+        }
+        if (!m_request.accountManagerDatabase->upsertCalDavOutboxItem(updated)) {
+            ++m_result.permanentFailureCount;
+            if (m_result.errorMessage.isEmpty()) {
+                m_result.errorMessage = QStringLiteral(
+                    "Failed to record a CalDAV synchronization conflict.");
+            }
+        } else {
+            ++m_result.conflictDiscardedCount;
+            ++m_result.permanentFailureCount;
+            if (m_result.errorMessage.isEmpty()) {
+                m_result.errorMessage = hasServerSnapshot
+                    ? QStringLiteral("CalDAV synchronization conflict requires resolution.")
+                    : QStringLiteral("CalDAV conflict snapshot is empty; keep the local version or retry.");
+            }
+        }
+        ++m_itemIndex;
+        processNext();
+    });
+}
+
+void DCalDavOutboxProcessor::completeSuccess(const DCalDavOutboxItem &item, const QUrl &resourceUrl,
+                                              const QByteArray &etag)
+{
+    if (!isCurrentItem(item)) {
+        processCurrentItemOrAdvance(item);
+        return;
+    }
+    if (item.operationType == DCalDavOutboxItem::DeleteOperation) {
+        const DCalDavEventMappingInfo mapping = m_request.accountManagerDatabase
+            ->getCalDavEventMappingByLocalScheduleID(item.accountID, item.localScheduleID);
+        if (m_request.localDatabase->scheduleExistsByScheduleID(item.localScheduleID)
+            && !m_request.localDatabase->deleteScheduleByScheduleID(item.localScheduleID, 1)) {
+            finish(false, QStringLiteral("Failed to remove completed local schedule."));
+            return;
+        }
+        if (!mapping.href.isEmpty()
+            && !m_request.accountManagerDatabase->deleteCalDavEventMapping(item.accountID, mapping.href)) {
+            finish(false, QStringLiteral("Failed to remove completed CalDAV event mapping."));
+            return;
+        }
+    } else {
+        const DSchedule::Ptr schedule = m_request.localDatabase->getScheduleByScheduleID(item.localScheduleID);
+        if (schedule.isNull()) {
+            ++m_itemIndex;
+            processNext();
+            return;
+        }
+        const DCalDavCalendarInfo calendar = calendarFor(item, schedule, m_request.accountManagerDatabase);
+        DCalDavEventMappingInfo mapping = m_request.accountManagerDatabase
+            ->getCalDavEventMappingByLocalScheduleID(item.accountID, item.localScheduleID);
+        mapping.localScheduleID = item.localScheduleID;
+        mapping.accountID = item.accountID;
+        mapping.calendarID = calendar.calendarId;
+        if (mapping.uid.isEmpty()) {
+            mapping.uid = schedule->uid();
+        }
+        DSchedule::Ptr remoteSchedule(new DSchedule(*schedule));
+        remoteSchedule->setUid(mapping.uid);
+        mapping.href = resourceUrl.toString();
+        mapping.etag = QString::fromUtf8(etag);
+        mapping.originalIcs = icsForRemoteWrite(remoteSchedule, mapping);
+        if (!m_request.accountManagerDatabase->upsertCalDavEventMapping(mapping)) {
+            finish(false, QStringLiteral("Failed to save CalDAV write mapping."));
+            return;
+        }
+    }
+
+    if (!m_request.accountManagerDatabase->deleteCalDavOutboxItemIfCurrent(item)) {
+        if (!isCurrentItem(item)) {
+            processCurrentItemOrAdvance(item);
+            return;
+        }
+        finish(false, QStringLiteral("Failed to remove completed CalDAV Outbox item."));
+        return;
+    }
+    ++m_result.processedCount;
+    ++m_itemIndex;
+    processNext();
+}
+
+void DCalDavOutboxProcessor::recordFailure(const DCalDavOutboxItem &item,
+                                           const DCalDavTransport::Response &response)
+{
+    if (!isCurrentItem(item)) {
+        processCurrentItemOrAdvance(item);
+        return;
+    }
+    DCalDavOutboxItem updated = item;
+    m_result.failureResponse = response;
+    const DCalDavRetryPolicy::Decision retry = DCalDavRetryPolicy::decide(response, item.retryCount);
+    if (retry.retry) {
+        updated.retryCount = item.retryCount + 1;
+        updated.nextRetryAt = QDateTime::currentDateTimeUtc().addSecs(retry.delaySeconds);
+        updated.failureType = DCalDavOutboxItem::NetworkFailure;
+        ++m_result.retryScheduledCount;
+    } else if (response.httpStatus == 401) {
+        updated.failureType = DCalDavOutboxItem::AuthenticationFailure;
+        ++m_result.permanentFailureCount;
+    } else if (response.httpStatus == 403) {
+        updated.failureType = DCalDavOutboxItem::PermissionFailure;
+        ++m_result.permanentFailureCount;
+    } else if (response.httpStatus == 409 || response.httpStatus == 412) {
+        updated.failureType = DCalDavOutboxItem::ConflictFailure;
+        updated.retryCount = 0;
+        updated.nextRetryAt = QDateTime();
+        if (updated.conflictIcs.isEmpty()) {
+            const DSchedule::Ptr localSchedule = m_request.localDatabase->getScheduleByScheduleID(
+                item.localScheduleID);
+            updated.conflictIcs = localSchedule.isNull() ? QString() : DSchedule::toIcsString(localSchedule);
+        }
+        ++m_result.permanentFailureCount;
+    } else {
+        updated.failureType = DCalDavOutboxItem::PermanentFailure;
+        ++m_result.permanentFailureCount;
+    }
+    const bool notifyCreateFailure = item.operationType == DCalDavOutboxItem::CreateOperation
+        && (item.retryCount == 0 || m_request.forceRetry);
+    if (notifyCreateFailure && response.httpStatus == 403) {
+        m_result.createFailure = DCalDavScheduleCreateError::PermissionDenied;
+    } else if (notifyCreateFailure
+               && (response.error == DCalDavTransport::NetworkUnavailable
+                   || response.error == DCalDavTransport::RequestTimedOut
+                   || response.error == DCalDavTransport::NetworkError)) {
+        m_result.createFailure = DCalDavScheduleCreateError::NetworkUnavailable;
+    }
+    if (!m_request.accountManagerDatabase->upsertCalDavOutboxItem(updated)
+        && m_result.errorMessage.isEmpty()) {
+        m_result.errorMessage = QStringLiteral("Failed to record CalDAV synchronization failure.");
+    }
+    if (m_result.errorMessage.isEmpty()) {
+        m_result.errorMessage = responseError(item, response);
+    }
+    ++m_itemIndex;
+    processNext();
+}
+
+bool DCalDavOutboxProcessor::isCurrentItem(const DCalDavOutboxItem &item) const
+{
+    const DCalDavOutboxItem current = m_request.accountManagerDatabase->getCalDavOutboxItem(
+        item.accountID, item.localScheduleID);
+    return current.operationID == item.operationID
+        && current.operationType == item.operationType
+        && current.baseEtag == item.baseEtag
+        && current.conflictIcs == item.conflictIcs
+        && current.serverIcs == item.serverIcs
+        && current.retryCount == item.retryCount
+        && current.nextRetryAt == item.nextRetryAt
+        && current.failureType == item.failureType;
+}
+
+bool DCalDavOutboxProcessor::processCurrentItemOrAdvance(const DCalDavOutboxItem &item)
+{
+    const DCalDavOutboxItem current = m_request.accountManagerDatabase->getCalDavOutboxItem(
+        item.accountID, item.localScheduleID);
+    if (current.operationID.isEmpty()) {
+        ++m_itemIndex;
+        processNext();
+        return false;
+    }
+    processItem(current);
+    return true;
+}
+
+void DCalDavOutboxProcessor::finish(bool success, const QString &errorMessage)
+{
+    if (!m_running) {
+        return;
+    }
+    m_result.success = success;
+    if (!errorMessage.isEmpty()) {
+        m_result.errorMessage = errorMessage;
+    }
+    m_request.password.clear();
+    m_running = false;
+    if (m_callback) {
+        const Callback callback = m_callback;
+        m_callback = Callback();
+        callback(m_result);
+    }
+}

--- a/src/calendar-service/src/caldav/dcaldavoutboxprocessor.h
+++ b/src/calendar-service/src/caldav/dcaldavoutboxprocessor.h
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVOUTBOXPROCESSOR_H
+#define DCALDAVOUTBOXPROCESSOR_H
+
+#include "dcaldaveventmappinginfo.h"
+#include "dcaldavoutboxitem.h"
+#include "dcaldavtransport.h"
+#include "dcaldavvalidationerror.h"
+
+#include <QObject>
+
+#include <functional>
+
+class DAccountDataBase;
+class DAccountManagerDataBase;
+
+class DCalDavOutboxProcessor : public QObject
+{
+    Q_OBJECT
+public:
+    struct Request {
+        QString accountID;
+        QString username;
+        QString password;
+        DAccountDataBase *localDatabase = nullptr;
+        DAccountManagerDataBase *accountManagerDatabase = nullptr;
+        bool forceRetry = false;
+    };
+
+    struct Result {
+        bool success = false;
+        QString errorMessage;
+        DCalDavTransport::Response failureResponse;
+        int processedCount = 0;
+        int retryScheduledCount = 0;
+        int conflictDiscardedCount = 0;
+        DCalDavScheduleCreateError::Type createFailure = DCalDavScheduleCreateError::NoError;
+        int permanentFailureCount = 0;
+    };
+
+    typedef std::function<void(const Result &)> Callback;
+
+    explicit DCalDavOutboxProcessor(QObject *parent = nullptr);
+
+    /**
+     * @brief Sends due durable Outbox operations to the CalDAV server.
+     * @param request Account credentials, databases, and retry policy.
+     * @param callback Invoked exactly once after processing or cancellation.
+     */
+    void start(const Request &request, const Callback &callback);
+    void cancel();
+
+private:
+    void processNext();
+    void processMissingSchedule(const DCalDavOutboxItem &item,
+                                const DCalDavEventMappingInfo &mapping);
+    void repairCreateOperation(const DCalDavOutboxItem &item,
+                               const DCalDavEventMappingInfo &mapping);
+    void sendDeleteRequest(const DCalDavOutboxItem &item,
+                           const DCalDavEventMappingInfo &mapping);
+    void fetchWriteEtag(const DCalDavOutboxItem &item, const QUrl &resourceUrl);
+    /**
+     * @brief Processes one pending local-to-remote operation.
+     * @param item Outbox item containing the operation and retry metadata.
+     *
+     * Resolves the target calendar and resource URL, performs the required
+     * CalDAV request, and advances or records failure through the processor.
+     */
+    void processItem(const DCalDavOutboxItem &item);
+    void sendWriteRequest(const DCalDavOutboxItem &item, const QUrl &resourceUrl,
+                          const QByteArray &etag);
+    void handleWriteResponse(const DCalDavOutboxItem &item, const QUrl &resourceUrl,
+                             const DCalDavTransport::Response &response);
+    void fetchEtag(const DCalDavOutboxItem &item, const QUrl &resourceUrl);
+    void fetchConflictSnapshot(const DCalDavOutboxItem &item, const QUrl &resourceUrl);
+    void completeSuccess(const DCalDavOutboxItem &item, const QUrl &resourceUrl,
+                         const QByteArray &etag);
+    void recordFailure(const DCalDavOutboxItem &item, const DCalDavTransport::Response &response);
+    void finish(bool success, const QString &errorMessage = QString());
+    bool isCurrentItem(const DCalDavOutboxItem &item) const;
+    bool processCurrentItemOrAdvance(const DCalDavOutboxItem &item);
+
+    DCalDavTransport m_transport;
+    Request m_request;
+    Callback m_callback;
+    DCalDavOutboxItem::List m_items;
+    Result m_result;
+    int m_itemIndex = 0;
+    bool m_running = false;
+};
+
+#endif // DCALDAVOUTBOXPROCESSOR_H

--- a/src/calendar-service/src/caldav/dcaldavrecoveryhandler.cpp
+++ b/src/calendar-service/src/caldav/dcaldavrecoveryhandler.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavrecoveryhandler.h"
+
+#include "daccountdatabase.h"
+#include "daccountmanagerdatabase.h"
+#include "dcaldavoutboxenqueuer.h"
+#include "dcaldavrecoveryitem.h"
+#include "dschedule.h"
+#include "commondef.h"
+
+namespace {
+
+bool restoreMapping(DAccountManagerDataBase *database,
+                    const DCalDavRecoveryItem &item,
+                    const DSchedule::Ptr &schedule)
+{
+    if (database == nullptr || schedule.isNull() || item.accountID.isEmpty()
+        || item.localScheduleID.isEmpty() || item.calendarID.isEmpty() || item.href.isEmpty()) {
+        return false;
+    }
+    DCalDavEventMappingInfo mapping = database->getCalDavEventMappingByLocalScheduleID(
+        item.accountID, item.localScheduleID);
+    if (!mapping.href.isEmpty()) {
+        return true;
+    }
+    mapping.accountID = item.accountID;
+    mapping.localScheduleID = item.localScheduleID;
+    mapping.calendarID = item.calendarID;
+    mapping.uid = schedule->uid();
+    mapping.href = item.href;
+    mapping.etag = item.etag;
+    mapping.originalIcs = item.originalIcs;
+    return database->upsertCalDavEventMapping(mapping);
+}
+
+} // namespace
+
+void DCalDavRecoveryHandler::recover(DAccountDataBase *localDatabase,
+                                     DAccountManagerDataBase *accountManagerDatabase,
+                                     const QString &accountID)
+{
+    if (localDatabase == nullptr || accountManagerDatabase == nullptr || accountID.isEmpty()) {
+        return;
+    }
+
+    const DCalDavRecoveryItem::List items = localDatabase->getCalDavRecoveryItems(accountID);
+    for (const DCalDavRecoveryItem &item : items) {
+        DSchedule::Ptr recoveredSchedule;
+        if (!DSchedule::fromIcsString(recoveredSchedule, item.scheduleIcs)
+            || recoveredSchedule.isNull()) {
+            // CREATE and DELETE recovery only need the persisted resource
+            // address. Do not discard a compensating DELETE merely because an
+            // older or damaged ICS payload cannot be parsed.
+            if (item.operationType == DCalDavRecoveryItem::ModifyOperation) {
+                qCWarning(ServiceLogger) << "Keeping invalid CalDAV modify recovery record for schedule:"
+                                         << item.localScheduleID;
+                continue;
+            }
+            recoveredSchedule.reset(new DSchedule);
+        }
+        recoveredSchedule->setUid(item.localScheduleID);
+
+        const bool exists = localDatabase->scheduleExistsByScheduleID(item.localScheduleID);
+        const bool deleted = exists && localDatabase->isScheduleDeletedByScheduleID(item.localScheduleID);
+        const bool mappingRestored = item.href.isEmpty()
+            || restoreMapping(accountManagerDatabase, item, recoveredSchedule);
+        bool recovered = false;
+        switch (item.operationType) {
+        case DCalDavRecoveryItem::CreateOperation:
+            if (exists && !deleted) {
+                recovered = mappingRestored;
+            } else if (mappingRestored) {
+                recovered = DCalDavOutboxEnqueuer::enqueue(
+                    accountManagerDatabase, item.accountID, recoveredSchedule,
+                    DCalDavOutboxEnqueuer::DeleteChange);
+            }
+            break;
+        case DCalDavRecoveryItem::LocalCreateOperation:
+            if (exists && !deleted) {
+                const DSchedule::Ptr current =
+                    localDatabase->getScheduleByScheduleID(item.localScheduleID);
+                recovered = !current.isNull()
+                    && DCalDavOutboxEnqueuer::enqueue(
+                        accountManagerDatabase, item.accountID, current,
+                        DCalDavOutboxEnqueuer::CreateChange);
+            } else {
+                // The local creation never committed, so there is no remote
+                // resource to compensate.
+                recovered = true;
+            }
+            break;
+        case DCalDavRecoveryItem::ModifyOperation:
+            if (exists && !deleted && mappingRestored) {
+                const DSchedule::Ptr current =
+                    localDatabase->getScheduleByScheduleID(item.localScheduleID);
+                recovered = !current.isNull()
+                    && DSchedule::toIcsString(current) == item.scheduleIcs
+                    && DCalDavOutboxEnqueuer::enqueue(
+                        accountManagerDatabase, item.accountID, current,
+                        DCalDavOutboxEnqueuer::ModifyChange);
+                if (!recovered && !current.isNull()
+                    && DSchedule::toIcsString(current) != item.scheduleIcs) {
+                    recovered = true;
+                }
+            }
+            break;
+        case DCalDavRecoveryItem::DeleteOperation:
+            if (deleted && mappingRestored) {
+                recovered = DCalDavOutboxEnqueuer::enqueue(
+                    accountManagerDatabase, item.accountID, recoveredSchedule,
+                    DCalDavOutboxEnqueuer::DeleteChange);
+            } else if (exists && !deleted) {
+                const DSchedule::Ptr current =
+                    localDatabase->getScheduleByScheduleID(item.localScheduleID);
+                recovered = !current.isNull()
+                    && DCalDavOutboxEnqueuer::enqueue(
+                        accountManagerDatabase, item.accountID, current,
+                        DCalDavOutboxEnqueuer::ModifyChange);
+            }
+            break;
+        }
+        if (recovered) {
+            localDatabase->deleteCalDavRecoveryItem(item.accountID, item.localScheduleID);
+        }
+    }
+}

--- a/src/calendar-service/src/caldav/dcaldavrecoveryhandler.h
+++ b/src/calendar-service/src/caldav/dcaldavrecoveryhandler.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVRECOVERYHANDLER_H
+#define DCALDAVRECOVERYHANDLER_H
+
+#include <QString>
+
+class DAccountDataBase;
+class DAccountManagerDataBase;
+
+class DCalDavRecoveryHandler
+{
+public:
+    static void recover(DAccountDataBase *localDatabase,
+                        DAccountManagerDataBase *accountManagerDatabase,
+                        const QString &accountID);
+};
+
+#endif // DCALDAVRECOVERYHANDLER_H

--- a/src/calendar-service/src/caldav/dcaldavretrypolicy.cpp
+++ b/src/calendar-service/src/caldav/dcaldavretrypolicy.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavretrypolicy.h"
+
+#include <QDateTime>
+
+#include <limits>
+
+namespace {
+
+int fallbackDelaySeconds(int retryCount)
+{
+    switch (retryCount) {
+    case 0:
+        return 60;
+    case 1:
+        return 5 * 60;
+    default:
+        return 15 * 60;
+    }
+}
+
+} // namespace
+
+DCalDavRetryPolicy::Decision DCalDavRetryPolicy::decide(const DCalDavTransport::Response &response,
+                                                        int retryCount)
+{
+    Decision decision;
+    if (retryCount < 0) {
+        return decision;
+    }
+
+    const bool retryable = response.error == DCalDavTransport::NetworkUnavailable
+        || response.error == DCalDavTransport::RequestTimedOut
+        || response.error == DCalDavTransport::RateLimited
+        || response.error == DCalDavTransport::ServerUnavailable
+        || response.error == DCalDavTransport::NetworkError;
+    if (!retryable) {
+        return decision;
+    }
+
+    bool retryAfterParsed = false;
+    const int retryAfterSeconds = response.retryAfter.trimmed().toInt(&retryAfterParsed);
+    int delaySeconds = fallbackDelaySeconds(retryCount);
+    if (retryAfterParsed && retryAfterSeconds >= 0) {
+        delaySeconds = retryAfterSeconds;
+    } else if (!response.retryAfter.trimmed().isEmpty()) {
+        const QDateTime retryAt = QDateTime::fromString(
+            QString::fromLatin1(response.retryAfter.trimmed()), Qt::RFC2822Date);
+        if (retryAt.isValid()) {
+            const qint64 seconds = QDateTime::currentDateTimeUtc().secsTo(retryAt.toUTC());
+            delaySeconds = static_cast<int>(qBound<qint64>(
+                static_cast<qint64>(0),
+                seconds,
+                static_cast<qint64>(std::numeric_limits<int>::max())));
+        }
+    }
+    delaySeconds = qBound(
+        0,
+        delaySeconds,
+        std::numeric_limits<int>::max());
+    decision.retry = true;
+    decision.delaySeconds = delaySeconds;
+    return decision;
+}

--- a/src/calendar-service/src/caldav/dcaldavretrypolicy.h
+++ b/src/calendar-service/src/caldav/dcaldavretrypolicy.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVRETRYPOLICY_H
+#define DCALDAVRETRYPOLICY_H
+
+#include "dcaldavtransport.h"
+
+class DCalDavRetryPolicy
+{
+public:
+    struct Decision {
+        bool retry = false;
+        int delaySeconds = 0;
+    };
+
+    static Decision decide(const DCalDavTransport::Response &response, int retryCount);
+};
+
+#endif // DCALDAVRETRYPOLICY_H

--- a/src/calendar-service/src/caldav/dcaldavsyncjobmanager.cpp
+++ b/src/calendar-service/src/caldav/dcaldavsyncjobmanager.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavsyncjobmanager.h"
+
+#include "commondef.h"
+
+#include <QTimer>
+
+DCalDavSyncJobManager::DCalDavSyncJobManager(QObject *parent)
+    : QObject(parent)
+    , m_stateMachine()
+{
+    connect(&m_stateMachine, &DCalDavSyncStateMachine::syncRequested,
+            this, &DCalDavSyncJobManager::processNext);
+    connect(&m_stateMachine, &DCalDavSyncStateMachine::stateChanged,
+            this, &DCalDavSyncJobManager::accountSyncStateChanged);
+}
+
+bool DCalDavSyncJobManager::registerAccount(const DCalDavAccountSync::Request &request)
+{
+    if (request.accountID.isEmpty()) {
+        return false;
+    }
+
+    if (m_stateMachine.containsAccount(request.accountID)) {
+        if (m_stateMachine.stateFor(request.accountID) == DCalDavSyncStateMachine::Running) {
+            return false;
+        }
+        m_requests.insert(request.accountID, request);
+        return true;
+    }
+
+    if (!m_stateMachine.registerAccount(request.accountID)) {
+        return false;
+    }
+    m_requests.insert(request.accountID, request);
+    m_jobs.insert(request.accountID, new DCalDavAccountSync(this));
+    return true;
+}
+
+bool DCalDavSyncJobManager::unregisterAccount(const QString &accountID)
+{
+    return cancelAccount(accountID);
+}
+
+bool DCalDavSyncJobManager::cancelAccount(const QString &accountID)
+{
+    if (!m_stateMachine.containsAccount(accountID)) {
+        return true;
+    }
+    if (DCalDavAccountSync *job = m_jobs.take(accountID)) {
+        job->cancel(false);
+        job->deleteLater();
+    }
+    if (!m_stateMachine.unregisterAccount(accountID)) {
+        return false;
+    }
+    m_requests.remove(accountID);
+    return true;
+}
+
+bool DCalDavSyncJobManager::requestSync(const QString &accountID, DCalDavSyncStateMachine::Trigger trigger)
+{
+    if (trigger == DCalDavSyncStateMachine::ManualTrigger
+        && m_requests.contains(accountID)) {
+        m_requests[accountID].forceOutboxRetry = true;
+    }
+    return m_stateMachine.requestSync(accountID, trigger);
+}
+
+int DCalDavSyncJobManager::requestSyncForAll(DCalDavSyncStateMachine::Trigger trigger)
+{
+    return m_stateMachine.requestSyncForAll(trigger);
+}
+
+DCalDavSyncStateMachine::State DCalDavSyncJobManager::stateFor(const QString &accountID) const
+{
+    return m_stateMachine.stateFor(accountID);
+}
+
+bool DCalDavSyncJobManager::containsAccount(const QString &accountID) const
+{
+    return m_stateMachine.containsAccount(accountID);
+}
+
+void DCalDavSyncJobManager::processNext(const QString &requestedAccountID)
+{
+    const QString accountID = requestedAccountID.isEmpty()
+        ? m_stateMachine.takeNextRunnableAccount()
+        : m_stateMachine.takeRunnableAccount(requestedAccountID);
+    if (accountID.isEmpty()) {
+        return;
+    }
+
+    qCDebug(ServiceLogger) << "CalDAV sync job selected account:" << accountID
+                              << "requested account:" << requestedAccountID;
+    if (!m_requests.contains(accountID) || !m_jobs.contains(accountID)) {
+        m_stateMachine.complete(accountID, false);
+        return;
+    }
+
+    DCalDavAccountSync *job = m_jobs.value(accountID);
+    const DCalDavAccountSync::Request request = m_requests.value(accountID);
+    m_requests[accountID].forceOutboxRetry = false;
+    job->start(request, [this, accountID](const DCalDavAccountSync::Result &result) {
+        m_stateMachine.complete(accountID, result.success);
+        if (result.success
+            && (result.createdCount > 0 || result.updatedCount > 0 || result.deletedCount > 0)) {
+            emit accountSyncDataChanged(accountID);
+        }
+        if (result.createFailure != DCalDavScheduleCreateError::NoError) {
+            emit accountScheduleCreateFailed(accountID, static_cast<int>(result.createFailure));
+        }
+        emit accountSyncFinished(accountID, result.success, result.errorMessage,
+                                  result.failureResponse);
+        QTimer::singleShot(0, this, [this, accountID]() {
+            processNext(accountID);
+        });
+    });
+}

--- a/src/calendar-service/src/caldav/dcaldavsyncjobmanager.h
+++ b/src/calendar-service/src/caldav/dcaldavsyncjobmanager.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVSYNCJOBMANAGER_H
+#define DCALDAVSYNCJOBMANAGER_H
+
+#include "dcaldavaccountsync.h"
+#include "dcaldavsyncstatemachine.h"
+
+#include <QHash>
+#include <QObject>
+
+class DCalDavSyncJobManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit DCalDavSyncJobManager(QObject *parent = nullptr);
+
+    bool registerAccount(const DCalDavAccountSync::Request &request);
+    bool unregisterAccount(const QString &accountID);
+    bool cancelAccount(const QString &accountID);
+    bool requestSync(const QString &accountID, DCalDavSyncStateMachine::Trigger trigger);
+    int requestSyncForAll(DCalDavSyncStateMachine::Trigger trigger);
+
+    DCalDavSyncStateMachine::State stateFor(const QString &accountID) const;
+    bool containsAccount(const QString &accountID) const;
+
+signals:
+    void accountSyncStateChanged(const QString &accountID, DCalDavSyncStateMachine::State state);
+    void accountSyncFinished(const QString &accountID, bool success, const QString &errorMessage,
+                             const DCalDavTransport::Response &failureResponse);
+    void accountSyncDataChanged(const QString &accountID);
+    void accountScheduleCreateFailed(const QString &accountID, int createFailure);
+
+private:
+    void processNext(const QString &requestedAccountID);
+
+    DCalDavSyncStateMachine m_stateMachine;
+    QHash<QString, DCalDavAccountSync::Request> m_requests;
+    QHash<QString, DCalDavAccountSync *> m_jobs;
+};
+
+#endif // DCALDAVSYNCJOBMANAGER_H

--- a/src/calendar-service/src/caldav/dcaldavsyncstatemachine.cpp
+++ b/src/calendar-service/src/caldav/dcaldavsyncstatemachine.cpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavsyncstatemachine.h"
+
+DCalDavSyncStateMachine::DCalDavSyncStateMachine(QObject *parent)
+    : QObject(parent)
+{
+    qRegisterMetaType<DCalDavSyncStateMachine::State>("DCalDavSyncStateMachine::State");
+}
+
+bool DCalDavSyncStateMachine::registerAccount(const QString &accountId)
+{
+    if (accountId.isEmpty() || m_accounts.contains(accountId)) {
+        return false;
+    }
+
+    m_accounts.insert(accountId, AccountState());
+    return true;
+}
+
+bool DCalDavSyncStateMachine::unregisterAccount(const QString &accountId)
+{
+    if (!m_accounts.contains(accountId)) {
+        return false;
+    }
+
+    m_accounts.remove(accountId);
+    return true;
+}
+
+bool DCalDavSyncStateMachine::requestSync(const QString &accountId, Trigger trigger)
+{
+    auto account = m_accounts.find(accountId);
+    if (account == m_accounts.end() || trigger == NoTrigger) {
+        return false;
+    }
+
+    if (account->state == Running) {
+        return false;
+    }
+
+    account->pendingTriggers |= trigger;
+    if (account->state != Queued) {
+        account->state = Queued;
+        m_queue.enqueue(accountId);
+        emitStateChanged(accountId, Queued);
+        emit syncRequested(accountId);
+    }
+    return true;
+}
+
+int DCalDavSyncStateMachine::requestSyncForAll(Trigger trigger)
+{
+    int count = 0;
+    const QStringList accountIds = m_accounts.keys();
+    for (const QString &accountId : accountIds) {
+        if (requestSync(accountId, trigger)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+QString DCalDavSyncStateMachine::takeNextRunnableAccount()
+{
+    while (!m_queue.isEmpty()) {
+        const QString accountId = m_queue.dequeue();
+        auto account = m_accounts.find(accountId);
+        if (account == m_accounts.end() || account->state != Queued) {
+            continue;
+        }
+
+        account->state = Running;
+        account->pendingTriggers = NoTrigger;
+        emitStateChanged(accountId, Running);
+        return accountId;
+    }
+    return QString();
+}
+
+QString DCalDavSyncStateMachine::takeRunnableAccount(const QString &accountId)
+{
+    if (accountId.isEmpty()) {
+        return QString();
+    }
+
+    auto account = m_accounts.find(accountId);
+    if (account == m_accounts.end() || account->state != Queued) {
+        return QString();
+    }
+
+    m_queue.removeAll(accountId);
+    account->state = Running;
+    account->pendingTriggers = NoTrigger;
+    emitStateChanged(accountId, Running);
+    return accountId;
+}
+
+bool DCalDavSyncStateMachine::complete(const QString &accountId, bool success)
+{
+    auto account = m_accounts.find(accountId);
+    if (account == m_accounts.end() || account->state != Running) {
+        return false;
+    }
+
+    if (account->pendingTriggers != NoTrigger) {
+        account->state = Queued;
+        m_queue.enqueue(accountId);
+        emitStateChanged(accountId, Queued);
+        emit syncRequested(accountId);
+        return true;
+    }
+
+    account->state = success ? Succeeded : Failed;
+    emitStateChanged(accountId, account->state);
+    return true;
+}
+
+DCalDavSyncStateMachine::State DCalDavSyncStateMachine::stateFor(const QString &accountId) const
+{
+    const auto account = m_accounts.constFind(accountId);
+    return account == m_accounts.constEnd() ? Idle : account->state;
+}
+
+DCalDavSyncStateMachine::Triggers DCalDavSyncStateMachine::pendingTriggersFor(const QString &accountId) const
+{
+    const auto account = m_accounts.constFind(accountId);
+    return account == m_accounts.constEnd() ? NoTrigger : account->pendingTriggers;
+}
+
+bool DCalDavSyncStateMachine::containsAccount(const QString &accountId) const
+{
+    return m_accounts.contains(accountId);
+}
+
+void DCalDavSyncStateMachine::emitStateChanged(const QString &accountId, State state)
+{
+    emit stateChanged(accountId, state);
+}

--- a/src/calendar-service/src/caldav/dcaldavsyncstatemachine.h
+++ b/src/calendar-service/src/caldav/dcaldavsyncstatemachine.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVSYNCSTATEMACHINE_H
+#define DCALDAVSYNCSTATEMACHINE_H
+
+#include <QObject>
+#include <QHash>
+#include <QMetaType>
+#include <QQueue>
+#include <QString>
+
+class DCalDavSyncStateMachine : public QObject
+{
+    Q_OBJECT
+public:
+    enum State {
+        Idle,
+        Queued,
+        Running,
+        Succeeded,
+        Failed,
+    };
+    Q_ENUM(State)
+
+    enum Trigger {
+        NoTrigger = 0x0,
+        StartupTrigger = 0x1,
+        ForegroundTrigger = 0x2,
+        DailyTrigger = 0x4,
+        ManualTrigger = 0x8,
+        NetworkRestoredTrigger = 0x10,
+        RetryTrigger = 0x20,
+        LocalChangeTrigger = 0x40,
+    };
+    Q_DECLARE_FLAGS(Triggers, Trigger)
+
+    explicit DCalDavSyncStateMachine(QObject *parent = nullptr);
+
+    bool registerAccount(const QString &accountId);
+    bool unregisterAccount(const QString &accountId);
+    bool requestSync(const QString &accountId, Trigger trigger);
+    int requestSyncForAll(Trigger trigger);
+
+    QString takeNextRunnableAccount();
+    QString takeRunnableAccount(const QString &accountId);
+    bool complete(const QString &accountId, bool success);
+
+    State stateFor(const QString &accountId) const;
+    Triggers pendingTriggersFor(const QString &accountId) const;
+    bool containsAccount(const QString &accountId) const;
+
+signals:
+    void stateChanged(const QString &accountId, DCalDavSyncStateMachine::State state);
+    void syncRequested(const QString &accountId);
+
+private:
+    struct AccountState {
+        State state = Idle;
+        Triggers pendingTriggers = NoTrigger;
+    };
+
+    void emitStateChanged(const QString &accountId, State state);
+
+    QHash<QString, AccountState> m_accounts;
+    QQueue<QString> m_queue;
+};
+
+Q_DECLARE_METATYPE(DCalDavSyncStateMachine::State)
+Q_DECLARE_OPERATORS_FOR_FLAGS(DCalDavSyncStateMachine::Triggers)
+
+#endif // DCALDAVSYNCSTATEMACHINE_H

--- a/src/calendar-service/src/caldav/dcaldavsyncstatusmapper.cpp
+++ b/src/calendar-service/src/caldav/dcaldavsyncstatusmapper.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavsyncstatusmapper.h"
+
+#include "dcaldavaccountstatus.h"
+
+DCalDavErrorCode DCalDavSyncStatusMapper::errorCodeForFailure(
+    const DCalDavTransport::Response &response)
+{
+    switch (response.httpStatus) {
+    case 401:
+        return DCalDavErrorCode::AuthenticationFailed;
+    case 403:
+        return DCalDavErrorCode::PermissionDenied;
+    case 409:
+    case 412:
+        return DCalDavErrorCode::Conflict;
+    case 429:
+        return DCalDavErrorCode::RateLimited;
+    case 503:
+        return DCalDavErrorCode::ServerUnavailable;
+    default:
+        break;
+    }
+
+    switch (response.error) {
+    case DCalDavTransport::InvalidUrl:
+    case DCalDavTransport::InsecureUrl:
+        return DCalDavErrorCode::InvalidRequest;
+    case DCalDavTransport::CertificateInvalid:
+        return DCalDavErrorCode::CertificateInvalid;
+    case DCalDavTransport::NetworkUnavailable:
+        return DCalDavErrorCode::NetworkUnavailable;
+    case DCalDavTransport::RequestTimedOut:
+        return DCalDavErrorCode::RequestTimedOut;
+    case DCalDavTransport::AuthenticationFailed:
+        return DCalDavErrorCode::AuthenticationFailed;
+    case DCalDavTransport::PermissionDenied:
+        return DCalDavErrorCode::PermissionDenied;
+    case DCalDavTransport::RateLimited:
+        return DCalDavErrorCode::RateLimited;
+    case DCalDavTransport::ServerUnavailable:
+        return DCalDavErrorCode::ServerUnavailable;
+    case DCalDavTransport::ResponseTooLarge:
+        return DCalDavErrorCode::ResponseTooLarge;
+    case DCalDavTransport::NetworkError:
+        return DCalDavErrorCode::NetworkError;
+    case DCalDavTransport::NoError:
+        return DCalDavErrorCode::NoError;
+    default:
+        return DCalDavErrorCode::Unknown;
+    }
+}
+
+int DCalDavSyncStatusMapper::statusForFailure(const DCalDavTransport::Response &response)
+{
+    return DCalDavSyncStatus::fromErrorCode(errorCodeForFailure(response));
+}

--- a/src/calendar-service/src/caldav/dcaldavsyncstatusmapper.h
+++ b/src/calendar-service/src/caldav/dcaldavsyncstatusmapper.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVSYNCSTATUSMAPPER_H
+#define DCALDAVSYNCSTATUSMAPPER_H
+
+#include "dcaldaverrorcode.h"
+#include "dcaldavtransport.h"
+
+class DCalDavSyncStatusMapper
+{
+public:
+    static DCalDavErrorCode errorCodeForFailure(
+        const DCalDavTransport::Response &response);
+    static int statusForFailure(const DCalDavTransport::Response &response);
+};
+
+#endif // DCALDAVSYNCSTATUSMAPPER_H

--- a/src/calendar-service/src/caldav/dcaldavutils.cpp
+++ b/src/calendar-service/src/caldav/dcaldavutils.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavutils.h"
+
+namespace DCalDavUtils {
+
+QString transportErrorText(const DCalDavTransport::Response &response)
+{
+    switch (response.error) {
+    case DCalDavTransport::CertificateInvalid:
+        return QStringLiteral("The server certificate is invalid.");
+    case DCalDavTransport::AuthenticationFailed:
+        return QStringLiteral("Incorrect username or password. Please try again.");
+    case DCalDavTransport::NetworkUnavailable:
+        return QStringLiteral("Unable to connect to the server. Please check your network connection and server address.");
+    case DCalDavTransport::RequestTimedOut:
+        return QStringLiteral("The server request timed out.");
+    case DCalDavTransport::PermissionDenied:
+        return QStringLiteral("The server denied access.");
+    default:
+        return QStringLiteral("CalDAV request failed (HTTP %1, error %2).")
+            .arg(response.httpStatus)
+            .arg(static_cast<int>(response.error));
+    }
+}
+
+QUrl eventUrl(const DCalDavCalendarInfo &calendar, const QString &uid)
+{
+    QUrl url(calendar.href);
+    QString path = url.path();
+    if (!path.endsWith(QLatin1Char('/'))) {
+        path.append(QLatin1Char('/'));
+    }
+    path.append(QString::fromLatin1(QUrl::toPercentEncoding(uid)));
+    path.append(QStringLiteral(".ics"));
+    url.setPath(path);
+    return url;
+}
+
+} // namespace DCalDavUtils

--- a/src/calendar-service/src/caldav/dcaldavutils.h
+++ b/src/calendar-service/src/caldav/dcaldavutils.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVUTILS_H
+#define DCALDAVUTILS_H
+
+#include "dcaldavcalendarinfo.h"
+#include "dcaldavtransport.h"
+
+#include <QString>
+#include <QUrl>
+
+namespace DCalDavUtils {
+
+/**
+ * @brief Converts a transport response into a user-facing CalDAV error.
+ * @param response The failed transport response.
+ * @return A stable English error description for the caller to localize.
+ */
+QString transportErrorText(const DCalDavTransport::Response &response);
+
+/**
+ * @brief Builds the deterministic resource URL for a new CalDAV event.
+ * @param calendar The target CalDAV calendar collection.
+ * @param uid The event UID.
+ * @return The URL of the event's .ics resource.
+ */
+QUrl eventUrl(const DCalDavCalendarInfo &calendar, const QString &uid);
+
+} // namespace DCalDavUtils
+
+#endif // DCALDAVUTILS_H


### PR DESCRIPTION
Add CalDAV sync jobs, state management, incremental sync, outbox
processing, retry handling, conflict recovery, and event mapping.

增加 CalDAV 同步任务、状态管理、增量同步、Outbox 处理、重试、
冲突恢复及日程映射功能。

Log: 增加 CalDAV 同步核心模块
PMS: TASK-393989
Influence: 提供 CalDAV 日程同步、失败重试和冲突恢复能力。

## Summary by Sourcery

Implement the CalDAV synchronization core with account orchestration, incremental event reconciliation, durable outbound changes, retries, and conflict recovery.

New Features:
- Add account-level CalDAV synchronization covering initial and incremental calendar synchronization with local event reconciliation and mapping.
- Add durable CalDAV Outbox processing for creating, updating, and deleting remote events.
- Add synchronization scheduling and per-account state management for startup, manual, network, periodic, local-change, and retry triggers.

Bug Fixes:
- Handle inaccessible calendars, stale sync tokens, provider limitations, transient failures, and interrupted operations through fallback and recovery paths.
- Preserve and recover recurring-event exceptions and resolve remote write conflicts with stored local and server versions.

Enhancements:
- Add retry scheduling, failure classification, synchronization status mapping, and user-facing transport error reporting.
- Map remote calendar events and categories to local schedules and schedule types while respecting calendar privileges and allocating colors.