### PR TITLE
feat(service): add CalDAV account management and DBus support

### DIFF
--- a/src/calendar-service/src/caldav/dcaldavaccountdeletioncleanup.cpp
+++ b/src/calendar-service/src/caldav/dcaldavaccountdeletioncleanup.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavaccountdeletioncleanup.h"
+#include "daccountmanagerdatabase.h"
+#include "commondef.h"
+#include <QFile>
+#include <QDir>
+void DCalDavAccountDeletionCleanup::resume(DAccountManagerDataBase *database, const QString &basePath)
+{
+    if (!database) return;
+    const QMap<QString, QString> cleanups = database->getCalDavAccountDeletionCleanups();
+    for (auto it = cleanups.constBegin(); it != cleanups.constEnd(); ++it) {
+        if (database->getAccountByID(it.key())) { database->deleteCalDavAccountDeletionCleanup(it.key()); continue; }
+        const QString dbName = it.value();
+        if (dbName.isEmpty() || dbName.contains(QChar::Null) || dbName.contains('/')
+            || dbName.contains(QStringLiteral(".."))) {
+            qCWarning(ServiceLogger) << "Ignoring unsafe CalDAV cleanup database name.";
+            continue;
+        }
+        const QString databasePath = QDir(basePath).filePath(dbName);
+        if (!QFile::exists(databasePath) || QFile::remove(databasePath))
+            database->deleteCalDavAccountDeletionCleanup(it.key());
+        else
+            qCWarning(ServiceLogger) << "Failed to remove pending CalDAV account database:" << databasePath;
+    }
+}

--- a/src/calendar-service/src/caldav/dcaldavaccountdeletioncleanup.h
+++ b/src/calendar-service/src/caldav/dcaldavaccountdeletioncleanup.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVACCOUNTDELETIONCLEANUP_H
+#define DCALDAVACCOUNTDELETIONCLEANUP_H
+#include <QString>
+class DAccountManagerDataBase;
+class DCalDavAccountDeletionCleanup
+{
+public:
+    static void resume(DAccountManagerDataBase *database, const QString &basePath);
+};
+#endif

--- a/src/calendar-service/src/caldav/dcaldavaccountregistrar.cpp
+++ b/src/calendar-service/src/caldav/dcaldavaccountregistrar.cpp
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavaccountregistrar.h"
+
+#include "daccountdatabase.h"
+#include "daccountmanagerdatabase.h"
+#include "dcaldavcredentialstore.h"
+#include "dcaldavcolorallocator.h"
+#include "dcaldavsyncjobmanager.h"
+#include "dcaldavxmlreader.h"
+#include "ddatabase.h"
+#include "dscheduletype.h"
+
+#include <QCoreApplication>
+#include <QSet>
+
+#include <QUrl>
+
+namespace {
+
+QString findCalendarID(const DCalDavCalendarInfo::List &calendars, const QString &href,
+                       QString *syncToken, bool *initialSyncCompleted)
+{
+    for (const DCalDavCalendarInfo &calendar : calendars) {
+        if (calendar.href == href) {
+            if (syncToken != nullptr) {
+                *syncToken = calendar.syncToken;
+            }
+            if (initialSyncCompleted != nullptr) {
+                *initialSyncCompleted = calendar.initialSyncCompleted;
+            }
+            return calendar.calendarId;
+        }
+    }
+    return QString();
+}
+
+QString createCalendarScheduleType(DAccountDataBase *database, const QString &accountID,
+                                    const QString &calendarID, const QString &displayName,
+                                    const QString &calendarColor, bool writable,
+                                    QString *errorMessage)
+{
+    Q_UNUSED(calendarColor);
+    if (database == nullptr || accountID.isEmpty() || calendarID.isEmpty()) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("CalDAV calendar type request is incomplete.");
+        }
+        return QString();
+    }
+
+    DTypeColor color;
+    color.setColorID(DDataBase::createUuid());
+    color.setColorCode(DCalDavColorAllocator::nextColor(database));
+    color.setPrivilege(DTypeColor::PriSystem);
+
+    DScheduleType::Ptr type(new DScheduleType(accountID));
+    const QString name = displayName.isEmpty()
+        ? QCoreApplication::translate("DCalDavAccountRegistrar", "Calendar")
+        : displayName;
+    type->setTypeName(name);
+    type->setDisplayName(name);
+    type->setTypePath(calendarID);
+    type->setTypeColor(color);
+    type->setDescription(QStringLiteral("CalDAV calendar"));
+    type->setPrivilege(writable ? DScheduleType::Privileges(
+                                      DScheduleType::Read | DScheduleType::Write | DScheduleType::Delete)
+                                : DScheduleType::Read);
+    type->setShowState(DScheduleType::Show);
+    type->setDtCreate(QDateTime::currentDateTime());
+    type->setDeleted(0);
+
+    if (!database->addTypeColor(color) || database->createScheduleType(type).isEmpty()) {
+        if (errorMessage != nullptr) {
+            *errorMessage = QStringLiteral("Failed to create CalDAV calendar type.");
+        }
+        return QString();
+    }
+    return type->typeID();
+}
+
+} // namespace
+
+DCalDavAccountRegistrar::DCalDavAccountRegistrar(QObject *parent)
+    : QObject(parent)
+    , m_discovery(this)
+{
+}
+
+void DCalDavAccountRegistrar::start(const Request &request, const Callback &callback)
+{
+    if (m_running) {
+        return;
+    }
+
+    m_request = request;
+    m_callback = callback;
+    m_password.clear();
+    m_running = true;
+
+    if (request.account.accountId.isEmpty() || request.account.serverUrl.isEmpty()
+        || request.account.username.isEmpty() || request.account.credentialRef.isEmpty()
+        || request.localDatabase == nullptr
+        || request.accountManagerDatabase == nullptr || request.jobManager == nullptr) {
+        finish(false, QStringLiteral("CalDAV account registration request is incomplete."));
+        return;
+    }
+
+    QString errorMessage;
+    if (!DCalDavCredentialStore::readPassword(request.account.credentialRef, m_password, &errorMessage)) {
+        finish(false, errorMessage, DCalDavTransport::Response(),
+               DCalDavErrorCode::StorageError);
+        return;
+    }
+
+    DCalDavReadOnlySync::Request discoveryRequest;
+    discoveryRequest.serverUrl = QUrl(request.account.serverUrl);
+    discoveryRequest.username = request.account.username;
+    discoveryRequest.password = m_password;
+    m_discovery.start(discoveryRequest, [this](const DCalDavReadOnlySync::Result &result) {
+        if (!result.success) {
+            finish(false, result.errorMessage, result.failureResponse, result.failureCode);
+            return;
+        }
+
+        DCalDavAccountSync::Request syncRequest;
+        syncRequest.accountID = m_request.account.accountId;
+        syncRequest.username = m_request.account.username;
+        syncRequest.password = m_password;
+        syncRequest.localDatabase = m_request.localDatabase;
+        syncRequest.accountManagerDatabase = m_request.accountManagerDatabase;
+        syncRequest.retryCount = m_request.account.retryCount;
+        QString errorMessage;
+        if (!persistCalendars(result.discovery, syncRequest, &errorMessage)) {
+            finish(false, errorMessage, DCalDavTransport::Response(),
+                   DCalDavErrorCode::StorageError);
+            return;
+        }
+        if (!m_request.jobManager->registerAccount(syncRequest)) {
+            finish(false, QStringLiteral("CalDAV account is already syncing."),
+                   DCalDavTransport::Response(), DCalDavErrorCode::Unknown);
+            return;
+        }
+        m_request.jobManager->requestSync(
+            m_request.account.accountId, DCalDavSyncStateMachine::StartupTrigger);
+        finish(true);
+    });
+}
+
+QString DCalDavAccountRegistrar::findScheduleTypeID(
+    const QString &calendarID, const DCalDavXmlReader::CalendarCollection &,
+    const DCalDavCalendarInfo::List &existing, QString *)
+{
+    for (const DCalDavCalendarInfo &calendar : existing) {
+        if (calendar.calendarId == calendarID) {
+            return calendar.scheduleTypeID;
+        }
+    }
+    // CalDAV event types are created from CATEGORIES after ICS parsing.
+    return QString();
+}
+
+bool DCalDavAccountRegistrar::persistCalendars(const DCalDavXmlReader::DiscoveryResult &discovery,
+                                               DCalDavAccountSync::Request &syncRequest,
+                                               QString *errorMessage)
+{
+    DCalDavCalendarInfo::List existing = m_request.accountManagerDatabase->getCalDavCalendarList(
+        m_request.account.accountId);
+    QSet<QString> discoveredHrefs;
+
+    for (const DCalDavXmlReader::CalendarCollection &collection : discovery.calendarCollections) {
+        const QUrl href(collection.href);
+        if (!href.isValid() || href.scheme() != QStringLiteral("https")) {
+            if (errorMessage != nullptr) {
+                *errorMessage = QStringLiteral("CalDAV discovery returned an insecure calendar URL.");
+            }
+            return false;
+        }
+        if (collection.privilegesKnown
+            && !(collection.privileges & DCalDavXmlReader::ReadPrivilege)) {
+            for (DCalDavCalendarInfo &calendar : existing) {
+                if (calendar.href == collection.href) {
+                    calendar.enabled = false;
+                    if (!m_request.accountManagerDatabase->upsertCalDavCalendar(calendar)) {
+                        if (errorMessage != nullptr) {
+                            *errorMessage = QStringLiteral("Failed to disable inaccessible CalDAV calendar.");
+                        }
+                        return false;
+                    }
+                    break;
+                }
+            }
+            continue;
+        }
+
+        QString syncToken;
+        bool initialSyncCompleted = false;
+        QString calendarID = findCalendarID(existing, collection.href, &syncToken,
+                                             &initialSyncCompleted);
+        if (calendarID.isEmpty()) {
+            calendarID = DDataBase::createUuid();
+        }
+
+        QString scheduleTypeID = findScheduleTypeID(calendarID, collection, existing, errorMessage);
+        const bool writable = (collection.privileges & DCalDavXmlReader::WritePrivilege) != 0;
+        if (scheduleTypeID.isEmpty()) {
+            scheduleTypeID = createCalendarScheduleType(
+                m_request.localDatabase, m_request.account.accountId, calendarID,
+                collection.displayName, collection.color, writable, errorMessage);
+            if (scheduleTypeID.isEmpty()) {
+                return false;
+            }
+        } else {
+            const DScheduleType::Ptr type = m_request.localDatabase->getScheduleTypeByID(scheduleTypeID);
+            if (type.isNull()) {
+                if (errorMessage != nullptr) {
+                    *errorMessage = QStringLiteral("Failed to load CalDAV calendar type.");
+                }
+                return false;
+            }
+            type->setPrivilege(writable ? DScheduleType::Privileges(
+                                             DScheduleType::Read | DScheduleType::Write | DScheduleType::Delete)
+                                       : DScheduleType::Read);
+            if (!m_request.localDatabase->updateScheduleType(type)) {
+                if (errorMessage != nullptr) {
+                    *errorMessage = QStringLiteral("Failed to update CalDAV calendar permissions.");
+                }
+                return false;
+            }
+        }
+
+        DCalDavCalendarInfo calendar;
+        calendar.calendarId = calendarID;
+        calendar.accountId = m_request.account.accountId;
+        calendar.href = collection.href;
+        calendar.displayName = collection.displayName;
+        calendar.color = collection.color;
+        calendar.scheduleTypeID = scheduleTypeID;
+        calendar.privileges = collection.privileges;
+        calendar.syncToken = syncToken;
+        calendar.initialSyncCompleted = initialSyncCompleted;
+        calendar.enabled = true;
+        if (!m_request.accountManagerDatabase->upsertCalDavCalendar(calendar)) {
+            if (errorMessage != nullptr) {
+                *errorMessage = QStringLiteral("Failed to persist discovered CalDAV calendar.");
+            }
+            return false;
+        }
+
+        DCalDavAccountSync::CalendarRequest calendarRequest;
+        calendarRequest.calendar = calendar;
+        calendarRequest.scheduleTypeID = calendar.scheduleTypeID;
+        syncRequest.calendars.append(calendarRequest);
+        discoveredHrefs.insert(collection.href);
+    }
+
+    for (DCalDavCalendarInfo &calendar : existing) {
+        if (calendar.enabled && !discoveredHrefs.contains(calendar.href)) {
+            calendar.enabled = false;
+            if (!m_request.accountManagerDatabase->upsertCalDavCalendar(calendar)) {
+                if (errorMessage != nullptr) {
+                    *errorMessage = QStringLiteral("Failed to disable removed CalDAV calendar.");
+                }
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+void DCalDavAccountRegistrar::finish(bool success, const QString &errorMessage,
+                                       const DCalDavTransport::Response &failureResponse,
+                                       DCalDavErrorCode failureCode)
+{
+    if (!m_running) {
+        return;
+    }
+
+    Result result;
+    result.success = success;
+    result.errorMessage = errorMessage;
+    result.failureResponse = failureResponse;
+    result.failureCode = success ? DCalDavErrorCode::NoError : failureCode;
+    if (success) {
+        result.calendarCount = m_request.accountManagerDatabase->getCalDavCalendarList(
+            m_request.account.accountId).size();
+        m_request.accountManagerDatabase->clearCalDavRetryState(m_request.account.accountId);
+    }
+    m_password.clear();
+    m_running = false;
+    if (m_callback) {
+        const Callback callback = m_callback;
+        m_callback = Callback();
+        callback(result);
+    }
+}

--- a/src/calendar-service/src/caldav/dcaldavaccountregistrar.h
+++ b/src/calendar-service/src/caldav/dcaldavaccountregistrar.h
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVACCOUNTREGISTRAR_H
+#define DCALDAVACCOUNTREGISTRAR_H
+
+#include "dcaldavaccountinfo.h"
+#include "dcaldaverrorcode.h"
+#include "dcaldavaccountsync.h"
+#include "dcaldavreadonlysync.h"
+
+#include <QObject>
+
+#include <functional>
+
+class DAccountDataBase;
+class DAccountManagerDataBase;
+class DCalDavSyncJobManager;
+
+class DCalDavAccountRegistrar : public QObject
+{
+    Q_OBJECT
+public:
+    struct Request {
+        DCalDavAccountInfo account;
+        DAccountDataBase *localDatabase = nullptr;
+        DAccountManagerDataBase *accountManagerDatabase = nullptr;
+        DCalDavSyncJobManager *jobManager = nullptr;
+    };
+
+    struct Result {
+        bool success = false;
+        QString errorMessage;
+        DCalDavTransport::Response failureResponse;
+        DCalDavErrorCode failureCode = DCalDavErrorCode::NoError;
+        int calendarCount = 0;
+    };
+
+    typedef std::function<void(const Result &)> Callback;
+
+    explicit DCalDavAccountRegistrar(QObject *parent = nullptr);
+
+    void start(const Request &request, const Callback &callback);
+
+private:
+    QString findScheduleTypeID(const QString &calendarID,
+                               const DCalDavXmlReader::CalendarCollection &collection,
+                               const DCalDavCalendarInfo::List &existing,
+                               QString *errorMessage);
+    /**
+     * @brief Persists discovered collections and prepares their initial sync requests.
+     *
+     * Reuses existing calendar identities and sync tokens, creates or updates
+     * local schedule types and permissions, disables missing collections, then
+     * appends every readable collection to the account synchronization request.
+     */
+    bool persistCalendars(const DCalDavXmlReader::DiscoveryResult &discovery,
+                          DCalDavAccountSync::Request &syncRequest,
+                          QString *errorMessage);
+    void finish(bool success, const QString &errorMessage = QString(),
+                const DCalDavTransport::Response &failureResponse = DCalDavTransport::Response(),
+                DCalDavErrorCode failureCode = DCalDavErrorCode::Unknown);
+
+    DCalDavReadOnlySync m_discovery;
+    Request m_request;
+    Callback m_callback;
+    QString m_password;
+    bool m_running = false;
+};
+
+#endif // DCALDAVACCOUNTREGISTRAR_H

--- a/src/calendar-service/src/caldav/dcaldavreadonlysync.cpp
+++ b/src/calendar-service/src/caldav/dcaldavreadonlysync.cpp
@@ -1,0 +1,397 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcaldavreadonlysync.h"
+
+#include "dcaldavdiscovery.h"
+#include "commondef.h"
+
+namespace {
+
+DCalDavValidationError::Type validationErrorForResponse(
+    const DCalDavTransport::Response &response)
+{
+    if (response.error == DCalDavTransport::CertificateInvalid) {
+        return DCalDavValidationError::CertificateInvalid;
+    }
+    if (response.error == DCalDavTransport::AuthenticationFailed
+        || response.httpStatus == 401) {
+        return DCalDavValidationError::AuthenticationFailed;
+    }
+    if (response.error == DCalDavTransport::PermissionDenied
+        || response.httpStatus == 403) {
+        return DCalDavValidationError::ServerRejected;
+    }
+    return DCalDavValidationError::NetworkUnavailable;
+}
+
+DCalDavValidationError::Type validationErrorForDiscoveryParse(
+    const DCalDavTransport::Response &response)
+{
+    // A resource endpoint returning 404/405/501 indicates that the server does
+    // not expose the requested CalDAV discovery resource. A successful HTTP
+    // response with malformed XML is a parse failure instead.
+    if (response.httpStatus == 404 || response.httpStatus == 405
+        || response.httpStatus == 501) {
+        return DCalDavValidationError::UnsupportedCalDav;
+    }
+    return DCalDavValidationError::ParseError;
+}
+
+DCalDavErrorCode errorCodeForValidation(
+    DCalDavValidationError::Type validationError,
+    const DCalDavTransport::Response &response)
+{
+    switch (validationError) {
+    case DCalDavValidationError::AuthenticationFailed:
+        return DCalDavErrorCode::AuthenticationFailed;
+    case DCalDavValidationError::UnsupportedCalDav:
+        return DCalDavErrorCode::UnsupportedCalDav;
+    case DCalDavValidationError::CertificateInvalid:
+        return DCalDavErrorCode::CertificateInvalid;
+    case DCalDavValidationError::ParseError:
+        return DCalDavErrorCode::ParseError;
+    case DCalDavValidationError::ServerRejected:
+        return DCalDavErrorCode::PermissionDenied;
+    case DCalDavValidationError::NetworkUnavailable:
+        return DCalDavErrorCode::NetworkUnavailable;
+    case DCalDavValidationError::Other:
+        return DCalDavErrorCode::Unknown;
+    case DCalDavValidationError::NoError:
+    default:
+        break;
+    }
+
+    switch (response.error) {
+    case DCalDavTransport::CertificateInvalid:
+        return DCalDavErrorCode::CertificateInvalid;
+    case DCalDavTransport::AuthenticationFailed:
+        return DCalDavErrorCode::AuthenticationFailed;
+    case DCalDavTransport::PermissionDenied:
+        return DCalDavErrorCode::PermissionDenied;
+    case DCalDavTransport::NetworkUnavailable:
+        return DCalDavErrorCode::NetworkUnavailable;
+    case DCalDavTransport::RequestTimedOut:
+        return DCalDavErrorCode::RequestTimedOut;
+    case DCalDavTransport::RateLimited:
+        return DCalDavErrorCode::RateLimited;
+    case DCalDavTransport::ServerUnavailable:
+        return DCalDavErrorCode::ServerUnavailable;
+    case DCalDavTransport::NetworkError:
+        return DCalDavErrorCode::NetworkError;
+    default:
+        return DCalDavErrorCode::Unknown;
+    }
+}
+
+QString transportErrorText(const DCalDavTransport::Response &response)
+{
+    switch (response.error) {
+    case DCalDavTransport::CertificateInvalid:
+        return QStringLiteral("The server certificate is invalid.");
+    case DCalDavTransport::AuthenticationFailed:
+        return QStringLiteral("Incorrect username or password. Please try again.");
+    case DCalDavTransport::NetworkUnavailable:
+        return QStringLiteral("Unable to connect to the server. Please check your network connection and server address.");
+    case DCalDavTransport::RequestTimedOut:
+        return QStringLiteral("The server request timed out.");
+    case DCalDavTransport::PermissionDenied:
+        return QStringLiteral("The server denied access.");
+    default:
+        return QStringLiteral("CalDAV request failed (HTTP %1, error %2).")
+            .arg(response.httpStatus)
+            .arg(static_cast<int>(response.error));
+    }
+}
+
+} // namespace
+
+DCalDavReadOnlySync::DCalDavReadOnlySync(QObject *parent)
+    : QObject(parent)
+    , m_transport()
+{
+}
+
+void DCalDavReadOnlySync::start(const Request &request, const Callback &callback)
+{
+    if (m_running) {
+        return;
+    }
+
+    m_request = request;
+    m_callback = callback;
+    m_result = Result();
+    m_candidates.clear();
+    m_candidateIndex = 0;
+    m_collectionIndex = 0;
+    m_running = true;
+
+    qCDebug(ServiceLogger) << "CalDAV validation started"
+                          << "endpoint:" << DCalDavTransport::urlForLog(request.serverUrl)
+                          << "usernamePresent:" << !request.username.isEmpty();
+    if (!DCalDavTransport::isSecureUrl(request.serverUrl) || request.username.isEmpty()) {
+        finish(false, QStringLiteral("Invalid CalDAV server URL or username."),
+               DCalDavValidationError::NetworkUnavailable);
+        return;
+    }
+
+    m_candidates = DCalDavDiscovery::discoveryCandidates(request.serverUrl);
+    sendPrincipalRequest();
+}
+
+void DCalDavReadOnlySync::sendPrincipalRequest()
+{
+    if (m_candidateIndex >= m_candidates.size()) {
+        if (m_result.failureResponse.error != DCalDavTransport::NoError) {
+            finish(false, transportErrorText(m_result.failureResponse));
+        } else {
+            finish(false, QStringLiteral("This server does not support CalDAV."));
+        }
+        return;
+    }
+
+    const QUrl candidate = m_candidates.at(m_candidateIndex);
+    const DCalDavTransport::Request request = DCalDavDiscovery::currentUserPrincipalRequest(
+        candidate, m_request.username, m_request.password);
+    m_transport.send(request, [this, candidate](const DCalDavTransport::Response &response) {
+        if (response.error != DCalDavTransport::NoError) {
+            qCWarning(ServiceLogger) << "CalDAV principal discovery request failed"
+                                     << "endpoint:" << DCalDavTransport::urlForLog(candidate)
+                                     << "httpStatus:" << response.httpStatus
+                                     << "error:" << static_cast<int>(response.error);
+            m_result.failureResponse = response;
+            // Authentication and certificate failures are terminal validation errors.
+            // Do not probe another discovery candidate after a TLS failure: the
+            // requirement is to terminate the connection and report the certificate
+            // problem directly to the user.
+            if (response.error == DCalDavTransport::AuthenticationFailed
+                || response.error == DCalDavTransport::PermissionDenied
+                || response.error == DCalDavTransport::CertificateInvalid) {
+                finish(false, transportErrorText(response));
+                return;
+            }
+            tryNextPrincipalCandidate(transportErrorText(response));
+            return;
+        }
+
+        DCalDavXmlReader::DiscoveryResult discovery;
+        QString errorMessage;
+        if (!DCalDavXmlReader::parseDiscovery(response.body, discovery, &errorMessage)) {
+            tryNextPrincipalCandidate(
+                errorMessage.isEmpty() ? QStringLiteral("Unable to parse the DAV discovery response.") : errorMessage,
+                validationErrorForDiscoveryParse(response));
+            return;
+        }
+        if (discovery.currentUserPrincipalHref.isEmpty()) {
+            tryNextPrincipalCandidate(QStringLiteral("Principal is missing."),
+                                      DCalDavValidationError::UnsupportedCalDav);
+            return;
+        }
+
+        qCDebug(ServiceLogger) << "CalDAV principal discovery succeeded"
+                                 << "httpStatus:" << response.httpStatus;
+        m_result.discovery.currentUserPrincipalHref = discovery.currentUserPrincipalHref;
+        if (!discovery.principalDisplayName.isEmpty()) {
+            m_result.discovery.principalDisplayName = discovery.principalDisplayName;
+        }
+        const QUrl baseUrl = response.finalUrl.isValid() ? response.finalUrl : candidate;
+        sendCalendarHomeRequest(DCalDavDiscovery::resolveHref(baseUrl, discovery.currentUserPrincipalHref));
+    });
+}
+
+void DCalDavReadOnlySync::tryNextPrincipalCandidate(
+    const QString &errorMessage, DCalDavValidationError::Type validationError)
+{
+    ++m_candidateIndex;
+    if (m_candidateIndex < m_candidates.size()) {
+        sendPrincipalRequest();
+        return;
+    }
+    finish(false, errorMessage, validationError);
+}
+
+void DCalDavReadOnlySync::sendCalendarHomeRequest(const QUrl &principalUrl)
+{
+    const DCalDavTransport::Request request = DCalDavDiscovery::calendarHomeSetRequest(
+        principalUrl, m_request.username, m_request.password);
+    m_transport.send(request, [this, principalUrl](const DCalDavTransport::Response &response) {
+        if (response.error != DCalDavTransport::NoError) {
+            qCWarning(ServiceLogger) << "CalDAV calendar home request failed"
+                                     << "endpoint:" << DCalDavTransport::urlForLog(principalUrl)
+                                     << "httpStatus:" << response.httpStatus
+                                     << "error:" << static_cast<int>(response.error);
+            m_result.failureResponse = response;
+            finish(false, transportErrorText(response));
+            return;
+        }
+
+        qCDebug(ServiceLogger) << "CalDAV calendar home request succeeded"
+                                 << "httpStatus:" << response.httpStatus;
+        DCalDavXmlReader::DiscoveryResult discovery;
+        QString errorMessage;
+        if (!DCalDavXmlReader::parseDiscovery(response.body, discovery, &errorMessage)) {
+            finish(false,
+                   errorMessage.isEmpty() ? QStringLiteral("Unable to parse the DAV discovery response.") : errorMessage,
+                   validationErrorForDiscoveryParse(response));
+            return;
+        }
+        if (discovery.calendarHomeSetHref.isEmpty()) {
+            finish(false, QStringLiteral("Calendar home is missing."),
+                   DCalDavValidationError::UnsupportedCalDav);
+            return;
+        }
+
+        if (m_result.discovery.principalDisplayName.isEmpty()) {
+            m_result.discovery.principalDisplayName = discovery.principalDisplayName;
+        }
+        const QUrl baseUrl = response.finalUrl.isValid() ? response.finalUrl : principalUrl;
+        sendCollectionsRequest(DCalDavDiscovery::resolveHref(baseUrl, discovery.calendarHomeSetHref));
+    });
+}
+
+void DCalDavReadOnlySync::sendCollectionsRequest(const QUrl &homeUrl)
+{
+    const DCalDavTransport::Request request = DCalDavDiscovery::calendarCollectionsRequest(
+        homeUrl, m_request.username, m_request.password);
+    m_transport.send(request, [this, homeUrl](const DCalDavTransport::Response &response) {
+        if (response.error != DCalDavTransport::NoError) {
+            qCWarning(ServiceLogger) << "CalDAV calendar collections request failed"
+                                     << "endpoint:" << DCalDavTransport::urlForLog(homeUrl)
+                                     << "httpStatus:" << response.httpStatus
+                                     << "error:" << static_cast<int>(response.error);
+            m_result.failureResponse = response;
+            finish(false, transportErrorText(response));
+            return;
+        }
+
+        qCDebug(ServiceLogger) << "CalDAV calendar collections request succeeded"
+                                 << "httpStatus:" << response.httpStatus;
+        DCalDavXmlReader::DiscoveryResult discovery;
+        QString errorMessage;
+        if (!DCalDavXmlReader::parseDiscovery(response.body, discovery, &errorMessage)) {
+            finish(false,
+                   QStringLiteral("Unable to parse the data returned by the server. Please verify the server address or try again later."),
+                   validationErrorForDiscoveryParse(response));
+            return;
+        }
+
+        qCDebug(ServiceLogger) << "CalDAV calendar collections discovered"
+                                 << "count:" << discovery.calendarCollections.size();
+        m_result.discovery.calendarHomeSetHref = homeUrl.toString();
+        const QUrl baseUrl = response.finalUrl.isValid() ? response.finalUrl : homeUrl;
+        for (DCalDavXmlReader::CalendarCollection &collection : discovery.calendarCollections) {
+            collection.href = DCalDavDiscovery::resolveHref(baseUrl, collection.href).toString();
+            if (collection.href.isEmpty()) {
+                finish(false, QStringLiteral("CalDAV discovery returned an invalid calendar URL."),
+                       DCalDavValidationError::ParseError);
+                return;
+            }
+            if (collection.privilegesKnown
+                && !(collection.privileges & DCalDavXmlReader::ReadPrivilege)) {
+                continue;
+            }
+            m_result.discovery.calendarCollections.append(collection);
+        }
+        if (m_result.discovery.calendarCollections.isEmpty()) {
+            finish(false, QStringLiteral("No readable CalDAV calendar was found."),
+                   DCalDavValidationError::UnsupportedCalDav);
+            return;
+        }
+        m_collectionIndex = 0;
+        sendCalendarQuery();
+    });
+}
+
+void DCalDavReadOnlySync::sendCalendarQuery()
+{
+    if (m_collectionIndex >= m_result.discovery.calendarCollections.size()) {
+        finish(true);
+        return;
+    }
+
+    const DCalDavXmlReader::CalendarCollection &collection =
+        m_result.discovery.calendarCollections.at(m_collectionIndex);
+    const QUrl collectionUrl(collection.href);
+    const DCalDavTransport::Request request = DCalDavCalendarQuery::firstSyncRequest(
+        collectionUrl, m_request.username, m_request.password, QDateTime::currentDateTimeUtc());
+    m_transport.send(request, [this, collectionUrl](const DCalDavTransport::Response &response) {
+        if (response.error != DCalDavTransport::NoError) {
+            qCWarning(ServiceLogger) << "CalDAV calendar query request failed"
+                                     << "endpoint:" << DCalDavTransport::urlForLog(collectionUrl)
+                                     << "httpStatus:" << response.httpStatus
+                                     << "error:" << static_cast<int>(response.error);
+            m_result.failureResponse = response;
+            finish(false, transportErrorText(response));
+            return;
+        }
+
+        qCDebug(ServiceLogger) << "CalDAV calendar query request succeeded"
+                              << "endpoint:" << DCalDavTransport::urlForLog(collectionUrl)
+                              << "httpStatus:" << response.httpStatus;
+        DCalDavCalendarQuery::RemoteEventList events;
+        QString errorMessage;
+        if (!DCalDavCalendarQuery::parseResponse(response.body, events, &errorMessage)) {
+            finish(false,
+                   QStringLiteral("Unable to parse the data returned by the server. Please verify the server address or try again later."),
+                   DCalDavValidationError::ParseError);
+            return;
+        }
+
+        for (DCalDavCalendarQuery::RemoteEvent event : events) {
+            event.href = DCalDavDiscovery::resolveHref(
+                response.finalUrl.isValid() ? response.finalUrl : collectionUrl, event.href).toString();
+            if (event.deleted) {
+                qCWarning(ServiceLogger) << "Skipping deleted CalDAV resource during validation";
+                continue;
+            }
+
+            if (event.calendarData.isEmpty() || event.uid.isEmpty()) {
+                qCWarning(ServiceLogger) << "Skipping CalDAV validation resource without calendar data.";
+                continue;
+            }
+
+            DSchedule::Ptr schedule;
+            if (!DCalDavEventMapper::toSchedule(event, schedule, &errorMessage)) {
+                qCWarning(ServiceLogger) << "Skipping unparsable CalDAV validation resource.";
+                continue;
+            }
+            m_result.remoteEvents.append(event);
+            m_result.schedules.append(schedule);
+        }
+
+        ++m_collectionIndex;
+        sendCalendarQuery();
+    });
+}
+
+void DCalDavReadOnlySync::finish(bool success, const QString &errorMessage,
+                                  DCalDavValidationError::Type validationError)
+{
+    if (!m_running) {
+        return;
+    }
+
+    m_result.success = success;
+    m_result.validationError = success ? DCalDavValidationError::NoError
+        : (validationError != DCalDavValidationError::NoError
+               ? validationError
+               : (m_result.failureResponse.error != DCalDavTransport::NoError
+                      ? validationErrorForResponse(m_result.failureResponse)
+                      : DCalDavValidationError::UnsupportedCalDav));
+    m_result.failureCode = success
+        ? DCalDavErrorCode::NoError
+        : errorCodeForValidation(m_result.validationError, m_result.failureResponse);
+    m_result.errorMessage = errorMessage;
+    qCDebug(ServiceLogger) << "CalDAV validation finished"
+                          << "success:" << success
+                          << "validationError:" << static_cast<int>(m_result.validationError)
+                          << "errorPresent:" << !errorMessage.isEmpty();
+    m_request.password.clear();
+    m_running = false;
+    if (m_callback) {
+        const Callback callback = m_callback;
+        m_callback = Callback();
+        callback(m_result);
+    }
+}

--- a/src/calendar-service/src/caldav/dcaldavreadonlysync.h
+++ b/src/calendar-service/src/caldav/dcaldavreadonlysync.h
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCALDAVREADONLYSYNC_H
+#define DCALDAVREADONLYSYNC_H
+
+#include "dcaldavcalendarquery.h"
+#include "dcaldaverrorcode.h"
+#include "dcaldaveventmapper.h"
+#include "dcaldavxmlreader.h"
+#include "dcaldavvalidationerror.h"
+
+#include <QObject>
+#include <QUrl>
+
+#include <functional>
+
+class DCalDavReadOnlySync : public QObject
+{
+public:
+    struct Request {
+        QUrl serverUrl;
+        QString username;
+        QString password;
+    };
+
+    struct Result {
+        bool success = false;
+        DCalDavValidationError::Type validationError = DCalDavValidationError::NoError;
+        DCalDavErrorCode failureCode = DCalDavErrorCode::NoError;
+        QString errorMessage;
+        DCalDavTransport::Response failureResponse;
+        DCalDavXmlReader::DiscoveryResult discovery;
+        DCalDavCalendarQuery::RemoteEventList remoteEvents;
+        DSchedule::List schedules;
+    };
+
+    typedef std::function<void(const Result &)> Callback;
+
+    explicit DCalDavReadOnlySync(QObject *parent = nullptr);
+
+    void start(const Request &request, const Callback &callback);
+
+private:
+    void sendPrincipalRequest();
+    void sendCalendarHomeRequest(const QUrl &principalUrl);
+    void sendCollectionsRequest(const QUrl &homeUrl);
+    void sendCalendarQuery();
+    void finish(bool success, const QString &errorMessage = QString(),
+                DCalDavValidationError::Type validationError = DCalDavValidationError::NoError);
+    void tryNextPrincipalCandidate(
+        const QString &errorMessage,
+        DCalDavValidationError::Type validationError = DCalDavValidationError::NoError);
+
+    DCalDavTransport m_transport;
+    Request m_request;
+    Callback m_callback;
+    Result m_result;
+    QList<QUrl> m_candidates;
+    int m_candidateIndex = 0;
+    int m_collectionIndex = 0;
+    bool m_running = false;
+};
+
+#endif // DCALDAVREADONLYSYNC_H

--- a/src/calendar-service/src/calendarDataManager/daccountmanagemodule.cpp
+++ b/src/calendar-service/src/calendarDataManager/daccountmanagemodule.cpp
@@ -6,13 +6,202 @@
 #include "commondef.h"
 #include "units.h"
 #include "calendarprogramexitcontrol.h"
+#include "dcaldavaccountregistrar.h"
+#include "dcaldavaccountdeletioncleanup.h"
+#include "dcaldavaccountstatus.h"
+#include "dcaldavcredentialstore.h"
+#include "dcalendareventlog.h"
+#include "dcaldavprofile.h"
+#include "dcaldavreadonlysync.h"
+#include "dcaldavretrypolicy.h"
+#include "dcaldavsyncstatusmapper.h"
+#include "dcaldavtransport.h"
 #include <qstandardpaths.h>
+#include <QUrl>
+#include <QCoreApplication>
+#include <QHash>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <DSysInfo>
+
+#include <limits>
 
 const QString firstDayOfWeek_key = "firstDayOfWeek";
 const QString shortTimeFormat_key = "shortTimeFormat";
 const QString firstDayOfWeekSource_key = "firstDayOfWeekSource";
 const QString shortTimeFormatSource_key = "shortTimeFormatSource";
+
+namespace {
+
+QString localTypeIDForCategories(DAccountDataBase *localDatabase,
+                                const QStringList &categories,
+                                QString *unmatchedOriginalType)
+{
+    if (unmatchedOriginalType != nullptr) {
+        unmatchedOriginalType->clear();
+    }
+
+    QStringList originalTypes;
+    for (const QString &category : categories) {
+        const QString normalized = category.trimmed();
+        if (!normalized.isEmpty()) {
+            originalTypes.append(normalized);
+        }
+    }
+    QHash<QString, QString> categoryTypeMap;
+    const auto addCategoryAliases = [&categoryTypeMap](const QString &targetName,
+                                                        const QStringList &aliases) {
+        for (const QString &alias : aliases) {
+            categoryTypeMap.insert(alias.toLower(), targetName);
+        }
+    };
+    addCategoryAliases(QStringLiteral("Work"),
+                       {QStringLiteral("Work"), QStringLiteral("Business"),
+                        QCoreApplication::translate("DAccountDataBase", "Work")});
+    addCategoryAliases(QStringLiteral("Life"),
+                       {QStringLiteral("Life"), QStringLiteral("Personal"),
+                        QCoreApplication::translate("DAccountDataBase", "Life")});
+    addCategoryAliases(QStringLiteral("Other"),
+                       {QStringLiteral("Other"),
+                        QCoreApplication::translate("DAccountDataBase", "Other")});
+
+    QString targetName = QStringLiteral("Other");
+    bool matched = false;
+    for (const QString &typeName : originalTypes) {
+        const auto target = categoryTypeMap.constFind(typeName.toLower());
+        if (target == categoryTypeMap.constEnd()) {
+            continue;
+        }
+        targetName = target.value();
+        matched = true;
+        break;
+    }
+
+    for (const DScheduleType::Ptr &type : localDatabase->getScheduleTypeList()) {
+        if (!type.isNull()
+            && (type->typeName().compare(targetName, Qt::CaseInsensitive) == 0
+                || type->displayName().compare(targetName, Qt::CaseInsensitive) == 0)) {
+            if (!matched && unmatchedOriginalType != nullptr) {
+                *unmatchedOriginalType = originalTypes.join(QStringLiteral(", "));
+            }
+            return type->typeID();
+        }
+    }
+    return QString();
+}
+
+
+QString defaultCalDavAccountColor(const QString &accountID)
+{
+    static const QStringList colors = {
+        QStringLiteral("#5B8FF9"), QStringLiteral("#61DDAA"), QStringLiteral("#65789B"),
+        QStringLiteral("#F6BD16"), QStringLiteral("#7262FD"), QStringLiteral("#78D3F8"),
+        QStringLiteral("#9661BC"), QStringLiteral("#F6903D"), QStringLiteral("#008685")
+    };
+    return colors.at(static_cast<uint>(qHash(accountID)) % colors.size());
+}
+
+bool restoreCalDavConflictSnapshot(const DAccountModule::Ptr &module,
+                                   const DCalDavOutboxItem &item)
+{
+    if (module.isNull() || item.localScheduleID.isEmpty() || item.conflictIcs.isEmpty()) {
+        return true;
+    }
+    DAccountDataBase *database = module->accountDatabase();
+    if (database == nullptr) {
+        return false;
+    }
+    const DSchedule::Ptr currentSchedule = database->getScheduleByScheduleID(item.localScheduleID);
+    DSchedule::Ptr snapshot;
+    if (!DSchedule::fromIcsString(snapshot, item.conflictIcs) || snapshot.isNull()
+        || currentSchedule.isNull()) {
+        return false;
+    }
+    snapshot->setUid(item.localScheduleID);
+    snapshot->setScheduleTypeID(currentSchedule->scheduleTypeID());
+    return database->updateSchedule(snapshot);
+}
+
+void appendOriginalTypeToSummary(const DSchedule::Ptr &schedule, const QString &originalType)
+{
+    if (schedule.isNull() || originalType.trimmed().isEmpty()) {
+        return;
+    }
+    const QString suffix = QCoreApplication::translate(
+        "DAccountManageModule", "[Original Type: %1]").arg(originalType.trimmed());
+    if (!schedule->summary().contains(suffix)) {
+        schedule->setSummary(schedule->summary() + suffix);
+    }
+}
+
+bool applyServerSnapshotToLocal(const DAccountModule::Ptr &module,
+                                const DCalDavOutboxItem &item)
+{
+    if (module.isNull() || item.localScheduleID.isEmpty() || item.serverIcs.isEmpty()) {
+        return false;
+    }
+
+    DAccountDataBase *database = module->accountDatabase();
+    if (database == nullptr) {
+        return false;
+    }
+    const DSchedule::Ptr currentSchedule = database->getScheduleByScheduleID(item.localScheduleID);
+    DSchedule::Ptr serverSchedule;
+    if (currentSchedule.isNull() || !DSchedule::fromIcsString(serverSchedule, item.serverIcs)
+        || serverSchedule.isNull()) {
+        return false;
+    }
+    serverSchedule->setUid(item.localScheduleID);
+    serverSchedule->setScheduleTypeID(currentSchedule->scheduleTypeID());
+    serverSchedule->setCreated(currentSchedule->created());
+    return database->updateSchedule(serverSchedule);
+}
+
+/**
+ * @brief Prepares a conflicted Outbox item for a local-version retry.
+ * @param item Persisted conflict item whose server state must be discarded.
+ * @return The retry item, using Modify for an already-created remote resource.
+ */
+DCalDavOutboxItem resetConflictOutboxItem(const DCalDavOutboxItem &item)
+{
+    DCalDavOutboxItem retryItem = item;
+    retryItem.baseEtag.clear();
+    retryItem.retryCount = 0;
+    retryItem.nextRetryAt = QDateTime();
+    retryItem.failureType = DCalDavOutboxItem::NoFailure;
+    retryItem.conflictIcs.clear();
+    retryItem.serverIcs.clear();
+    if (retryItem.operationType == DCalDavOutboxItem::CreateOperation) {
+        retryItem.operationType = DCalDavOutboxItem::ModifyOperation;
+    }
+    return retryItem;
+}
+
+bool applyServerCalDavConflict(const DAccountModule::Ptr &module,
+                               DAccountManagerDataBase *accountManagerDatabase,
+                               const DCalDavOutboxItem &item)
+{
+    if (module.isNull() || accountManagerDatabase == nullptr || item.operationID.isEmpty()
+        || item.serverIcs.isEmpty()) {
+        return false;
+    }
+
+    const DCalDavEventMappingInfo mapping = accountManagerDatabase
+        ->getCalDavEventMappingByLocalScheduleID(item.accountID, item.localScheduleID);
+    if (mapping.href.isEmpty() || !applyServerSnapshotToLocal(module, item)) {
+        return false;
+    }
+
+    DCalDavEventMappingInfo updatedMapping = mapping;
+    updatedMapping.originalIcs = item.serverIcs;
+    // The conflict response may not include a reliable ETag. Fetch it before
+    // the next write instead of reusing the stale pre-conflict value.
+    updatedMapping.etag.clear();
+    return accountManagerDatabase->upsertCalDavEventMapping(updatedMapping)
+        && accountManagerDatabase->deleteCalDavOutboxItemIfCurrent(item);
+}
+
+} // namespace
 
 DAccountManageModule::DAccountManageModule(QObject *parent)
     : QObject(parent)
@@ -43,7 +232,8 @@ DAccountManageModule::DAccountManageModule(QObject *parent)
     QString newDB(newDbPath + "/" + "accountmanager.db");
     qCDebug(ServiceLogger) << "Setting account manager DB path to:" << newDB;
     m_accountManagerDB->setDBPath(newDB);
-    m_accountManagerDB->dbOpen();
+    m_accountManagerDB->ensureSchema();
+    resumeCalDavAccountDeletionCleanups();
 
     QDBusConnection::RegisterOptions options = QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllSignals | QDBusConnection::ExportAllProperties;
     QDBusConnection sessionBus = QDBusConnection::sessionBus();
@@ -59,8 +249,23 @@ DAccountManageModule::DAccountManageModule(QObject *parent)
         if (!m_isSupportUid && account->accountType() == DAccount::Account_UnionID) {
             continue;
         }
-        DAccountModule::Ptr accountModule = DAccountModule::Ptr(new DAccountModule(account));
+        DAccountModule::Ptr accountModule = DAccountModule::Ptr(new DAccountModule(account, m_accountManagerDB.data()));
         QObject::connect(accountModule.data(), &DAccountModule::signalSettingChange, this, &DAccountManageModule::slotSettingChange);
+        const QString accountID = account->accountID();
+        QObject::connect(accountModule.data(), &DAccountModule::signalCalDavScheduleCreateFailed,
+                         this, [this, accountID](int) {
+            emit calDavAccountStatusChanged(accountID);
+        });
+        QObject::connect(accountModule.data(), &DAccountModule::signalCalDavLocalChange,
+                         this, [this, accountID]() {
+            qCDebug(ServiceLogger) << "Requesting immediate CalDAV sync after local change"
+                                   << "accountID:" << accountID;
+            if (!m_calDavSyncJobManager.requestSync(
+                    accountID, DCalDavSyncStateMachine::LocalChangeTrigger)) {
+                qCWarning(ServiceLogger) << "Failed to request immediate CalDAV sync"
+                                         << "accountID:" << accountID;
+            }
+        });
         m_accountModuleMap[account->accountID()] = accountModule;
         DAccountService::Ptr accountService = DAccountService::Ptr(new DAccountService(account->dbusPath(), account->dbusInterface(), accountModule, this));
         if (!sessionBus.registerObject(accountService->getPath(), accountService->getInterface(), accountService.data(), options)) {
@@ -69,7 +274,8 @@ DAccountManageModule::DAccountManageModule(QObject *parent)
         } else {
             m_AccountServiceMap[account->accountType()].insert(account->accountID(), accountService);
             //如果是网络帐户则开启定时下载任务
-            if (account->isNetWorkAccount() && account->accountState().testFlag(DAccount::Account_Open)) {
+            if (account->isNetWorkAccount() && account->accountType() != DAccount::Account_CalDav
+                && account->accountState().testFlag(DAccount::Account_Open)) {
                 qCDebug(ServiceLogger) << "Starting download task for network account:" << account->accountID();
                 accountModule->downloadTaskhanding(0);
             }
@@ -79,6 +285,28 @@ DAccountManageModule::DAccountManageModule(QObject *parent)
 
     connect(&m_timer, &QTimer::timeout, this, &DAccountManageModule::slotClientIsOpen);
     m_timer.start(2000);
+    QTimer::singleShot(0, this, &DAccountManageModule::registerCalDavAccounts);
+
+    connect(&m_calDavDailyTimer, &QTimer::timeout,
+            this, &DAccountManageModule::slotCalDavDailySync);
+    scheduleNextCalDavDailySync();
+    connect(&m_calDavRetryTimer, &QTimer::timeout,
+            this, &DAccountManageModule::slotCalDavRetry);
+    scheduleNextCalDavRetry();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (QNetworkInformation::loadDefaultBackend()) {
+        if (QNetworkInformation *networkInformation = QNetworkInformation::instance()) {
+            connect(networkInformation, &QNetworkInformation::reachabilityChanged, this,
+                    [this](QNetworkInformation::Reachability reachability) {
+                slotCalDavOnlineStateChanged(
+                    reachability == QNetworkInformation::Reachability::Online);
+            });
+        }
+    }
+#else
+    connect(&m_networkConfigurationManager, &QNetworkConfigurationManager::onlineStateChanged,
+            this, &DAccountManageModule::slotCalDavOnlineStateChanged);
+#endif
 
     if (m_isSupportUid) {
         qCDebug(ServiceLogger) << "UID is supported, connecting signals.";
@@ -88,6 +316,30 @@ DAccountManageModule::DAccountManageModule(QObject *parent)
 
     //第一次启动加载完成后发送帐户改变信号
     // emit signalLoginStatusChange();
+    connect(&m_calDavSyncJobManager, &DCalDavSyncJobManager::accountSyncStateChanged,
+            this, [this](const QString &accountID, DCalDavSyncStateMachine::State) {
+        emit calDavAccountStatusChanged(accountID);
+    });
+    connect(&m_calDavSyncJobManager, &DCalDavSyncJobManager::accountSyncDataChanged,
+            this, [this](const QString &accountID) {
+        const DAccountModule::Ptr accountModule = m_accountModuleMap.value(accountID);
+        if (!accountModule.isNull()) {
+            accountModule->notifyScheduleDataChanged();
+        }
+    });
+    connect(&m_calDavSyncJobManager, &DCalDavSyncJobManager::accountScheduleCreateFailed,
+            this, [this](const QString &accountID, int createFailure) {
+        const DAccountModule::Ptr accountModule = m_accountModuleMap.value(accountID);
+        if (!accountModule.isNull()) {
+            accountModule->notifyCalDavScheduleCreateFailed(createFailure);
+        }
+    });
+    connect(&m_calDavSyncJobManager, &DCalDavSyncJobManager::accountSyncFinished,
+            this, [this](const QString &, bool, const QString &,
+                        const DCalDavTransport::Response &) {
+        scheduleNextCalDavRetry();
+    });
+
     qCDebug(ServiceLogger) << "DAccountManageModule constructed.";
 }
 
@@ -198,9 +450,698 @@ void DAccountManageModule::notifyMsgHanding(const QString &accountID, const QStr
 void DAccountManageModule::downloadByAccountID(const QString &accountID)
 {
     qCDebug(ServiceLogger) << "Triggering download for account:" << accountID;
+    const DAccount::Ptr account = m_accountManagerDB->getAccountByID(accountID);
+    if (account && account->accountType() == DAccount::Account_CalDav) {
+        m_calDavSyncJobManager.requestSync(accountID, DCalDavSyncStateMachine::ManualTrigger);
+        return;
+    }
     if (m_accountModuleMap.contains(accountID)) {
         m_accountModuleMap[accountID]->accountDownload();
     }
+}
+
+QString DAccountManageModule::getCalDavAccountStatusList()
+{
+    return m_accountManagerDB->getCalDavAccountStatusList();
+}
+
+QString DAccountManageModule::getCalDavAccountConfig(const QString &accountID)
+{
+    DCalDavAccountInfo accountInfo;
+    const DAccount::Ptr account = m_accountManagerDB->getAccountByID(accountID);
+    if (account.isNull() || account->accountType() != DAccount::Account_CalDav
+        || !m_accountManagerDB->getCalDavAccountInfo(accountID, accountInfo)) {
+        return QString();
+    }
+
+    QJsonObject object;
+    object.insert(QStringLiteral("accountID"), accountInfo.accountId);
+    object.insert(QStringLiteral("providerType"), accountInfo.providerType);
+    object.insert(QStringLiteral("serverUrl"), accountInfo.serverUrl);
+    object.insert(QStringLiteral("username"), accountInfo.username);
+    object.insert(QStringLiteral("accountColor"), accountInfo.accountColor);
+    object.insert(QStringLiteral("displayName"), account->displayName());
+    return QString::fromUtf8(QJsonDocument(object).toJson(QJsonDocument::Compact));
+}
+
+QString DAccountManageModule::validateCalDavAccountForUpdate(
+    const QString &accountID, int providerType, const QString &serverUrl,
+    const QString &username, const QString &credentialRef)
+{
+    DCalDavAccountInfo oldInfo;
+    const DAccount::Ptr account = m_accountManagerDB->getAccountByID(accountID);
+    if (account.isNull() || account->accountType() != DAccount::Account_CalDav
+        || !m_accountManagerDB->getCalDavAccountInfo(accountID, oldInfo)) {
+        return QString();
+    }
+
+    const QString effectiveCredentialRef = credentialRef.isEmpty()
+        ? oldInfo.credentialRef : credentialRef;
+    return validateCalDavAccount(providerType, serverUrl, username, effectiveCredentialRef);
+}
+
+QString DAccountManageModule::validateCalDavAccount(int providerType, const QString &serverUrl,
+                                                     const QString &username, const QString &credentialRef)
+{
+    const QString requestID = DDataBase::createUuid();
+    const auto finishValidationFailure = [this, requestID](
+        DCalDavValidationError::Type validationError) {
+        QTimer::singleShot(0, this, [this, requestID, validationError]() {
+            emit calDavAccountValidationFinished(requestID, false,
+                                                 static_cast<int>(validationError), QString(), QString());
+        });
+    };
+
+    const QUrl normalizedServerUrl = DCalDavProviderProfile::normalizeServerUrl(serverUrl);
+    if (providerType < DCalDavProviderProfile::Provider_DingTalk
+        || providerType > DCalDavProviderProfile::Provider_Other
+        || !normalizedServerUrl.isValid()
+        || username.trimmed().isEmpty() || credentialRef.isEmpty()) {
+        DCalendarEventLog::instance().reportLoginValidationFinished(
+            false, DCalDavValidationError::Other);
+        finishValidationFailure(DCalDavValidationError::Other);
+        return requestID;
+    }
+
+    QString password;
+    QString errorMessage;
+    if (!DCalDavCredentialStore::readPassword(credentialRef, password, &errorMessage)) {
+        qCWarning(ServiceLogger) << "Failed to read CalDAV validation credential"
+                                 << "errorPresent:" << !errorMessage.isEmpty();
+        DCalendarEventLog::instance().reportLoginValidationFinished(
+            false, DCalDavValidationError::Other);
+        finishValidationFailure(DCalDavValidationError::Other);
+        return requestID;
+    }
+
+    DCalDavReadOnlySync *validator = new DCalDavReadOnlySync(this);
+    m_calDavValidationJobs.insert(requestID, validator);
+
+    DCalDavReadOnlySync::Request request;
+    request.serverUrl = normalizedServerUrl;
+    request.username = username.trimmed();
+    request.password = password;
+    password.clear();
+    validator->start(request, [this, requestID, validator](const DCalDavReadOnlySync::Result &result) {
+        DCalendarEventLog::instance().reportLoginValidationFinished(
+            result.success, result.validationError);
+        m_calDavValidationJobs.remove(requestID);
+        validator->deleteLater();
+        emit calDavAccountValidationFinished(requestID, result.success,
+                                             static_cast<int>(result.validationError),
+                                             result.errorMessage,
+                                             result.discovery.principalDisplayName);
+    });
+    return requestID;
+}
+
+QString DAccountManageModule::createCalDavAccount(int providerType, const QString &serverUrl,
+                                                   const QString &username, const QString &credentialRef,
+                                                   const QString &displayName)
+{
+    const QUrl normalizedServerUrl = DCalDavProviderProfile::normalizeServerUrl(serverUrl);
+    if (providerType < DCalDavProviderProfile::Provider_DingTalk
+        || providerType > DCalDavProviderProfile::Provider_Other
+        || !normalizedServerUrl.isValid()
+        || username.trimmed().isEmpty() || credentialRef.isEmpty()) {
+        return QString();
+    }
+
+    QString password;
+    QString errorMessage;
+    if (!DCalDavCredentialStore::readPassword(credentialRef, password, &errorMessage)) {
+        qCWarning(ServiceLogger) << "Failed to read CalDAV account credential"
+                                 << "errorPresent:" << !errorMessage.isEmpty();
+        return QString();
+    }
+    password.clear();
+
+    const DCalDavProviderProfile profile = DCalDavProviderProfile::forProvider(
+        static_cast<DCalDavProviderProfile::ProviderType>(providerType));
+    const QString accountDisplayName = displayName.trimmed().isEmpty()
+        ? profile.displayName : displayName.trimmed();
+
+    const QString normalizedUsername = username.trimmed();
+    DAccount::Ptr account(new DAccount(DAccount::Account_CalDav));
+    account->setAccountName(normalizedUsername);
+    account->setDisplayName(accountDisplayName);
+    initAccountDBusInfo(account);
+    SqlTransactionLocker accountTransaction({DDataBase::NameAccountManager});
+    if (!accountTransaction.isValid() || m_accountManagerDB->addAccountInfo(account).isEmpty()) {
+        return QString();
+    }
+
+    DCalDavAccountInfo accountInfo;
+    accountInfo.accountId = account->accountID();
+    accountInfo.providerType = providerType;
+    accountInfo.serverUrl = normalizedServerUrl.toString();
+    accountInfo.username = normalizedUsername;
+    accountInfo.credentialRef = credentialRef;
+    accountInfo.accountColor = defaultCalDavAccountColor(account->accountID());
+    if (!m_accountManagerDB->upsertCalDavAccountInfo(accountInfo)
+        || !accountTransaction.commit()) {
+        return QString();
+    }
+
+    DAccountModule::Ptr accountModule(new DAccountModule(account, m_accountManagerDB.data()));
+    const QString accountID = account->accountID();
+    QObject::connect(accountModule.data(), &DAccountModule::signalCalDavScheduleCreateFailed,
+                     this, [this, accountID](int) {
+        emit calDavAccountStatusChanged(accountID);
+    });
+    QObject::connect(accountModule.data(), &DAccountModule::signalCalDavLocalChange,
+                     this, [this, accountID]() {
+        qCDebug(ServiceLogger) << "Requesting immediate CalDAV sync after local change"
+                               << "accountID:" << accountID;
+        if (!m_calDavSyncJobManager.requestSync(
+                accountID, DCalDavSyncStateMachine::LocalChangeTrigger)) {
+            qCWarning(ServiceLogger) << "Failed to request immediate CalDAV sync"
+                                     << "accountID:" << accountID;
+        }
+    });
+    DAccountService::Ptr accountService(new DAccountService(
+        account->dbusPath(), account->dbusInterface(), accountModule, this));
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+    const QDBusConnection::RegisterOptions options = QDBusConnection::ExportAllSlots
+        | QDBusConnection::ExportAllSignals | QDBusConnection::ExportAllProperties;
+    if (!sessionBus.registerObject(accountService->getPath(), accountService->getInterface(),
+                                   accountService.data(), options)) {
+        accountModule->removeDB();
+        SqlTransactionLocker cleanupTransaction({DDataBase::NameAccountManager});
+        if (cleanupTransaction.isValid()
+            && m_accountManagerDB->deleteCalDavAccountInfo(account->accountID())
+            && m_accountManagerDB->deleteAccountInfo(account->accountID())) {
+            cleanupTransaction.commit();
+        }
+        return QString();
+    }
+
+    m_accountList.append(account);
+    m_accountModuleMap.insert(account->accountID(), accountModule);
+    m_AccountServiceMap[account->accountType()].insert(account->accountID(), accountService);
+    registerCalDavAccount(account);
+    emit signalLoginStatusChange();
+    return account->accountID();
+}
+
+bool DAccountManageModule::updateCalDavAccount(const QString &accountID, int providerType,
+                                                 const QString &serverUrl, const QString &username,
+                                                 const QString &credentialRef, const QString &displayName)
+{
+    const QUrl normalizedServerUrl = DCalDavProviderProfile::normalizeServerUrl(serverUrl);
+    const QString normalizedUsername = username.trimmed();
+    if (providerType < DCalDavProviderProfile::Provider_DingTalk
+        || providerType > DCalDavProviderProfile::Provider_Other
+        || !normalizedServerUrl.isValid() || normalizedUsername.isEmpty()
+        || !m_accountModuleMap.contains(accountID) || m_calDavRegistrars.contains(accountID)) {
+        return false;
+    }
+    const DAccountModule::Ptr accountModule = m_accountModuleMap.value(accountID);
+    const DAccount::Ptr account = accountModule->account();
+    if (account.isNull() || account->accountType() != DAccount::Account_CalDav) {
+        return false;
+    }
+
+    DCalDavAccountInfo oldInfo;
+    if (!m_accountManagerDB->getCalDavAccountInfo(accountID, oldInfo)) {
+        return false;
+    }
+    if (DCalDavProviderProfile::normalizeServerUrl(oldInfo.serverUrl) != normalizedServerUrl) {
+        qCWarning(ServiceLogger) << "Changing the CalDAV server requires removing and re-adding the account.";
+        return false;
+    }
+
+    const DCalDavProviderProfile profile = DCalDavProviderProfile::forProvider(
+        static_cast<DCalDavProviderProfile::ProviderType>(providerType));
+    const QString newDisplayName = displayName.trimmed().isEmpty()
+        ? profile.displayName : displayName.trimmed();
+    DCalDavAccountInfo newInfo = oldInfo;
+    newInfo.providerType = providerType;
+    newInfo.serverUrl = normalizedServerUrl.toString();
+    newInfo.username = normalizedUsername;
+
+    if (!credentialRef.isEmpty()) {
+        QString password;
+        QString errorMessage;
+        if (!DCalDavCredentialStore::readPassword(credentialRef, password, &errorMessage)) {
+            qCWarning(ServiceLogger) << "Failed to read CalDAV update credential"
+                                     << "errorPresent:" << !errorMessage.isEmpty();
+            return false;
+        }
+        password.clear();
+        newInfo.credentialRef = credentialRef;
+    }
+
+    SqlTransactionLocker accountTransaction({DDataBase::NameAccountManager});
+    if (!accountTransaction.isValid() || !m_accountManagerDB->upsertCalDavAccountInfo(newInfo)) {
+        return false;
+    }
+
+    const QString oldAccountName = account->accountName();
+    const QString oldDisplayName = account->displayName();
+    account->setAccountName(normalizedUsername);
+    account->setDisplayName(newDisplayName);
+    if (!m_accountManagerDB->updateAccountInfo(account) || !accountTransaction.commit()) {
+        account->setAccountName(oldAccountName);
+        account->setDisplayName(oldDisplayName);
+        return false;
+    }
+
+    if (!credentialRef.isEmpty() && credentialRef != oldInfo.credentialRef
+        && !oldInfo.credentialRef.isEmpty()
+        && !DCalDavCredentialStore::deletePassword(oldInfo.credentialRef)) {
+        qCWarning(ServiceLogger) << "CalDAV account was updated but its previous credential could not be removed.";
+    }
+
+    registerCalDavAccount(account);
+    emit signalLoginStatusChange();
+    emit calDavAccountStatusChanged(accountID);
+    return true;
+}
+
+bool DAccountManageModule::deleteCalDavAccount(const QString &accountID)
+{
+    return deleteCalDavAccountInternal(accountID, true);
+}
+
+bool DAccountManageModule::deleteCalDavAccountWithLocalDataOption(const QString &accountID,
+                                                                    bool deleteLocalData)
+{
+    return deleteCalDavAccountInternal(accountID, deleteLocalData);
+}
+
+bool DAccountManageModule::resolveAllCalDavConflicts(const QString &accountID, bool keepLocal)
+{
+    if (!m_accountModuleMap.contains(accountID)) {
+        return false;
+    }
+    const DCalDavOutboxItem::List conflicts = m_accountManagerDB->getCalDavConflictItems(accountID);
+    if (conflicts.isEmpty()) {
+        return false;
+    }
+    const DAccountModule::Ptr module = m_accountModuleMap.value(accountID);
+    if (module.isNull() || module->accountDatabase() == nullptr) {
+        return false;
+    }
+    std::unique_ptr<SqlTransactionLocker> transaction(new SqlTransactionLocker(
+        {module->accountDatabase()->getConnectionName(), DDataBase::NameAccountManager}));
+    if (!transaction->isValid()) {
+        return false;
+    }
+
+    for (const DCalDavOutboxItem &item : conflicts) {
+        bool success = false;
+        if (keepLocal) {
+            if (!restoreCalDavConflictSnapshot(module, item)) {
+                transaction->rollback();
+                return false;
+            }
+            success = m_accountManagerDB->upsertCalDavOutboxItem(
+                resetConflictOutboxItem(item));
+        } else {
+            success = applyServerCalDavConflict(module, m_accountManagerDB.data(), item);
+        }
+        if (!success) {
+            // Abort all still-active database transactions immediately. The
+            // locker destructor remains a safety net for other early returns.
+            transaction->rollback();
+            return false;
+        }
+    }
+    if (!transaction->commit()) {
+        if (!keepLocal) {
+            for (const DCalDavOutboxItem &item : conflicts) {
+                if (!applyServerSnapshotToLocal(module, item)) {
+                    qCWarning(ServiceLogger)
+                        << "Failed to restore server conflict snapshot after transaction failure.";
+                }
+            }
+        }
+        return false;
+    }
+
+    module->notifyScheduleDataChanged();
+    m_calDavSyncJobManager.requestSync(accountID, DCalDavSyncStateMachine::ManualTrigger);
+    emit calDavAccountStatusChanged(accountID);
+    return true;
+}
+
+bool DAccountManageModule::resolveCalDavConflict(const QString &accountID,
+                                                   const QString &localScheduleID,
+                                                   bool keepLocal)
+{
+    if (!m_accountModuleMap.contains(accountID) || localScheduleID.isEmpty()) {
+        return false;
+    }
+    const DCalDavOutboxItem item = m_accountManagerDB->getCalDavOutboxItem(
+        accountID, localScheduleID);
+    if (item.operationID.isEmpty() || item.failureType != DCalDavOutboxItem::ConflictFailure) {
+        return false;
+    }
+    const DAccountModule::Ptr module = m_accountModuleMap.value(accountID);
+    if (module.isNull() || module->accountDatabase() == nullptr) {
+        return false;
+    }
+    std::unique_ptr<SqlTransactionLocker> transaction(new SqlTransactionLocker(
+        {module->accountDatabase()->getConnectionName(), DDataBase::NameAccountManager}));
+    if (!transaction->isValid()) {
+        return false;
+    }
+
+    bool success = false;
+    if (keepLocal) {
+        if (!restoreCalDavConflictSnapshot(module, item)) {
+            return false;
+        }
+        success = m_accountManagerDB->upsertCalDavOutboxItem(
+            resetConflictOutboxItem(item));
+    } else {
+        success = applyServerCalDavConflict(module, m_accountManagerDB.data(), item);
+    }
+    if (success && !transaction->commit()) {
+        if (!keepLocal) {
+            success = applyServerSnapshotToLocal(module, item);
+            if (!success) {
+                qCWarning(ServiceLogger)
+                    << "Failed to restore server conflict snapshot after transaction failure.";
+            }
+        } else {
+            success = false;
+        }
+    }
+    if (success) {
+        module->notifyScheduleDataChanged();
+        m_calDavSyncJobManager.requestSync(accountID, DCalDavSyncStateMachine::ManualTrigger);
+        emit calDavAccountStatusChanged(accountID);
+    }
+    return success;
+}
+
+bool DAccountManageModule::migrateCalDavSchedulesToLocal(
+    const DAccountModule::Ptr &calDavModule, const DAccountModule::Ptr &localModule,
+    QStringList *createdScheduleIDs, QStringList *createdScheduleTypeIDs)
+{
+    if (calDavModule.isNull() || localModule.isNull() || createdScheduleIDs == nullptr
+        || createdScheduleTypeIDs == nullptr) {
+        return false;
+    }
+
+    DAccountDataBase *sourceDatabase = calDavModule->accountDatabase();
+    DAccountDataBase *targetDatabase = localModule->accountDatabase();
+    if (sourceDatabase == nullptr || targetDatabase == nullptr) {
+        return false;
+    }
+
+    Q_UNUSED(createdScheduleTypeIDs);
+    const DScheduleType::List sourceTypes = sourceDatabase->getScheduleTypeList();
+    for (const DScheduleType::Ptr &sourceType : sourceTypes) {
+        if (sourceType.isNull()) {
+            continue;
+        }
+
+        const DSchedule::List sourceSchedules = sourceDatabase->getScheduleListByTypeID(
+            sourceType->typeID());
+        for (const DSchedule::Ptr &sourceSchedule : sourceSchedules) {
+            if (sourceSchedule.isNull()) {
+                continue;
+            }
+
+            QString unmatchedOriginalType;
+            const QString targetTypeID = localTypeIDForCategories(
+                targetDatabase, sourceSchedule->categories(), &unmatchedOriginalType);
+            if (targetTypeID.isEmpty()) {
+                return false;
+            }
+
+            DSchedule::Ptr targetSchedule(new DSchedule(*sourceSchedule));
+            targetSchedule->setScheduleTypeID(targetTypeID);
+            // Keep the remote UID as the local copy's stable identity. This
+            // allows a later remove-and-readd cycle to recognize the same
+            // event and avoid creating a second local copy.
+            const QString localScheduleID = sourceSchedule->uid();
+            if (localScheduleID.isEmpty()) {
+                return false;
+            }
+            if (targetDatabase->scheduleExistsByScheduleID(localScheduleID)) {
+                continue;
+            }
+            targetSchedule->setSchedulingID(localScheduleID, localScheduleID);
+            appendOriginalTypeToSummary(targetSchedule, unmatchedOriginalType);
+            const QString targetScheduleID = targetDatabase->createSchedule(targetSchedule);
+            if (targetScheduleID.isEmpty()) {
+                return false;
+            }
+            createdScheduleIDs->append(targetScheduleID);
+        }
+    }
+    return true;
+}
+
+bool DAccountManageModule::deleteCalDavAccountInternal(const QString &accountID,
+                                                         bool deleteLocalData)
+{
+    if (!m_accountModuleMap.contains(accountID) || m_calDavRegistrars.contains(accountID)) {
+        return false;
+    }
+    const DAccountModule::Ptr accountModule = m_accountModuleMap.value(accountID);
+    const DAccount::Ptr account = accountModule->account();
+    DCalDavAccountInfo accountInfo;
+    if (account.isNull() || account->accountType() != DAccount::Account_CalDav
+        || !m_accountManagerDB->getCalDavAccountInfo(accountID, accountInfo)) {
+        return false;
+    }
+    if (!m_calDavSyncJobManager.cancelAccount(accountID)) {
+        return false;
+    }
+    const auto restoreSyncJob = [&]() {
+        registerCalDavAccount(account);
+    };
+
+    QStringList createdScheduleIDs;
+    QStringList createdScheduleTypeIDs;
+    DAccountModule::Ptr localModule;
+    const auto rollbackLocalMigration = [&]() {
+        if (localModule.isNull()) {
+            return;
+        }
+        DAccountDataBase *database = localModule->accountDatabase();
+        for (const QString &scheduleID : createdScheduleIDs) {
+            database->deleteScheduleByScheduleID(scheduleID, 1);
+        }
+        for (const QString &typeID : createdScheduleTypeIDs) {
+            database->deleteScheduleTypeByID(typeID);
+        }
+    };
+
+    if (!deleteLocalData) {
+        for (const DAccount::Ptr &candidate : m_accountList) {
+            if (candidate && candidate->accountType() == DAccount::Account_Local) {
+                localModule = m_accountModuleMap.value(candidate->accountID());
+                break;
+            }
+        }
+        if (localModule.isNull()
+            || !migrateCalDavSchedulesToLocal(accountModule, localModule, &createdScheduleIDs,
+                                              &createdScheduleTypeIDs)) {
+            rollbackLocalMigration();
+            restoreSyncJob();
+            return false;
+        }
+    }
+
+    if (!m_accountManagerDB->upsertCalDavAccountDeletionCleanup(accountID, account->dbName())) {
+        rollbackLocalMigration();
+        restoreSyncJob();
+        return false;
+    }
+    if (!m_accountManagerDB->deleteCalDavAccountData(accountID)) {
+        m_accountManagerDB->deleteCalDavAccountDeletionCleanup(accountID);
+        rollbackLocalMigration();
+        restoreSyncJob();
+        return false;
+    }
+
+    if (!accountInfo.credentialRef.isEmpty()
+        && !DCalDavCredentialStore::deletePassword(accountInfo.credentialRef)) {
+        qCWarning(ServiceLogger) << "CalDAV account was deleted but its credential could not be removed.";
+    }
+
+    QDBusConnection::sessionBus().unregisterObject(account->dbusPath());
+    m_AccountServiceMap[account->accountType()].remove(accountID);
+    m_accountModuleMap.remove(accountID);
+    m_accountList.removeOne(account);
+    const bool databaseRemoved = accountModule->removeDB();
+    if (databaseRemoved) {
+        m_accountManagerDB->deleteCalDavAccountDeletionCleanup(accountID);
+    } else {
+        qCWarning(ServiceLogger) << "CalDAV account data database removal is pending"
+                                 << "accountID:" << accountID
+                                 << "database:" << account->dbName();
+    }
+    if (!deleteLocalData && !localModule.isNull()) {
+        localModule->notifyScheduleDataChanged();
+    }
+    emit signalLoginStatusChange();
+    return true;
+}
+
+void DAccountManageModule::resumeCalDavAccountDeletionCleanups()
+{
+    DCalDavAccountDeletionCleanup::resume(m_accountManagerDB.data(), getDBPath());
+}
+
+bool DAccountManageModule::updateCalDavCredentialReference(const QString &accountID, const QString &credentialRef)
+{
+    const bool updated = m_accountManagerDB->updateCalDavCredentialReference(accountID, credentialRef);
+    if (updated) {
+        const DAccount::Ptr account = m_accountManagerDB->getAccountByID(accountID);
+        if (account && account->accountType() == DAccount::Account_CalDav
+            && m_calDavSyncJobManager.stateFor(accountID) != DCalDavSyncStateMachine::Running) {
+            registerCalDavAccount(account);
+        }
+        emit calDavAccountStatusChanged(accountID);
+    }
+    return updated;
+}
+
+void DAccountManageModule::scheduleNextCalDavDailySync()
+{
+    const QDateTime now = QDateTime::currentDateTime();
+    QDateTime next(now.date(), QTime(9, 0));
+    if (next <= now) {
+        next = next.addDays(1);
+    }
+    m_calDavDailyTimer.start(static_cast<int>(now.msecsTo(next)));
+}
+
+void DAccountManageModule::slotCalDavDailySync()
+{
+    m_calDavSyncJobManager.requestSyncForAll(DCalDavSyncStateMachine::DailyTrigger);
+    scheduleNextCalDavDailySync();
+}
+
+void DAccountManageModule::scheduleNextCalDavRetry()
+{
+    const QDateTime retryAt = m_accountManagerDB->earliestCalDavRetryAt();
+    if (!retryAt.isValid()) {
+        m_calDavRetryTimer.stop();
+        return;
+    }
+
+    const qint64 delay = QDateTime::currentDateTimeUtc().msecsTo(retryAt.toUTC());
+    const qint64 boundedDelay = qBound<qint64>(
+        1, delay, static_cast<qint64>(std::numeric_limits<int>::max()));
+    m_calDavRetryTimer.start(static_cast<int>(boundedDelay));
+}
+
+void DAccountManageModule::slotCalDavRetry()
+{
+    const QDateTime now = QDateTime::currentDateTimeUtc();
+    QStringList accountIDs = m_accountManagerDB->dueCalDavAccountRetryIDs(now);
+    const QStringList outboxAccountIDs = m_accountManagerDB->dueCalDavOutboxAccountIDs(now);
+    for (const QString &accountID : outboxAccountIDs) {
+        if (!accountIDs.contains(accountID)) {
+            accountIDs.append(accountID);
+        }
+    }
+    for (const QString &accountID : accountIDs) {
+        if (m_calDavSyncJobManager.containsAccount(accountID)) {
+            m_calDavSyncJobManager.requestSync(accountID, DCalDavSyncStateMachine::RetryTrigger);
+            continue;
+        }
+        for (const DAccount::Ptr &account : m_accountList) {
+            if (!account.isNull() && account->accountID() == accountID) {
+                registerCalDavAccount(account);
+                break;
+            }
+        }
+    }
+    scheduleNextCalDavRetry();
+}
+
+void DAccountManageModule::slotCalDavOnlineStateChanged(bool isOnline)
+{
+    if (isOnline) {
+        m_calDavSyncJobManager.requestSyncForAll(DCalDavSyncStateMachine::NetworkRestoredTrigger);
+    }
+}
+
+void DAccountManageModule::registerCalDavAccounts()
+{
+    for (const DAccount::Ptr &account : m_accountList) {
+        if (account->accountType() == DAccount::Account_CalDav) {
+            registerCalDavAccount(account);
+        }
+    }
+}
+
+void DAccountManageModule::registerCalDavAccount(const DAccount::Ptr &account)
+{
+    if (account.isNull() || account->accountID().isEmpty()
+        || !m_accountModuleMap.contains(account->accountID())
+        || m_calDavRegistrars.contains(account->accountID())) {
+        return;
+    }
+
+    DCalDavAccountInfo accountInfo;
+    if (!m_accountManagerDB->getCalDavAccountInfo(account->accountID(), accountInfo)) {
+        m_accountManagerDB->updateCalDavSyncStatus(
+            account->accountID(), DCalDavSyncStatus::Failed, QDateTime(),
+            QStringLiteral("CalDAV account configuration is missing."),
+            DCalDavErrorCode::StorageError);
+        emit calDavAccountStatusChanged(account->accountID());
+        return;
+    }
+    if (accountInfo.nextRetryAt.isValid()
+        && accountInfo.nextRetryAt > QDateTime::currentDateTimeUtc()) {
+        return;
+    }
+
+    const DAccountModule::Ptr accountModule = m_accountModuleMap.value(account->accountID());
+
+    DCalDavAccountRegistrar::Request request;
+    request.account = accountInfo;
+    request.localDatabase = accountModule->accountDatabase();
+    request.accountManagerDatabase = m_accountManagerDB.data();
+    request.jobManager = &m_calDavSyncJobManager;
+
+    const QString accountID = account->accountID();
+    DCalDavAccountRegistrar *registrar = new DCalDavAccountRegistrar(this);
+    m_calDavRegistrars.insert(accountID, registrar);
+    registrar->start(request, [this, accountID, registrar](
+                         const DCalDavAccountRegistrar::Result &result) {
+        m_calDavRegistrars.remove(accountID);
+        if (result.success) {
+            const DAccountModule::Ptr accountModule = m_accountModuleMap.value(accountID);
+            if (!accountModule.isNull()) {
+                accountModule->notifyScheduleDataChanged();
+            }
+        } else {
+            DCalDavAccountInfo accountInfo;
+            if (m_accountManagerDB->getCalDavAccountInfo(accountID, accountInfo)
+                && result.failureResponse.error != DCalDavTransport::NoError) {
+                const DCalDavRetryPolicy::Decision retry = DCalDavRetryPolicy::decide(
+                    result.failureResponse, accountInfo.retryCount);
+                if (retry.retry) {
+                    m_accountManagerDB->updateCalDavRetryState(
+                        accountID, accountInfo.retryCount + 1,
+                        QDateTime::currentDateTimeUtc().addSecs(retry.delaySeconds),
+                        result.errorMessage, result.failureCode);
+                } else {
+                    m_accountManagerDB->updateCalDavSyncStatus(
+                        accountID, DCalDavSyncStatus::fromErrorCode(result.failureCode),
+                        QDateTime(), result.errorMessage, result.failureCode);
+                }
+            } else {
+                m_accountManagerDB->updateCalDavSyncStatus(
+                    accountID, DCalDavSyncStatus::fromErrorCode(result.failureCode),
+                    QDateTime(), result.errorMessage, result.failureCode);
+            }
+        }
+        scheduleNextCalDavRetry();
+        emit calDavAccountStatusChanged(accountID);
+        registrar->deleteLater();
+    });
 }
 
 void DAccountManageModule::uploadNetWorkAccountData()
@@ -208,6 +1149,9 @@ void DAccountManageModule::uploadNetWorkAccountData()
     qCDebug(ServiceLogger) << "Uploading network account data for all accounts.";
     QMap<QString, DAccountModule::Ptr>::const_iterator iter = m_accountModuleMap.constBegin();
     for (; iter != m_accountModuleMap.constEnd(); ++iter) {
+        if (iter.value()->account()->accountType() == DAccount::Account_CalDav) {
+            continue;
+        }
         iter.value()->uploadNetWorkAccountData();
     }
 }
@@ -238,8 +1182,12 @@ void DAccountManageModule::calendarOpen(bool isOpen)
     if (isOpen) {
         QMap<QString, DAccountModule::Ptr>::iterator iter = m_accountModuleMap.begin();
         for (; iter != m_accountModuleMap.end(); ++iter) {
+            if (iter.value()->account()->accountType() == DAccount::Account_CalDav) {
+                continue;
+            }
             iter.value()->accountDownload();
         }
+        m_calDavSyncJobManager.requestSyncForAll(DCalDavSyncStateMachine::ForegroundTrigger);
     }
 }
 
@@ -324,12 +1272,14 @@ void DAccountManageModule::initAccountDBusInfo(const DAccount::Ptr &account)
         break;
     }
     QString sortID = DDataBase::createUuid().mid(0, 5);
-    account->setAccountState(DAccount::AccountState::Account_Setting | DAccount::Account_Calendar);
-    setUidSwitchStatus(account);
-    
+    if (account->accountType() == DAccount::Account_UnionID) {
+        account->setAccountState(DAccount::Account_Setting | DAccount::Account_Calendar);
+        setUidSwitchStatus(account);
+    } else {
+        account->setAccountState(DAccount::Account_Open | DAccount::Account_Calendar);
+    }
+
     //设置DBus路径和数据库名
-    //account
-    account->setAccountType(DAccount::Account_UnionID);
     account->setDtCreate(QDateTime::currentDateTime());
     account->setDbName(QString("account_%1_%2.db").arg(typeStr).arg(sortID));
     account->setDbusPath(QString("%1/account_%2_%3").arg(serviceBasePath).arg(typeStr).arg(sortID));

--- a/src/calendar-service/src/calendarDataManager/daccountmanagemodule.h
+++ b/src/calendar-service/src/calendarDataManager/daccountmanagemodule.h
@@ -12,10 +12,20 @@
 #include "daccountmanagerdatabase.h"
 #include "daccountservice.h"
 #include "dbustimedate.h"
+#include "dcaldavsyncjobmanager.h"
+
+class DCalDavAccountRegistrar;
+class DCalDavReadOnlySync;
 
 #include <QObject>
 #include <QSharedPointer>
+#include <QHash>
 #include <QTimer>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QNetworkInformation>
+#else
+#include <QNetworkConfigurationManager>
+#endif
 #include <DConfig>
 
 //帐户类型总数，若支持的类型增加则需要修改
@@ -67,6 +77,25 @@ public:
     void downloadByAccountID(const QString &accountID);
     void uploadNetWorkAccountData();
 
+    QString getCalDavAccountStatusList();
+    QString getCalDavAccountConfig(const QString &accountID);
+    QString validateCalDavAccountForUpdate(const QString &accountID, int providerType,
+                                           const QString &serverUrl, const QString &username,
+                                           const QString &credentialRef);
+    QString validateCalDavAccount(int providerType, const QString &serverUrl,
+                                  const QString &username, const QString &credentialRef);
+    bool updateCalDavCredentialReference(const QString &accountID, const QString &credentialRef);
+    QString createCalDavAccount(int providerType, const QString &serverUrl, const QString &username,
+                                const QString &credentialRef, const QString &displayName);
+    bool updateCalDavAccount(const QString &accountID, int providerType, const QString &serverUrl,
+                             const QString &username, const QString &credentialRef,
+                             const QString &displayName);
+    bool deleteCalDavAccount(const QString &accountID);
+    bool deleteCalDavAccountWithLocalDataOption(const QString &accountID, bool deleteLocalData);
+    bool resolveCalDavConflict(const QString &accountID, const QString &localScheduleID,
+                               bool keepLocal);
+    bool resolveAllCalDavConflicts(const QString &accountID, bool keepLocal);
+
     //账户登录
     void login();
     //账户登出
@@ -91,11 +120,31 @@ private:
     DCalendarGeneralSettings::Ptr getGeneralSettings();
     // 保存通用配置
     void setGeneralSettings(const DCalendarGeneralSettings::Ptr &cgSet);
+    void registerCalDavAccounts();
+    void registerCalDavAccount(const DAccount::Ptr &account);
+    void scheduleNextCalDavDailySync();
+    void scheduleNextCalDavRetry();
+    bool migrateCalDavSchedulesToLocal(const DAccountModule::Ptr &calDavModule,
+                                       const DAccountModule::Ptr &localModule,
+                                       QStringList *createdScheduleIDs,
+                                       QStringList *createdScheduleTypeIDs);
+    /**
+     * @brief Removes a CalDAV account and optionally migrates its events locally.
+     *
+     * Stops sync first, rolls back an incomplete local migration on failure, and
+     * persists deletion cleanup metadata until the account database is removed.
+     */
+    bool deleteCalDavAccountInternal(const QString &accountID, bool deleteLocalData);
+    void resumeCalDavAccountDeletionCleanups();
 
 signals:
     void firstDayOfWeekChange();
     void timeFormatTypeChange();
     void signalLoginStatusChange();
+    void calDavAccountStatusChanged(const QString &accountID);
+    void calDavAccountValidationFinished(const QString &requestID, bool success, int validationError,
+                                         const QString &errorMessage,
+                                         const QString &principalDisplayName);
 
 public slots:
     void slotFirstDayOfWeek(const int firstDay);
@@ -109,6 +158,9 @@ public slots:
 
     //定时判断日历界面是否打开
     void slotClientIsOpen();
+    void slotCalDavDailySync();
+    void slotCalDavRetry();
+    void slotCalDavOnlineStateChanged(bool isOnline);
 
 private:
     SyncFileManage *m_syncFileManage = nullptr;
@@ -122,6 +174,14 @@ private:
     bool m_isSupportUid = false;
     QSettings m_settings;
     DBusTimedate m_timeDateDbus;
+    DCalDavSyncJobManager m_calDavSyncJobManager;
+    QMap<QString, DCalDavAccountRegistrar *> m_calDavRegistrars;
+    QHash<QString, DCalDavReadOnlySync *> m_calDavValidationJobs;
+    QTimer m_calDavDailyTimer;
+    QTimer m_calDavRetryTimer;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QNetworkConfigurationManager m_networkConfigurationManager;
+#endif
 };
 
 #endif // DACCOUNTMANAGEMODULE_H

--- a/src/calendar-service/src/calendarDataManager/daccountmodule.cpp
+++ b/src/calendar-service/src/calendarDataManager/daccountmodule.cpp
@@ -17,24 +17,130 @@
 #include "unionIDDav/dunioniddav.h"
 #include "ddatasyncbase.h"
 #include "dbusnotify.h"
+#include "daccountmanagerdatabase.h"
+#include "dcaldavoutboxenqueuer.h"
+#include "dcaldavrecoveryhandler.h"
+#include "dcaldavaccountinfo.h"
+#include "dcaldavcredentialstore.h"
+#include "dcaldavcalendarinfo.h"
+#include "dcaldavcategoryinfo.h"
+#include "dcaldavprofile.h"
+#include "dcaldavxmlreader.h"
 
 #include <QDir>
 #include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+
+#include <memory>
 
 #define UPDATEREMINDJOBTIMEINTERVAL 1000 * 60 * 10 //提醒任务更新时间间隔毫秒数（10分钟）
 
-DAccountModule::DAccountModule(const DAccount::Ptr &account, QObject *parent)
+namespace {
+
+bool usesLegacyNetworkSync(const DAccount::Ptr &account)
+{
+    return account->isNetWorkAccount() && account->accountType() != DAccount::Account_CalDav;
+}
+
+bool isCalDavRemoteScheduleType(const DScheduleType &scheduleType)
+{
+    return scheduleType.description() == QStringLiteral("CalDAV calendar")
+        || scheduleType.description() == QStringLiteral("CalDAV category");
+}
+
+DCalDavCalendarInfo writableCalDavCalendar(DAccountManagerDataBase *database,
+                                           const QString &accountID,
+                                           const QString &scheduleTypeID)
+{
+    DCalDavCalendarInfo calendar = database->getCalDavCalendarByScheduleTypeID(accountID, scheduleTypeID);
+    if (calendar.calendarId.isEmpty()) {
+        const DCalDavCategoryInfo category =
+            database->getCalDavCategoryMappingByScheduleTypeID(accountID, scheduleTypeID);
+        if (!category.calendarId.isEmpty()) {
+            const DCalDavCalendarInfo::List calendars = database->getCalDavCalendarList(accountID);
+            for (const DCalDavCalendarInfo &candidate : calendars) {
+                if (candidate.enabled && candidate.calendarId == category.calendarId) {
+                    calendar = candidate;
+                    break;
+                }
+            }
+        }
+    }
+    if (calendar.calendarId.isEmpty()
+        || !(calendar.privileges & DCalDavXmlReader::WritePrivilege)) {
+        return DCalDavCalendarInfo();
+    }
+    return calendar;
+}
+
+QUrl calDavEventUrl(const DCalDavCalendarInfo &calendar, const QString &uid)
+{
+    QUrl url(calendar.href);
+    QString path = url.path();
+    if (!path.endsWith(QLatin1Char('/'))) {
+        path.append(QLatin1Char('/'));
+    }
+    path.append(QString::fromLatin1(QUrl::toPercentEncoding(uid)));
+    path.append(QStringLiteral(".ics"));
+    url.setPath(path);
+    return url;
+}
+
+/**
+ * @brief Builds the durable record used to recover a partially applied CalDAV change.
+ * @param account Owning CalDAV account of the local schedule.
+ * @param schedule Current local schedule serialized for recovery.
+ * @param operation Intended local Create, Modify, or Delete operation.
+ * @param mapping Persisted remote mapping, when an event already exists remotely.
+ * @param calendar Writable calendar used to derive a new event URL when needed.
+ * @return A recovery item sufficient to recreate the Outbox operation after restart.
+ */
+DCalDavRecoveryItem makeCalDavRecoveryItem(const DAccount::Ptr &account,
+                                           const DSchedule::Ptr &schedule,
+                                           DCalDavRecoveryItem::OperationType operation,
+                                           const DCalDavEventMappingInfo &mapping,
+                                           const DCalDavCalendarInfo &calendar)
+{
+    DCalDavRecoveryItem item;
+    item.accountID = account->accountID();
+    item.localScheduleID = schedule->uid();
+    item.operationType = operation;
+    item.scheduleIcs = DSchedule::toIcsString(schedule);
+    item.calendarID = !mapping.calendarID.isEmpty() ? mapping.calendarID : calendar.calendarId;
+    item.href = mapping.href;
+    // A remote-first creation has a deterministic resource URL before the
+    // local schedule is committed. Existing events without a mapping must not
+    // invent one during recovery: the outbox can still reconcile a pending
+    // Create/Modify operation using its normal mapping lookup.
+    if (operation == DCalDavRecoveryItem::CreateOperation && item.href.isEmpty()
+        && !calendar.calendarId.isEmpty()) {
+        item.href = calDavEventUrl(calendar, schedule->uid()).toString();
+    }
+    item.etag = mapping.etag;
+    item.originalIcs = mapping.originalIcs;
+    item.createdAt = QDateTime::currentDateTimeUtc();
+    return item;
+}
+
+} // namespace
+
+DAccountModule::DAccountModule(const DAccount::Ptr &account,
+                               DAccountManagerDataBase *calDavAccountManagerDatabase,
+                               QObject *parent)
     : QObject(parent)
     , m_account(account)
     , m_accountDB(new DAccountDataBase(account))
     , m_alarm(new DAlarmManager)
     , m_dataSync(DSyncDataFactory::createDataSync(m_account))
+    , m_calDavAccountManagerDatabase(calDavAccountManagerDatabase)
 {
     qCDebug(ServiceLogger) << "DAccountModule constructor called for account:" << account->accountID();
     QString newDbPath = getDBPath();
     m_accountDB->setDBPath(newDbPath + "/" + account->dbName());
     m_accountDB->initDBData();
     m_accountDB->getAccountInfo(m_account);
+    recoverPendingCalDavOperations();
 
     //关联打开日历界面
     connect(m_alarm.data(), &DAlarmManager::signalCallOpenCalendarUI, this, &DAccountModule::slotOpenCalendar);
@@ -143,17 +249,54 @@ QString DAccountModule::createScheduleType(const QString &typeInfo)
 {
     qCDebug(ServiceLogger) << "Creating schedule type for account:" << m_account->accountID() << "with info:" << typeInfo;
     DScheduleType::Ptr scheduleType;
-    DScheduleType::fromJsonString(scheduleType, typeInfo);
+    if (!DScheduleType::fromJsonString(scheduleType, typeInfo) || scheduleType.isNull()) {
+        qCWarning(ServiceLogger) << "Failed to parse schedule type creation payload.";
+        return QString();
+    }
+
+    DCalDavCalendarInfo selectedCalendar;
+    const bool isCalDav = m_account->accountType() == DAccount::Account_CalDav;
+    std::unique_ptr<SqlTransactionLocker> calDavTransaction;
+    if (isCalDav) {
+        if (m_calDavAccountManagerDatabase == nullptr) {
+            return QString();
+        }
+        const DCalDavCalendarInfo::List calendars =
+            m_calDavAccountManagerDatabase->getCalDavCalendarList(m_account->accountID());
+        for (const DCalDavCalendarInfo &calendar : calendars) {
+            if (!calendar.enabled || !(calendar.privileges & DCalDavXmlReader::WritePrivilege)) {
+                continue;
+            }
+            if (!scheduleType->typePath().isEmpty() && scheduleType->typePath() != calendar.calendarId) {
+                continue;
+            }
+            selectedCalendar = calendar;
+            break;
+        }
+        if (selectedCalendar.calendarId.isEmpty()) {
+            qCWarning(ServiceLogger) << "No writable CalDAV calendar is available for a new schedule type.";
+            return QString();
+        }
+        calDavTransaction.reset(new SqlTransactionLocker(
+            {m_accountDB->getConnectionName(), DDataBase::NameAccountManager}));
+        if (!calDavTransaction->isValid()) {
+            return QString();
+        }
+        scheduleType->setTypePath(selectedCalendar.calendarId);
+        scheduleType->setPrivilege(DScheduleType::User);
+    }
+    QString createdColorID;
     //如果颜色为用户自定义则需要在数据库中记录
     if (scheduleType->typeColor().colorID() == "") {
         scheduleType->setColorID(DDataBase::createUuid());
+        createdColorID = scheduleType->typeColor().colorID();
         DTypeColor::Ptr typeColor(new DTypeColor(scheduleType->typeColor()));
         typeColor->setPrivilege(DTypeColor::PriUser);
         m_accountDB->addTypeColor(typeColor);
         qCDebug(ServiceLogger) << "Added custom color for schedule type:" << typeColor->colorID();
         
         //添加创建颜色任务
-        if (m_account->isNetWorkAccount()) {
+        if (usesLegacyNetworkSync(m_account)) {
             DUploadTaskData::Ptr uploadTask(new DUploadTaskData);
             uploadTask->setTaskType(DUploadTaskData::TaskType::Create);
             uploadTask->setTaskObject(DUploadTaskData::Task_Color);
@@ -165,8 +308,37 @@ QString DAccountModule::createScheduleType(const QString &typeInfo)
     //设置创建时间
     scheduleType->setDtCreate(QDateTime::currentDateTime());
     QString scheduleTypeID = m_accountDB->createScheduleType(scheduleType);
+    if (scheduleTypeID.isEmpty()) {
+        if (calDavTransaction) {
+            calDavTransaction->rollback();
+        }
+        return QString();
+    }
+    if (isCalDav) {
+        QJsonArray categories;
+        categories.append(scheduleType->typeName().trimmed());
+        DCalDavCategoryInfo categoryMapping;
+        categoryMapping.accountId = m_account->accountID();
+        categoryMapping.calendarId = selectedCalendar.calendarId;
+        categoryMapping.categoryKey = QString::fromUtf8(
+            QJsonDocument(categories).toJson(QJsonDocument::Compact));
+        categoryMapping.scheduleTypeId = scheduleTypeID;
+        if (!m_calDavAccountManagerDatabase->upsertCalDavCategoryMapping(categoryMapping)
+            || !calDavTransaction->commit()) {
+            if (calDavTransaction) {
+                calDavTransaction->rollback();
+            }
+            m_accountDB->deleteScheduleTypeByID(scheduleTypeID, 1);
+            if (!createdColorID.isEmpty()) {
+                m_accountDB->deleteTypeColor(createdColorID);
+            }
+            return QString();
+        }
+        emit signalScheduleTypeUpdate();
+        return scheduleTypeID;
+    }
     //如果为网络日程则需要上传任务
-    if (m_account->isNetWorkAccount()) {
+    if (usesLegacyNetworkSync(m_account)) {
         DUploadTaskData::Ptr uploadTask(new DUploadTaskData);
         uploadTask->setTaskType(DUploadTaskData::TaskType::Create);
         uploadTask->setTaskObject(DUploadTaskData::Task_ScheduleType);
@@ -182,6 +354,16 @@ QString DAccountModule::createScheduleType(const QString &typeInfo)
 
 bool DAccountModule::deleteScheduleTypeByID(const QString &typeID)
 {
+    DScheduleType::Ptr scheduleType = m_accountDB->getScheduleTypeByID(typeID);
+    if (scheduleType.isNull()) {
+        qCWarning(ServiceLogger) << "scheduleType isNull, typeID:" << typeID;
+        return false;
+    }
+    if (m_account->accountType() == DAccount::Account_CalDav
+        && isCalDavRemoteScheduleType(*scheduleType)) {
+        qCWarning(ServiceLogger) << "CalDAV remote calendar/category types cannot be changed through schedule type APIs.";
+        return false;
+    }
     qCDebug(ServiceLogger) << "Deleting schedule type by ID:" << typeID << "for account:" << m_account->accountID();
     //如果日程类型被使用需要删除对应到日程信息
     if (m_accountDB->scheduleTypeByUsed(typeID)) {
@@ -190,7 +372,7 @@ bool DAccountModule::deleteScheduleTypeByID(const QString &typeID)
         foreach (auto scheduleID, scheduleIDList) {
             closeNotification(scheduleID);
             //添加删除日程任务
-            if (m_account->isNetWorkAccount()) {
+            if (usesLegacyNetworkSync(m_account)) {
                 DUploadTaskData::Ptr uploadTask(new DUploadTaskData);
                 uploadTask->setTaskType(DUploadTaskData::TaskType::Delete);
                 uploadTask->setTaskObject(DUploadTaskData::Task_Schedule);
@@ -200,12 +382,11 @@ bool DAccountModule::deleteScheduleTypeByID(const QString &typeID)
         }
         //更新提醒任务
         updateRemindSchedules(false);
-        m_accountDB->deleteSchedulesByScheduleTypeID(typeID, !m_account->isNetWorkAccount());
+        m_accountDB->deleteSchedulesByScheduleTypeID(typeID, m_account->accountType() == DAccount::Account_Local);
         emit signalScheduleUpdate();
     }
-    DScheduleType::Ptr scheduleType = m_accountDB->getScheduleTypeByID(typeID);
     //根据帐户是否为网络帐户需要添加任务列表中,并设置弱删除
-    if (m_account->isNetWorkAccount()) {
+    if (usesLegacyNetworkSync(m_account)) {
         QStringList scheduleIDList = m_accountDB->getScheduleIDListByTypeID(typeID);
         //弱删除
         m_accountDB->deleteScheduleTypeByID(typeID);
@@ -234,6 +415,12 @@ bool DAccountModule::deleteScheduleTypeByID(const QString &typeID)
         if(scheduleType->typeColor().privilege() != DTypeColor::PriSystem){
             m_accountDB->deleteTypeColor(scheduleType->typeColor().colorID());
         }
+        if (m_account->accountType() == DAccount::Account_CalDav
+            && m_calDavAccountManagerDatabase != nullptr
+            && !m_calDavAccountManagerDatabase->deleteCalDavCategoryMappingByScheduleTypeID(
+                   m_account->accountID(), typeID)) {
+            qCWarning(ServiceLogger) << "Failed to remove CalDAV category mapping for schedule type:" << typeID;
+        }
     }
     if (scheduleType.isNull()) {
         qCWarning(ServiceLogger) << "scheduleType isNull, typeID:" << typeID;
@@ -258,39 +445,61 @@ bool DAccountModule::updateScheduleType(const QString &typeInfo)
 {
     qCDebug(ServiceLogger) << "Updating schedule type for account:" << m_account->accountID() << "with info:" << typeInfo;
     DScheduleType::Ptr scheduleType;
-    DScheduleType::fromJsonString(scheduleType, typeInfo);
+    if (!DScheduleType::fromJsonString(scheduleType, typeInfo) || scheduleType.isNull()) {
+        qCWarning(ServiceLogger) << "Failed to parse schedule type update payload.";
+        return false;
+    }
+
     DScheduleType::Ptr oldScheduleType = m_accountDB->getScheduleTypeByID(scheduleType->typeID());
-    //如果颜色有改动
     if (oldScheduleType.isNull()) {
-        qCWarning(ServiceLogger) << "get oldScheduleType error,typeID:" << scheduleType->typeID();
-    } else {
-        qCDebug(ServiceLogger) << "oldScheduleType:" << oldScheduleType->typeID();
-        if (oldScheduleType->typeColor() != scheduleType->typeColor()) {
-            if (!oldScheduleType->typeColor().isSysColorInfo()) {
-                m_accountDB->deleteTypeColor(oldScheduleType->typeColor().colorID());
-                //添加删除颜色任务
-                if (m_account->isNetWorkAccount()) {
-                    DUploadTaskData::Ptr uploadTask(new DUploadTaskData);
-                    uploadTask->setTaskType(DUploadTaskData::TaskType::Delete);
-                    uploadTask->setTaskObject(DUploadTaskData::Task_Color);
-                    uploadTask->setObjectId(oldScheduleType->typeColor().colorID());
-                    m_accountDB->addUploadTask(uploadTask);
-                }
+        qCWarning(ServiceLogger) << "Schedule type not found, typeID:" << scheduleType->typeID();
+        return false;
+    }
+
+    // Remote CalDAV collection/category metadata is read-only, but the local
+    // display state must remain user-configurable and persistent across restarts.
+    if (m_account->accountType() == DAccount::Account_CalDav
+        && isCalDavRemoteScheduleType(*oldScheduleType)) {
+        const DScheduleType::ShowState oldShowState = oldScheduleType->showState();
+        oldScheduleType->setShowState(scheduleType->showState());
+        oldScheduleType->setDtUpdate(QDateTime::currentDateTime());
+        const bool isSucc = m_accountDB->updateScheduleType(oldScheduleType);
+        if (isSucc) {
+            if (oldShowState == oldScheduleType->showState()) {
+                emit signalScheduleTypeUpdate();
+            } else {
+                emit signalScheduleUpdate();
             }
-            if (!scheduleType->typeColor().isSysColorInfo()) {
-                DTypeColor::Ptr typeColor(new DTypeColor(scheduleType->typeColor()));
-                typeColor->setPrivilege(DTypeColor::PriUser);
-                m_accountDB->addTypeColor(typeColor);
-                scheduleType->setColorID(typeColor->colorID());
-                //添加创建颜色任务
-                if (m_account->isNetWorkAccount()) {
-                    DUploadTaskData::Ptr uploadTask(new DUploadTaskData);
-//                    uploadTask->setTaskType(DUploadTaskData::TaskType::Delete);
-                    uploadTask->setTaskType(DUploadTaskData::TaskType::Create);
-                    uploadTask->setTaskObject(DUploadTaskData::Task_Color);
-                    uploadTask->setObjectId(typeColor->colorID());
-                    m_accountDB->addUploadTask(uploadTask);
-                }
+        }
+        qCDebug(ServiceLogger) << "CalDAV schedule type display state update result:" << isSucc;
+        return isSucc;
+    }
+    qCDebug(ServiceLogger) << "oldScheduleType:" << oldScheduleType->typeID();
+    //如果颜色有改动
+    if (oldScheduleType->typeColor() != scheduleType->typeColor()) {
+        if (!oldScheduleType->typeColor().isSysColorInfo()) {
+            m_accountDB->deleteTypeColor(oldScheduleType->typeColor().colorID());
+            //添加删除颜色任务
+            if (usesLegacyNetworkSync(m_account)) {
+                DUploadTaskData::Ptr uploadTask(new DUploadTaskData);
+                uploadTask->setTaskType(DUploadTaskData::TaskType::Delete);
+                uploadTask->setTaskObject(DUploadTaskData::Task_Color);
+                uploadTask->setObjectId(oldScheduleType->typeColor().colorID());
+                m_accountDB->addUploadTask(uploadTask);
+            }
+        }
+        if (!scheduleType->typeColor().isSysColorInfo()) {
+            DTypeColor::Ptr typeColor(new DTypeColor(scheduleType->typeColor()));
+            typeColor->setPrivilege(DTypeColor::PriUser);
+            m_accountDB->addTypeColor(typeColor);
+            scheduleType->setColorID(typeColor->colorID());
+            //添加创建颜色任务
+            if (usesLegacyNetworkSync(m_account)) {
+                DUploadTaskData::Ptr uploadTask(new DUploadTaskData);
+                uploadTask->setTaskType(DUploadTaskData::TaskType::Create);
+                uploadTask->setTaskObject(DUploadTaskData::Task_Color);
+                uploadTask->setObjectId(typeColor->colorID());
+                m_accountDB->addUploadTask(uploadTask);
             }
         }
     }
@@ -299,7 +508,7 @@ bool DAccountModule::updateScheduleType(const QString &typeInfo)
 
     if (isSucc) {
         qCDebug(ServiceLogger) << "Schedule type updated successfully";
-        if (m_account->isNetWorkAccount()) {
+        if (usesLegacyNetworkSync(m_account)) {
             DUploadTaskData::Ptr uploadTask(new DUploadTaskData);
             uploadTask->setTaskType(DUploadTaskData::TaskType::Modify);
             uploadTask->setTaskObject(DUploadTaskData::Task_ScheduleType);
@@ -322,45 +531,162 @@ bool DAccountModule::updateScheduleType(const QString &typeInfo)
     return isSucc;
 }
 
+void DAccountModule::notifyCalDavScheduleCreateFailed(int createFailure)
+{
+    emit signalCalDavScheduleCreateFailed(createFailure);
+}
+
+void DAccountModule::recoverPendingCalDavOperations()
+{
+    if (m_account.isNull() || m_account->accountType() != DAccount::Account_CalDav) {
+        return;
+    }
+    DCalDavRecoveryHandler::recover(m_accountDB.data(), m_calDavAccountManagerDatabase,
+                                    m_account->accountID());
+}
+
 QString DAccountModule::createSchedule(const QString &scheduleInfo)
 {
-    qCDebug(ServiceLogger) << "Creating schedule for account:" << m_account->accountID() << "with info:" << scheduleInfo;
+    qCDebug(ServiceLogger) << "Creating schedule for account:" << m_account->accountID()
+                             << "payloadLength:" << scheduleInfo.size();
     DSchedule::Ptr schedule;
-    DSchedule::fromJsonString(schedule, scheduleInfo);
+    if (!DSchedule::fromJsonString(schedule, scheduleInfo) || schedule.isNull()) {
+        qCWarning(ServiceLogger) << "Failed to parse schedule creation payload.";
+        return QString();
+    }
     schedule->setCreated(QDateTime::currentDateTime());
 
-    QString scheduleID = m_accountDB->createSchedule(schedule);
-    //根据是否为网络帐户判断是否需要更新任务列表
-    if (m_account->isNetWorkAccount()) {
-        qCDebug(ServiceLogger) << "Schedule type is network account";
+    DCalDavRecoveryItem recoveryItem;
+    bool hasRecoveryItem = false;
+    if (m_account->accountType() == DAccount::Account_CalDav) {
+        if (m_calDavAccountManagerDatabase == nullptr) {
+            return QString();
+        }
+        schedule->setUid(DDataBase::createUuid());
+        recoveryItem.accountID = m_account->accountID();
+        recoveryItem.localScheduleID = schedule->uid();
+        recoveryItem.operationType = DCalDavRecoveryItem::LocalCreateOperation;
+        recoveryItem.scheduleIcs = DSchedule::toIcsString(schedule);
+        recoveryItem.createdAt = QDateTime::currentDateTimeUtc();
+        if (!m_accountDB->upsertCalDavRecoveryItem(recoveryItem)) {
+            qCWarning(ServiceLogger) << "Failed to persist CalDAV local creation recovery record.";
+            return QString();
+        }
+        hasRecoveryItem = true;
+    }
+
+    std::unique_ptr<SqlTransactionLocker> calDavTransaction;
+    if (m_account->accountType() == DAccount::Account_CalDav) {
+        calDavTransaction.reset(new SqlTransactionLocker(
+            {m_accountDB->getConnectionName(), DDataBase::NameAccountManager}));
+        if (!calDavTransaction->isValid()) {
+            m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), schedule->uid());
+            return QString();
+        }
+    }
+
+    const QString scheduleID = m_accountDB->createSchedule(schedule);
+    if (scheduleID.isEmpty()) {
+        if (calDavTransaction) {
+            calDavTransaction->rollback();
+        }
+        if (hasRecoveryItem) {
+            m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), schedule->uid());
+        }
+        return QString();
+    }
+
+    bool calDavOutboxQueued = false;
+    if (usesLegacyNetworkSync(m_account)) {
         DUploadTaskData::Ptr uploadTask(new DUploadTaskData);
         uploadTask->setTaskType(DUploadTaskData::TaskType::Create);
         uploadTask->setTaskObject(DUploadTaskData::Task_Schedule);
         uploadTask->setObjectId(scheduleID);
         m_accountDB->addUploadTask(uploadTask);
-        qCDebug(ServiceLogger) << "Added schedule upload task for network account";
-        //开启上传任务
         uploadNetWorkAccountData();
+    } else if (m_account->accountType() == DAccount::Account_CalDav) {
+        calDavOutboxQueued = DCalDavOutboxEnqueuer::enqueue(
+            m_calDavAccountManagerDatabase, m_account->accountID(), schedule,
+            DCalDavOutboxEnqueuer::CreateChange);
+        if (!calDavOutboxQueued) {
+            // The requirement is local-first: a permission/configuration
+            // failure must not discard the event the user just saved.
+            qCWarning(ServiceLogger) << "CalDAV creation was saved locally but could not be queued.";
+        }
     }
-    //根据是否为提醒日程更新提醒任务
+
+    if (calDavTransaction && !calDavTransaction->commit()) {
+        qCWarning(ServiceLogger) << "Failed to commit CalDAV local creation transaction.";
+        // Keep the recovery record. If the local database committed before the
+        // account-manager database, startup will recreate the Create Outbox.
+        return QString();
+    }
+    if (hasRecoveryItem
+        && !m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), schedule->uid())) {
+        qCWarning(ServiceLogger) << "Failed to clear completed CalDAV local creation recovery record.";
+    }
+
     if (schedule->alarms().size() > 0) {
-        qCDebug(ServiceLogger) << "Updating reminders for new schedule:" << scheduleID;
         updateRemindSchedules(false);
     }
-    //发送日程更新信号
+    if (m_account->accountType() == DAccount::Account_CalDav) {
+        if (calDavOutboxQueued) {
+            emit signalCalDavLocalChange();
+        } else {
+            qCWarning(ServiceLogger) << "CalDAV creation was saved locally but could not be queued.";
+        }
+    }
     emit signalScheduleUpdate();
     return scheduleID;
 }
 
 bool DAccountModule::updateSchedule(const QString &scheduleInfo)
 {
-    qCDebug(ServiceLogger) << "Updating schedule for account:" << m_account->accountID() << "with info:" << scheduleInfo;
+    qCDebug(ServiceLogger) << "Updating schedule for account:" << m_account->accountID()
+                             << "payloadLength:" << scheduleInfo.size();
     //根据是否为提醒日程更新提醒任务
     DSchedule::Ptr schedule;
-    DSchedule::fromJsonString(schedule, scheduleInfo);
+    if (!DSchedule::fromJsonString(schedule, scheduleInfo) || schedule.isNull()) {
+        qCWarning(ServiceLogger) << "Failed to parse schedule update payload.";
+        return false;
+    }
     DSchedule::Ptr oldSchedule = m_accountDB->getScheduleByScheduleID(schedule->uid());
+    if (oldSchedule.isNull() || oldSchedule->uid().isEmpty()) {
+        qCWarning(ServiceLogger) << "Schedule to update was not found.";
+        return false;
+    }
     schedule->setLastModified(QDateTime::currentDateTime());
     schedule->setRevision(schedule->revision() + 1);
+
+    DCalDavRecoveryItem recoveryItem;
+    bool hasRecoveryItem = false;
+    if (m_account->accountType() == DAccount::Account_CalDav) {
+        if (m_calDavAccountManagerDatabase == nullptr) {
+            return false;
+        }
+        const DCalDavEventMappingInfo mapping =
+            m_calDavAccountManagerDatabase->getCalDavEventMappingByLocalScheduleID(
+                m_account->accountID(), schedule->uid());
+        const DCalDavCalendarInfo calendar = writableCalDavCalendar(
+            m_calDavAccountManagerDatabase, m_account->accountID(), schedule->scheduleTypeID());
+        recoveryItem = makeCalDavRecoveryItem(
+            m_account, schedule, DCalDavRecoveryItem::ModifyOperation, mapping, calendar);
+        if (!m_accountDB->upsertCalDavRecoveryItem(recoveryItem)) {
+            qCWarning(ServiceLogger) << "Failed to persist CalDAV update recovery record.";
+            return false;
+        }
+        hasRecoveryItem = true;
+    }
+
+    std::unique_ptr<SqlTransactionLocker> calDavTransaction;
+    if (m_account->accountType() == DAccount::Account_CalDav) {
+        calDavTransaction.reset(new SqlTransactionLocker(
+            {m_accountDB->getConnectionName(), DDataBase::NameAccountManager}));
+        if (!calDavTransaction->isValid()) {
+            m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), schedule->uid());
+            return false;
+        }
+    }
 
     //如果旧日程为提醒日程
     if (oldSchedule->alarms().size() > 0) {
@@ -407,24 +733,66 @@ bool DAccountModule::updateSchedule(const QString &scheduleInfo)
     }
 
     bool ok = m_accountDB->updateSchedule(schedule);
+    if (!ok) {
+        if (calDavTransaction) {
+            calDavTransaction->rollback();
+        }
+        if (hasRecoveryItem) {
+            m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), schedule->uid());
+        }
+        return false;
+    }
 
     //如果存在提醒
     if (oldSchedule->alarms().size() > 0 || schedule->alarms().size() > 0) {
         updateRemindSchedules(false);
     }
 
-    emit signalScheduleUpdate();
-    //根据是否为网络帐户判断是否需要更新任务列表
-    if (m_account->isNetWorkAccount()) {
+    //根据账户类型分别记录旧网络同步任务或 CalDAV Outbox。
+    if (usesLegacyNetworkSync(m_account)) {
         qCDebug(ServiceLogger) << "Schedule is network account";
         DUploadTaskData::Ptr uploadTask(new DUploadTaskData);
         uploadTask->setTaskType(DUploadTaskData::TaskType::Modify);
         uploadTask->setTaskObject(DUploadTaskData::Task_Schedule);
         uploadTask->setObjectId(schedule->uid());
         m_accountDB->addUploadTask(uploadTask);
-        //开启上传任务
         uploadNetWorkAccountData();
+    } else if (ok && m_account->accountType() == DAccount::Account_CalDav
+               && !DCalDavOutboxEnqueuer::enqueue(m_calDavAccountManagerDatabase,
+                                                   m_account->accountID(), schedule,
+                                                   DCalDavOutboxEnqueuer::ModifyChange)) {
+        qCWarning(ServiceLogger) << "Failed to enqueue CalDAV schedule update.";
+        if (calDavTransaction) {
+            calDavTransaction->rollback();
+        }
+        if (hasRecoveryItem) {
+            m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), schedule->uid());
+        }
+        return false;
     }
+    if (calDavTransaction && !calDavTransaction->commit()) {
+        qCWarning(ServiceLogger) << "Failed to commit CalDAV schedule update transaction.";
+        // SqlTransactionLocker coordinates two independent SQLite
+        // connections and cannot provide a true cross-database atomic commit.
+        // If the local connection committed before the account-manager
+        // connection failed, restore the pre-update row so the next retry does
+        // not lose the user's pending change without an outbox item.
+        const bool restored = m_accountDB->updateSchedule(oldSchedule);
+        if (!restored) {
+            qCWarning(ServiceLogger) << "Failed to restore schedule after CalDAV transaction failure.";
+        } else if (hasRecoveryItem) {
+            m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), schedule->uid());
+        }
+        if (oldSchedule->alarms().size() > 0 || schedule->alarms().size() > 0) {
+            updateRemindSchedules(false);
+        }
+        return false;
+    }
+    if (hasRecoveryItem
+        && !m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), schedule->uid())) {
+        qCWarning(ServiceLogger) << "Failed to clear completed CalDAV update recovery record.";
+    }
+    emit signalScheduleUpdate();
     return ok;
 }
 
@@ -443,17 +811,72 @@ bool DAccountModule::deleteScheduleByScheduleID(const QString &scheduleID)
     //根据是否为网络判断是否需要弱删除
     bool isOK;
     DSchedule::Ptr schedule = m_accountDB->getScheduleByScheduleID(scheduleID);
-    if (m_account->isNetWorkAccount()) {
+    if (schedule.isNull() || schedule->uid().isEmpty()) {
+        qCWarning(ServiceLogger) << "Schedule to delete was not found.";
+        return false;
+    }
+
+    DCalDavRecoveryItem recoveryItem;
+    bool hasRecoveryItem = false;
+    if (m_account->accountType() == DAccount::Account_CalDav) {
+        if (m_calDavAccountManagerDatabase == nullptr) {
+            return false;
+        }
+        const DCalDavEventMappingInfo mapping =
+            m_calDavAccountManagerDatabase->getCalDavEventMappingByLocalScheduleID(
+                m_account->accountID(), scheduleID);
+        const DCalDavCalendarInfo calendar = writableCalDavCalendar(
+            m_calDavAccountManagerDatabase, m_account->accountID(), schedule->scheduleTypeID());
+        recoveryItem = makeCalDavRecoveryItem(
+            m_account, schedule, DCalDavRecoveryItem::DeleteOperation, mapping, calendar);
+        if (!m_accountDB->upsertCalDavRecoveryItem(recoveryItem)) {
+            qCWarning(ServiceLogger) << "Failed to persist CalDAV deletion recovery record.";
+            return false;
+        }
+        hasRecoveryItem = true;
+    }
+
+    std::unique_ptr<SqlTransactionLocker> calDavTransaction;
+    if (m_account->accountType() == DAccount::Account_CalDav) {
+        calDavTransaction.reset(new SqlTransactionLocker(
+            {m_accountDB->getConnectionName(), DDataBase::NameAccountManager}));
+        if (!calDavTransaction->isValid()) {
+            m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), scheduleID);
+            return false;
+        }
+    }
+    if (usesLegacyNetworkSync(m_account)) {
         qCDebug(ServiceLogger) << "Schedule is network account";
         isOK = m_accountDB->deleteScheduleByScheduleID(scheduleID);
-        //更新上传任务表
         DUploadTaskData::Ptr uploadTask(new DUploadTaskData);
         uploadTask->setTaskType(DUploadTaskData::TaskType::Delete);
         uploadTask->setTaskObject(DUploadTaskData::Task_Schedule);
         uploadTask->setObjectId(scheduleID);
         m_accountDB->addUploadTask(uploadTask);
-        //开启任务
         uploadNetWorkAccountData();
+    } else if (m_account->accountType() == DAccount::Account_CalDav) {
+        isOK = m_accountDB->deleteScheduleByScheduleID(scheduleID);
+        if (!isOK) {
+            if (calDavTransaction) {
+                calDavTransaction->rollback();
+            }
+            if (hasRecoveryItem) {
+                m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), scheduleID);
+            }
+            return false;
+        }
+        if (!DCalDavOutboxEnqueuer::enqueue(m_calDavAccountManagerDatabase,
+                                            m_account->accountID(), schedule,
+                                            DCalDavOutboxEnqueuer::DeleteChange)) {
+            qCWarning(ServiceLogger) << "Failed to enqueue CalDAV schedule deletion.";
+            if (calDavTransaction) {
+                calDavTransaction->rollback();
+            }
+            if (hasRecoveryItem) {
+                m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), scheduleID);
+            }
+            return false;
+        }
     } else {
         qCDebug(ServiceLogger) << "Schedule is not network account";
         isOK = m_accountDB->deleteScheduleByScheduleID(scheduleID, 1);
@@ -464,6 +887,35 @@ bool DAccountModule::deleteScheduleByScheduleID(const QString &scheduleID)
         //关闭提醒消息和对应的通知弹框
         closeNotification(scheduleID);
         updateRemindSchedules(false);
+    }
+    if (calDavTransaction && !calDavTransaction->commit()) {
+        qCWarning(ServiceLogger) << "Failed to commit CalDAV schedule deletion transaction.";
+        // The two database files are committed independently.  If the local
+        // deletion was committed but the outbox transaction was not, restore
+        // the original schedule; otherwise the remote DELETE could never be
+        // retried after restart.
+        const bool restored = m_accountDB->scheduleExistsByScheduleID(scheduleID)
+            ? m_accountDB->updateSchedule(schedule)
+            : !m_accountDB->createSchedule(schedule).isEmpty();
+        if (!restored) {
+            qCWarning(ServiceLogger) << "Failed to restore schedule after CalDAV deletion transaction failure.";
+        } else if (hasRecoveryItem) {
+            m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), scheduleID);
+        }
+        if (schedule->alarms().size() > 0) {
+            updateRemindSchedules(false);
+        }
+        return false;
+    }
+    if (hasRecoveryItem
+        && !m_accountDB->deleteCalDavRecoveryItem(m_account->accountID(), scheduleID)) {
+        qCWarning(ServiceLogger) << "Failed to clear completed CalDAV deletion recovery record.";
+    }
+    if (m_account->accountType() == DAccount::Account_CalDav) {
+        // The local delete is committed. Let the account manager start the
+        // asynchronous remote DELETE immediately; the UI remains responsive
+        // while the server response is handled by the CalDAV outbox.
+        emit signalCalDavLocalChange();
     }
     emit signalScheduleUpdate();
     return isOK;
@@ -538,6 +990,18 @@ DAccount::Ptr DAccountModule::account() const
     return m_account;
 }
 
+
+DAccountDataBase *DAccountModule::accountDatabase() const
+{
+    return m_accountDB.data();
+}
+
+void DAccountModule::notifyScheduleDataChanged()
+{
+    updateRemindSchedules(false);
+    emit signalScheduleTypeUpdate();
+    emit signalScheduleUpdate();
+}
 void DAccountModule::updateRemindSchedules(bool isClear)
 {
     qCDebug(ServiceLogger) << "Updating remind schedules for account:" << m_account->accountID() << "isClear:" << isClear;
@@ -703,10 +1167,10 @@ QString DAccountModule::getDtLastUpdate()
     return dtToString(m_account->dtLastSync());
 }
 
-void DAccountModule::removeDB()
+bool DAccountModule::removeDB()
 {
     qCDebug(ServiceLogger) << "Removing database for account:" << m_account->accountID();
-    m_accountDB->removeDB();
+    bool removed = m_accountDB->removeDB();
     //如果为uid帐户退出则清空目录下所有关于uid的数据库文件
     //解决在某些条件下数据库没有被移除的问题（自测未发现）
     if(account()->accountType() == DAccount::Type::Account_UnionID){
@@ -719,10 +1183,15 @@ void DAccountModule::removeDB()
             dir.setFilter(QDir::Files | QDir::NoSymLinks);
             dir.setNameFilters(filters);
             for (uint i = 0; i < dir.count(); ++i) {
-                QFile::remove(dbPatch + dir[i]);
+                if (!QFile::remove(dbPatch + dir[i])) {
+                    removed = false;
+                    qCWarning(ServiceLogger) << "Failed to remove UID account database file:"
+                                             << dbPatch + dir[i];
+                }
             }
         }
     }
+    return removed;
 }
 
 QMap<QDate, DSchedule::List> DAccountModule::getScheduleTimesOn(const QDateTime &dtStart, const QDateTime &dtEnd, const DSchedule::List &scheduleList, bool extend)
@@ -917,7 +1386,7 @@ void DAccountModule::downloadTaskhanding(int index)
         qCDebug(ServiceLogger) << "Starting download task for account:" << m_account->accountID();
         //如果帐户刚刚登录开启定时任务
         //设置同步频率
-        if (m_account->isNetWorkAccount()) {
+        if (usesLegacyNetworkSync(m_account)) {
             int sync = -1;
             switch (m_account->syncFreq()) {
             case DAccount::SyncFreq_15Mins:

--- a/src/calendar-service/src/calendarDataManager/daccountmodule.h
+++ b/src/calendar-service/src/calendarDataManager/daccountmodule.h
@@ -18,6 +18,8 @@
 
 //帐户模块
 //处理后端数据获取，提醒，上传下载等
+class DAccountManagerDataBase;
+
 class DAccountModule : public QObject
 {
     Q_OBJECT
@@ -25,7 +27,9 @@ public:
     typedef QSharedPointer<DAccountModule> Ptr;
     typedef QList<Ptr> List;
 
-    explicit DAccountModule(const DAccount::Ptr &account, QObject *parent = nullptr);
+    explicit DAccountModule(const DAccount::Ptr &account,
+                            DAccountManagerDataBase *calDavAccountManagerDatabase = nullptr,
+                            QObject *parent = nullptr);
     ~DAccountModule();
     //获取帐户信息
     QString getAccountInfo();
@@ -65,6 +69,8 @@ public:
     QString getSysColors();
 
     DAccount::Ptr account() const;
+    DAccountDataBase *accountDatabase() const;
+    void notifyScheduleDataChanged();
 
     /**
      * @brief updateRemindSchedules     更新未来10分钟的提醒任务
@@ -86,9 +92,10 @@ public:
 
     void accountDownload();
     void uploadNetWorkAccountData();
+    void notifyCalDavScheduleCreateFailed(int createFailure);
 
     //删除数据库
-    void removeDB();
+    bool removeDB();
     //index: 0:帐户登录 1：修改同步频率 2：帐户登出
     void downloadTaskhanding(int index);
 
@@ -113,9 +120,12 @@ private:
 
     //根据提醒任务获取对应的日程信息
     DSchedule::Ptr getScheduleByRemind(const DRemindData::Ptr &remindData);
+    void recoverPendingCalDavOperations();
 
 signals:
     void signalScheduleUpdate();
+    void signalCalDavScheduleCreateFailed(int createFailure);
+    void signalCalDavLocalChange();
     void signalScheduleTypeUpdate();
     //关闭通知弹框
     void signalCloseNotification(quint64 notifyID);
@@ -141,6 +151,7 @@ private:
     DAccountDataBase::Ptr m_accountDB;
     DAlarmManager::Ptr m_alarm;
     DDataSyncBase *m_dataSync;
+    DAccountManagerDataBase *m_calDavAccountManagerDatabase = nullptr;
 };
 
 #endif // DACCOUNTMODULE_H

--- a/src/calendar-service/src/dbusservice/daccountmanagerservice.cpp
+++ b/src/calendar-service/src/dbusservice/daccountmanagerservice.cpp
@@ -19,6 +19,10 @@ DAccountManagerService::DAccountManagerService(QObject *parent)
     //自动退出
     DServiceExitControl exitControl;
     connect(m_accountManager.data(), &DAccountManageModule::signalLoginStatusChange, this, &DAccountManagerService::accountUpdate);
+    connect(m_accountManager.data(), &DAccountManageModule::calDavAccountStatusChanged,
+            this, &DAccountManagerService::calDavAccountStatusChanged);
+    connect(m_accountManager.data(), &DAccountManageModule::calDavAccountValidationFinished,
+            this, &DAccountManagerService::calDavAccountValidationFinished);
     qCDebug(ServiceLogger) << "Connected login status change signal";
 
     connect(m_accountManager.data(), &DAccountManageModule::firstDayOfWeekChange, this, [&]() {
@@ -76,6 +80,118 @@ void DAccountManagerService::downloadByAccountID(const QString &accountID)
     DServiceExitControl exitControl;
     m_accountManager->downloadByAccountID(accountID);
     qCDebug(ServiceLogger) << "Completed download for accountID:" << accountID;
+}
+
+QString DAccountManagerService::validateCalDavAccount(int providerType, const QString &serverUrl,
+                                                       const QString &username, const QString &credentialRef)
+{
+    DServiceExitControl exitControl;
+    if (!clientWhite(0)) {
+        return QString();
+    }
+    return m_accountManager->validateCalDavAccount(providerType, serverUrl, username, credentialRef);
+}
+
+QString DAccountManagerService::getCalDavAccountConfig(const QString &accountID)
+{
+    DServiceExitControl exitControl;
+    if (!clientWhite(0)) {
+        return QString();
+    }
+    return m_accountManager->getCalDavAccountConfig(accountID);
+}
+
+QString DAccountManagerService::validateCalDavAccountForUpdate(
+    const QString &accountID, int providerType, const QString &serverUrl,
+    const QString &username, const QString &credentialRef)
+{
+    DServiceExitControl exitControl;
+    if (!clientWhite(0)) {
+        return QString();
+    }
+    return m_accountManager->validateCalDavAccountForUpdate(
+        accountID, providerType, serverUrl, username, credentialRef);
+}
+
+QString DAccountManagerService::getCalDavAccountStatusList()
+{
+    DServiceExitControl exitControl;
+    if (!clientWhite(0)) {
+        return QStringLiteral("[]");
+    }
+    return m_accountManager->getCalDavAccountStatusList();
+}
+
+bool DAccountManagerService::updateCalDavCredentialReference(const QString &accountID, const QString &credentialRef)
+{
+    DServiceExitControl exitControl;
+    if (!clientWhite(0)) {
+        return false;
+    }
+    return m_accountManager->updateCalDavCredentialReference(accountID, credentialRef);
+}
+
+QString DAccountManagerService::createCalDavAccount(int providerType, const QString &serverUrl,
+                                                       const QString &username, const QString &credentialRef,
+                                                       const QString &displayName)
+{
+    DServiceExitControl exitControl;
+    if (!clientWhite(0)) {
+        return QString();
+    }
+    return m_accountManager->createCalDavAccount(
+        providerType, serverUrl, username, credentialRef, displayName);
+}
+
+bool DAccountManagerService::updateCalDavAccount(const QString &accountID, int providerType,
+                                                   const QString &serverUrl, const QString &username,
+                                                   const QString &credentialRef, const QString &displayName)
+{
+    DServiceExitControl exitControl;
+    if (!clientWhite(0)) {
+        return false;
+    }
+    return m_accountManager->updateCalDavAccount(
+        accountID, providerType, serverUrl, username, credentialRef, displayName);
+}
+
+bool DAccountManagerService::deleteCalDavAccount(const QString &accountID)
+{
+    DServiceExitControl exitControl;
+    if (!clientWhite(0)) {
+        return false;
+    }
+    return m_accountManager->deleteCalDavAccount(accountID);
+}
+
+bool DAccountManagerService::deleteCalDavAccountWithLocalDataOption(const QString &accountID,
+                                                                     bool deleteLocalData)
+{
+    DServiceExitControl exitControl;
+    if (!clientWhite(0)) {
+        return false;
+    }
+    return m_accountManager->deleteCalDavAccountWithLocalDataOption(accountID, deleteLocalData);
+}
+
+bool DAccountManagerService::resolveCalDavConflict(const QString &accountID,
+                                                        const QString &localScheduleID,
+                                                        bool keepLocal)
+{
+    DServiceExitControl exitControl;
+    if (!clientWhite(0)) {
+        return false;
+    }
+    return m_accountManager->resolveCalDavConflict(accountID, localScheduleID, keepLocal);
+}
+
+bool DAccountManagerService::resolveAllCalDavConflicts(const QString &accountID, bool keepLocal)
+{
+    DServiceExitControl exitControl;
+    if (!clientWhite(0)) {
+        return false;
+    }
+    return m_accountManager->resolveAllCalDavConflicts(accountID, keepLocal);
 }
 
 void DAccountManagerService::uploadNetWorkAccountData()

--- a/src/calendar-service/src/dbusservice/daccountmanagerservice.h
+++ b/src/calendar-service/src/dbusservice/daccountmanagerservice.h
@@ -48,6 +48,27 @@ public slots:
 
     Q_SCRIPTABLE void downloadByAccountID(const QString &accountID);
     Q_SCRIPTABLE void uploadNetWorkAccountData();
+    Q_SCRIPTABLE QString getCalDavAccountStatusList();
+    Q_SCRIPTABLE QString getCalDavAccountConfig(const QString &accountID);
+    Q_SCRIPTABLE QString validateCalDavAccountForUpdate(const QString &accountID, int providerType,
+                                                        const QString &serverUrl,
+                                                        const QString &username,
+                                                        const QString &credentialRef);
+    Q_SCRIPTABLE QString validateCalDavAccount(int providerType, const QString &serverUrl,
+                                               const QString &username, const QString &credentialRef);
+    Q_SCRIPTABLE bool updateCalDavCredentialReference(const QString &accountID, const QString &credentialRef);
+    Q_SCRIPTABLE QString createCalDavAccount(int providerType, const QString &serverUrl,
+                                             const QString &username, const QString &credentialRef,
+                                             const QString &displayName);
+    Q_SCRIPTABLE bool updateCalDavAccount(const QString &accountID, int providerType,
+                                          const QString &serverUrl, const QString &username,
+                                          const QString &credentialRef, const QString &displayName);
+    Q_SCRIPTABLE bool deleteCalDavAccount(const QString &accountID);
+    Q_SCRIPTABLE bool deleteCalDavAccountWithLocalDataOption(const QString &accountID,
+                                                              bool deleteLocalData);
+    Q_SCRIPTABLE bool resolveCalDavConflict(const QString &accountID,
+                                             const QString &localScheduleID, bool keepLocal);
+    Q_SCRIPTABLE bool resolveAllCalDavConflicts(const QString &accountID, bool keepLocal);
     //获取通用设置
     Q_SCRIPTABLE QString getCalendarGeneralSettings();
     //设置通用设置
@@ -63,6 +84,10 @@ public slots:
 
 signals:
     Q_SCRIPTABLE void accountUpdate();
+    Q_SCRIPTABLE void calDavAccountValidationFinished(const QString &requestID, bool success,
+                                                      int validationError, const QString &errorMessage,
+                                                      const QString &principalDisplayName);
+    Q_SCRIPTABLE void calDavAccountStatusChanged(const QString &accountID);
 private:
     int getfirstDayOfWeek() const;
     void setFirstDayOfWeek(const int firstday);

--- a/src/calendar-service/src/dbusservice/daccountservice.cpp
+++ b/src/calendar-service/src/dbusservice/daccountservice.cpp
@@ -12,6 +12,8 @@ DAccountService::DAccountService(const QString &path, const QString &interface, 
 {
     connect(m_accountModel.data(), &DAccountModule::signalScheduleUpdate, this, &DAccountService::scheduleUpdate);
     connect(m_accountModel.data(), &DAccountModule::signalScheduleTypeUpdate, this, &DAccountService::scheduleTypeUpdate);
+    connect(m_accountModel.data(), &DAccountModule::signalCalDavScheduleCreateFailed,
+            this, &DAccountService::calDavScheduleCreateFailed);
 
     connect(m_accountModel.data(), &DAccountModule::signalAccountState, this, [&]() {
         qCDebug(ServiceLogger) << "Account state changed, notifying property change";

--- a/src/calendar-service/src/dbusservice/daccountservice.h
+++ b/src/calendar-service/src/dbusservice/daccountservice.h
@@ -131,6 +131,7 @@ signals:
     //日程更新信号，日程颜色更新信号
     void scheduleUpdate();
     void scheduleTypeUpdate();
+    Q_SCRIPTABLE void calDavScheduleCreateFailed(int createFailure);
 
 private:
     //帐户列表是否展开


### PR DESCRIPTION
Add CalDAV account registration, validation, deletion, sync scheduling, and DBus service interfaces.

增加 CalDAV 账户注册、验证、删除、同步调度及 DBus 服务接口。

Log: 增加 CalDAV 服务端账户和 DBus 模块
PMS: TASK-393989
Influence: 提供 CalDAV 账户管理、验证、同步和服务端调用能力。

## Summary by Sourcery

Enable complete CalDAV account lifecycle management with validated discovery, resilient synchronization, local data integration, conflict handling, and DBus service support.

New Features:
- Add CalDAV account creation, update, deletion, credential management, server validation, status reporting, and conflict resolution capabilities.
- Discover CalDAV principals and calendars, create corresponding local calendar types, and initiate synchronization for readable collections.
- Expose CalDAV account management and validation operations through DBus APIs and signals.

Bug Fixes:
- Preserve and recover pending CalDAV account database deletion and local schedule operations across failures and restarts.
- Improve handling of CalDAV synchronization errors, retries, inaccessible calendars, and network restoration.

Enhancements:
- Integrate CalDAV accounts with local schedule CRUD operations, writable calendar/category mappings, outbox synchronization, and conflict recovery.
- Schedule daily, foreground, manual, retry, and network-restored CalDAV synchronization while keeping legacy network-account behavior unchanged.