### PR TITLE
feat(client): add CalDAV account data and DBus support

### DIFF
--- a/src/calendar-client/src/dataManage/accountitem.cpp
+++ b/src/calendar-client/src/dataManage/accountitem.cpp
@@ -28,6 +28,10 @@ void AccountItem::initConnect()
     connect(m_dbusRequest, &DbusAccountRequest::signalSyncStateChange, this, &AccountItem::slotSyncStateChange);
     connect(m_dbusRequest, &DbusAccountRequest::signalAccountStateChange, this, &AccountItem::slotAccountStateChange);
     connect(m_dbusRequest, &DbusAccountRequest::signalSearchUpdate, this, &AccountItem::slotSearchUpdata);
+    connect(m_dbusRequest, &DbusAccountRequest::signalCalDavScheduleCreateFailed, this,
+            [this](int createFailure) {
+        emit signalCalDavScheduleCreateFailed(m_account->accountID(), createFailure);
+    });
 }
 
 /**
@@ -67,7 +71,9 @@ QString AccountItem::getSyncMsg(DAccount::AccountSyncState code)
  */
 void AccountItem::resetAccount()
 {
-    qCDebug(ClientLogger) << "Resetting account data for:" << m_account->accountName();
+    qCDebug(ClientLogger) << "Resetting account data"
+                            << "accountId:" << m_account->accountID()
+                            << "accountName:" << m_account->accountName();
 
     // Optimization: Load only 3 months before and after the current month instead of the entire year
     // Use symmetric range: first day of month -3 to last day of month +3
@@ -85,7 +91,10 @@ void AccountItem::resetAccount()
     QDateTime start(startDate, QTime(0, 0, 0));
     QDateTime end(endDate, QTime(23, 59, 59));
 
-    qCDebug(ClientLogger) << "Loading schedules from" << start.toString() << "to" << end.toString();
+    qCDebug(ClientLogger) << "Loading schedules"
+                            << "accountId:" << m_account->accountID()
+                            << "start:" << start
+                            << "end:" << end;
     querySchedulesWithParameter(start, end);
 
     m_dbusRequest->getScheduleTypeList();
@@ -100,6 +109,14 @@ void AccountItem::resetAccount()
 DAccount::Ptr AccountItem::getAccount()
 {
     return m_account;
+}
+
+void AccountItem::updateAccount(const DAccount::Ptr &account)
+{
+    if (!account.isNull() && account->accountID() == m_account->accountID()) {
+        m_account = account;
+        emit signalAccountDataUpdate();
+    }
 }
 
 //获取日程
@@ -409,7 +426,11 @@ void AccountItem::querySchedulesWithParameter(const QDateTime &start, const QDat
 
 void AccountItem::querySchedulesWithParameter(const QString &key, const QDateTime &start, const QDateTime &end, CallbackFunc callback)
 {
-    qCDebug(ClientLogger) << "Querying schedules with key:" << key << "from" << start.toString() << "to" << end.toString() << "for account:" << m_account->accountName();
+    qCDebug(ClientLogger) << "Querying schedules"
+                            << "accountId:" << m_account->accountID()
+                            << "keyPresent:" << !key.isEmpty()
+                            << "start:" << start
+                            << "end:" << end;
     DScheduleQueryPar::Ptr ptr;
     ptr.reset(new DScheduleQueryPar);
     ptr->setKey(key);
@@ -426,10 +447,11 @@ void AccountItem::querySchedulesWithParameter(const QString &key, const QDateTim
  */
 void AccountItem::querySchedulesWithParameter(const DScheduleQueryPar::Ptr &params, CallbackFunc callback)
 {
-    qCDebug(ClientLogger) << "Querying schedules with parameters for account:" << m_account->accountName()
-                          << "key:" << params->key()
-                          << "start:" << params->dtStart().toString()
-                          << "end:" << params->dtEnd().toString();
+    qCDebug(ClientLogger) << "Querying schedules with parameters"
+                            << "accountId:" << m_account->accountID()
+                            << "keyPresent:" << !params->key().isEmpty()
+                            << "start:" << params->dtStart()
+                            << "end:" << params->dtEnd();
     m_preQuery = params;
     m_dbusRequest->setCallbackFunc(callback);
     m_dbusRequest->querySchedulesWithParameter(params);
@@ -497,7 +519,14 @@ void AccountItem::slotGetScheduleTypeListFinish(DScheduleType::List scheduleType
  */
 void AccountItem::slotGetScheduleListFinish(QMap<QDate, DSchedule::List> map)
 {
-    qCDebug(ClientLogger) << "Received schedule list with" << map.size() << "dates for account:" << m_account->accountName();
+    int scheduleCount = 0;
+    for (const DSchedule::List &schedules : map) {
+        scheduleCount += schedules.size();
+    }
+    qCDebug(ClientLogger) << "Received schedule list"
+                            << "accountId:" << m_account->accountID()
+                            << "dateCount:" << map.size()
+                            << "scheduleCount:" << scheduleCount;
     m_scheduleMap = map;
     emit signalScheduleUpdate();
 }

--- a/src/calendar-client/src/dataManage/accountitem.h
+++ b/src/calendar-client/src/dataManage/accountitem.h
@@ -24,6 +24,7 @@ public:
 
     //获取帐户数据
     DAccount::Ptr getAccount();
+    void updateAccount(const DAccount::Ptr &account);
 
     //获取日程
     QMap<QDate, DSchedule::List> getScheduleMap();
@@ -114,6 +115,7 @@ signals:
     void signalDtLastUpdate(QString);
     void signalAccountStateChange();
     void signalSyncStateChange(DAccount::AccountSyncState);
+    void signalCalDavScheduleCreateFailed(const QString &accountID, int createFailure);
 
 public slots:
     //获取帐户信息完成事件

--- a/src/calendar-client/src/dataManage/accountmanager.cpp
+++ b/src/calendar-client/src/dataManage/accountmanager.cpp
@@ -14,6 +14,7 @@ AccountManager::AccountManager(QObject *parent)
     qCDebug(ClientLogger) << "Creating AccountManager";
     initConnect();
     m_dbusRequest->clientIsShow(true);
+    m_dbusRequest->getCalDavAccountStatusList();
 
     if (isCommunityEdition()) {
         m_isSupportUid = false;
@@ -31,12 +32,141 @@ void AccountManager::initConnect()
     connect(m_dbusRequest, &DbusAccountManagerRequest::signalGetAccountListFinish, this, &AccountManager::slotGetAccountListFinish);
     connect(m_dbusRequest, &DbusAccountManagerRequest::signalGetGeneralSettingsFinish, this, &AccountManager::slotGetGeneralSettingsFinish);
     connect(m_dbusRequest, &DbusAccountManagerRequest::signalGetIsSupportUidFinish, this, &AccountManager::slotGetIsSupportUidFinish);
+    connect(m_dbusRequest, &DbusAccountManagerRequest::signalGetCalDavAccountStatusListFinish,
+            this, &AccountManager::slotGetCalDavAccountStatusListFinish);
+    connect(m_dbusRequest, &DbusAccountManagerRequest::signalValidateCalDavAccountStart,
+            this, [this](const QString &requestID) {
+        qCDebug(ClientLogger) << "Forwarding CalDAV validation start"
+                                << "accountManager:" << this
+                                << "requestIdPresent:" << !requestID.isEmpty()
+                                << "receiverCount:"
+                                << receivers(SIGNAL(signalCalDavAccountValidationStarted(QString)));
+        emit signalCalDavAccountValidationStarted(requestID);
+    });
+    connect(m_dbusRequest, &DbusAccountManagerRequest::signalValidateCalDavAccountForUpdateStart,
+            this, [this](const QString &requestID) {
+        qCDebug(ClientLogger) << "Forwarding CalDAV update validation start"
+                                << "accountManager:" << this
+                                << "requestIdPresent:" << !requestID.isEmpty()
+                                << "receiverCount:"
+                                << receivers(SIGNAL(signalCalDavAccountValidationForUpdateStarted(QString)));
+        emit signalCalDavAccountValidationForUpdateStarted(requestID);
+    });
+    connect(m_dbusRequest, &DbusAccountManagerRequest::signalGetCalDavAccountConfigFinish,
+            this, &AccountManager::signalGetCalDavAccountConfigFinish);
+    connect(m_dbusRequest, &DbusAccountManagerRequest::signalUpdateCalDavAccountFinish,
+            this, &AccountManager::signalUpdateCalDavAccountFinish);
+    connect(m_dbusRequest, &DbusAccountManagerRequest::signalCalDavAccountValidationFinished,
+            this, [this](const QString &requestID, bool success, int validationError,
+                         const QString &errorMessage, const QString &principalDisplayName) {
+        qCDebug(ClientLogger) << "Forwarding CalDAV validation result"
+                                << "accountManager:" << this
+                                << "requestIdPresent:" << !requestID.isEmpty()
+                                << "success:" << success
+                                << "validationError:" << validationError
+                                << "errorPresent:" << !errorMessage.isEmpty()
+                                << "principalDisplayNamePresent:" << !principalDisplayName.isEmpty()
+                                << "receiverCount:"
+                                << receivers(SIGNAL(signalCalDavAccountValidationFinished(QString,bool,int,QString,QString)));
+        emit signalCalDavAccountValidationFinished(requestID, success, validationError, errorMessage,
+                                                    principalDisplayName);
+    });
+    connect(m_dbusRequest, &DbusAccountManagerRequest::signalCreateCalDavAccountFinish,
+            this, [this](const QString &accountID) {
+        if (!accountID.isEmpty()) {
+            if (m_pendingCalDavProviderType >= 0) {
+                m_calDavProviderTypeOverrides.insert(accountID, m_pendingCalDavProviderType);
+                DCalDavAccountStatus &status = m_calDavAccountStatuses[accountID];
+                status.accountId = accountID;
+                status.providerType = m_pendingCalDavProviderType;
+            }
+            m_pendingCalDavProviderType = -1;
+            // Refresh immediately so the new account starts loading its schedule data
+            // without waiting for a later settings refresh or application restart.
+            m_dbusRequest->getAccountList();
+        }
+        emit signalCreateCalDavAccountFinish(accountID);
+    });
+    connect(m_dbusRequest, &DbusAccountManagerRequest::signalDeleteCalDavAccountFinish,
+            this, [this](bool success) {
+        if (success && !m_pendingCalDavDeleteAccountID.isEmpty()) {
+            m_calDavProviderTypeOverrides.remove(m_pendingCalDavDeleteAccountID);
+            m_calDavAccountStatuses.remove(m_pendingCalDavDeleteAccountID);
+        }
+        m_pendingCalDavDeleteAccountID.clear();
+        emit signalDeleteCalDavAccountFinish(success);
+    });
+    connect(m_dbusRequest, &DbusAccountManagerRequest::signalCalDavAccountRequestFailed,
+            this, &AccountManager::signalCalDavAccountRequestFailed);
+}
+
+DCalDavAccountStatus AccountManager::getCalDavAccountStatus(const QString &accountID) const
+{
+    return m_calDavAccountStatuses.value(accountID);
+}
+
+bool AccountManager::canWriteCalDavAccount(const QString &accountID) const
+{
+    const DCalDavAccountStatus status = m_calDavAccountStatuses.value(accountID);
+    return !status.accountId.isEmpty() && status.supportsWrite;
 }
 
 bool AccountManager::getIsSupportUid() const
 {
     qCDebug(ClientLogger) << "Getting isSupportUid:" << m_isSupportUid;
     return m_isSupportUid;
+}
+
+void AccountManager::slotGetCalDavAccountStatusListFinish(DCalDavAccountStatus::List statusList)
+{
+    QHash<QString, DCalDavAccountStatus> updatedStatuses;
+    for (const DCalDavAccountStatus &status : statusList) {
+        updatedStatuses.insert(status.accountId, status);
+    }
+    for (auto it = m_calDavProviderTypeOverrides.cbegin();
+         it != m_calDavProviderTypeOverrides.cend(); ++it) {
+        auto status = updatedStatuses.find(it.key());
+        if (status != updatedStatuses.end()) {
+            status->providerType = it.value();
+        }
+    }
+
+    // The first status query is an initial snapshot, not a new failure event.
+    // Do not notify consumers here, otherwise a previously persisted failure
+    // would show a stale toast when the calendar starts.
+    const bool shouldNotifyChanges = m_calDavStatusesInitialized;
+    const QHash<QString, DCalDavAccountStatus> previousStatuses = m_calDavAccountStatuses;
+    m_calDavAccountStatuses = updatedStatuses;
+    m_calDavStatusesInitialized = true;
+    if (!shouldNotifyChanges) {
+        // The initial snapshot is intentionally not exposed as a status-change
+        // event, otherwise persisted failures could trigger stale toasts. The
+        // settings page still needs a separate notification to refresh actions
+        // that depend on supportsWrite.
+        emit signalCalDavAccountStatusReady();
+        return;
+    }
+
+    for (auto it = updatedStatuses.cbegin(); it != updatedStatuses.cend(); ++it) {
+        const DCalDavAccountStatus previous = previousStatuses.value(it.key());
+        const DCalDavAccountStatus &current = it.value();
+        if (previous.accountId != current.accountId
+            || previous.displayName != current.displayName
+            || previous.providerType != current.providerType
+            || previous.syncStatus != current.syncStatus
+            || previous.lastSuccessfulSync != current.lastSuccessfulSync
+            || previous.failureReason != current.failureReason
+            || previous.failureCode != current.failureCode
+            || previous.accountColor != current.accountColor
+            || previous.supportsWrite != current.supportsWrite
+            || previous.pendingOperationCount != current.pendingOperationCount
+            || previous.pendingDeleteCount != current.pendingDeleteCount
+            || previous.conflictCount != current.conflictCount
+            || previous.nextRetryAt != current.nextRetryAt) {
+            emit signalCalDavAccountStatusChanged(current.accountId);
+        }
+    }
+    emit signalCalDavAccountStatusReady();
 }
 
 void AccountManager::slotGetIsSupportUidFinish(bool supported)
@@ -86,6 +216,9 @@ QList<AccountItem::Ptr> AccountManager::getAccountList()
     if (nullptr != m_unionAccountItem.data()) {
         qCDebug(ClientLogger) << "Adding union account to list";
         accountList.append(m_unionAccountItem);
+    }
+    for (const AccountItem::Ptr &account : m_calDavAccountItems) {
+        accountList.append(account);
     }
     qCDebug(ClientLogger) << "Returning" << accountList.size() << "accounts";
     return accountList;
@@ -214,6 +347,58 @@ void AccountManager::downloadByAccountID(const QString &accountID, CallbackFunc 
  * 更新网络帐户数据
  * @param callback 回调函数
  */
+void AccountManager::validateCalDavAccount(int providerType, const QString &serverUrl,
+                                             const QString &username, const QString &credentialRef)
+{
+    m_dbusRequest->validateCalDavAccount(providerType, serverUrl, username, credentialRef);
+}
+
+void AccountManager::deleteCalDavAccountWithLocalDataOption(const QString &accountID,
+                                                             bool deleteLocalData)
+{
+    m_pendingCalDavDeleteAccountID = accountID;
+    m_dbusRequest->deleteCalDavAccountWithLocalDataOption(accountID, deleteLocalData);
+}
+
+void AccountManager::getCalDavAccountConfig(const QString &accountID)
+{
+    m_dbusRequest->getCalDavAccountConfig(accountID);
+}
+
+void AccountManager::validateCalDavAccountForUpdate(
+    const QString &accountID, int providerType, const QString &serverUrl,
+    const QString &username, const QString &credentialRef)
+{
+    m_dbusRequest->validateCalDavAccountForUpdate(
+        accountID, providerType, serverUrl, username, credentialRef);
+}
+
+void AccountManager::createCalDavAccount(int providerType, const QString &serverUrl,
+                                           const QString &username, const QString &credentialRef,
+                                           const QString &displayName)
+{
+    m_pendingCalDavProviderType = providerType;
+    m_dbusRequest->createCalDavAccount(providerType, serverUrl, username, credentialRef, displayName);
+}
+
+void AccountManager::updateCalDavAccount(const QString &accountID, int providerType,
+                                          const QString &serverUrl, const QString &username,
+                                          const QString &credentialRef, const QString &displayName)
+{
+    m_calDavProviderTypeOverrides.insert(accountID, providerType);
+    if (m_calDavAccountStatuses.contains(accountID)) {
+        m_calDavAccountStatuses[accountID].providerType = providerType;
+        emit signalCalDavAccountStatusChanged(accountID);
+    }
+    m_dbusRequest->updateCalDavAccount(accountID, providerType, serverUrl, username, credentialRef,
+                                       displayName);
+}
+
+void AccountManager::resolveAllCalDavConflicts(const QString &accountID, bool keepLocal)
+{
+    m_dbusRequest->resolveAllCalDavConflicts(accountID, keepLocal);
+}
+
 void AccountManager::uploadNetWorkAccountData(CallbackFunc callback)
 {
     qCDebug(ClientLogger) << "Uploading network account data";
@@ -294,6 +479,12 @@ void AccountManager::slotGetAccountListFinish(DAccount::List accountList)
 {
     qCDebug(ClientLogger) << "Received account list with" << accountList.size() << "accounts";
     bool hasUnionAccount = false;
+    QHash<QString, AccountItem::Ptr> existingCalDavAccounts;
+    for (const AccountItem::Ptr &item : m_calDavAccountItems) {
+        existingCalDavAccounts.insert(item->getAccount()->accountID(), item);
+    }
+    QList<AccountItem::Ptr> updatedCalDavAccounts;
+    QStringList currentCalDavAccountIDs;
     for (DAccount::Ptr account : accountList) {
         if (account->accountType() == DAccount::Account_Local) {
             qCDebug(ClientLogger) << "Processing local account";
@@ -307,7 +498,7 @@ void AccountManager::slotGetAccountListFinish(DAccount::List accountList)
                 qCDebug(ClientLogger) << "Creating new local account item";
                 m_localAccountItem.reset(new AccountItem(account, this));
             }
-            m_localAccountItem->resetAccount();
+
 
         } else if (account->accountType() == DAccount::Account_UnionID && !isCommunityEdition()) {
             qCDebug(ClientLogger) << "Processing UnionID account:" << account->accountName();
@@ -315,28 +506,64 @@ void AccountManager::slotGetAccountListFinish(DAccount::List accountList)
             if (!m_unionAccountItem) {
                 qCDebug(ClientLogger) << "Creating new union account item";
                 m_unionAccountItem.reset(new AccountItem(account, this));
-                m_unionAccountItem->resetAccount();
             } else if (m_unionAccountItem && m_unionAccountItem->getAccount()->accountID() != account->accountID()) {
                 qCDebug(ClientLogger) << "Union account ID changed, creating new union account item";
                 emit m_unionAccountItem->signalLogout(m_unionAccountItem->getAccount()->accountType());
                 m_unionAccountItem.reset(new AccountItem(account, this));
-                m_unionAccountItem->resetAccount();
             }
+        } else if (account->accountType() == DAccount::Account_CalDav) {
+            currentCalDavAccountIDs.append(account->accountID());
+            AccountItem::Ptr item = existingCalDavAccounts.value(account->accountID());
+            if (!item) {
+                item.reset(new AccountItem(account, this));
+            } else {
+                item->updateAccount(account);
+            }
+            updatedCalDavAccounts.append(item);
         }
     }
+    m_calDavAccountItems = updatedCalDavAccounts;
+    for (auto it = m_calDavProviderTypeOverrides.begin();
+         it != m_calDavProviderTypeOverrides.end();) {
+        if (!currentCalDavAccountIDs.contains(it.key())) {
+            it = m_calDavProviderTypeOverrides.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
     if (!hasUnionAccount && m_unionAccountItem) {
         qCDebug(ClientLogger) << "No union account in list but union account item exists, clearing it";
         emit m_unionAccountItem->signalLogout(m_unionAccountItem->getAccount()->accountType());
         m_unionAccountItem.reset(nullptr);
     }
 
+    // Install all account signal connections before starting asynchronous
+    // data queries. A local CalDAV database can answer quickly, so starting a
+    // query before these connections are in place may lose the result and
+    // leave the calendar view without the remote schedules.
     for (AccountItem::Ptr p : getAccountList()) {
-        qCDebug(ClientLogger) << "Setting up connections for account:" << p->getAccount()->accountName();
-        connect(p.data(), &AccountItem::signalScheduleUpdate, this, &AccountManager::signalScheduleUpdate);
-        connect(p.data(), &AccountItem::signalSearchScheduleUpdate, this, &AccountManager::signalSearchScheduleUpdate);
-        connect(p.data(), &AccountItem::signalScheduleTypeUpdate, this, &AccountManager::signalScheduleTypeUpdate);
-        connect(p.data(), &AccountItem::signalLogout, this, &AccountManager::signalLogout);
-        connect(p.data(), &AccountItem::signalAccountStateChange, this, &AccountManager::signalAccountStateChange);
+        qCDebug(ClientLogger) << "Setting up account data connections"
+                                << "accountId:" << p->getAccount()->accountID()
+                                << "accountType:" << p->getAccount()->accountType();
+        connect(p.data(), &AccountItem::signalScheduleUpdate, this, &AccountManager::signalScheduleUpdate,
+                Qt::UniqueConnection);
+        connect(p.data(), &AccountItem::signalSearchScheduleUpdate, this, &AccountManager::signalSearchScheduleUpdate,
+                Qt::UniqueConnection);
+        connect(p.data(), &AccountItem::signalScheduleTypeUpdate, this, &AccountManager::signalScheduleTypeUpdate,
+                Qt::UniqueConnection);
+        connect(p.data(), &AccountItem::signalLogout, this, &AccountManager::signalLogout,
+                Qt::UniqueConnection);
+        connect(p.data(), &AccountItem::signalAccountStateChange, this, &AccountManager::signalAccountStateChange,
+                Qt::UniqueConnection);
+        connect(p.data(), &AccountItem::signalCalDavScheduleCreateFailed, this,
+                &AccountManager::signalCalDavScheduleCreateFailed, Qt::UniqueConnection);
+    }
+
+    // Start loading only after the account list and all forwarding connections
+    // are ready.
+    for (AccountItem::Ptr p : getAccountList()) {
+        p->resetAccount();
     }
 
     emit signalAccountUpdate();

--- a/src/calendar-client/src/dataManage/accountmanager.h
+++ b/src/calendar-client/src/dataManage/accountmanager.h
@@ -9,6 +9,9 @@
 #include "accountitem.h"
 #include "dcalendargeneralsettings.h"
 
+#include <QHash>
+#include <QString>
+
 //所有帐户管理类
 class AccountManager : public QObject
 {
@@ -33,6 +36,19 @@ public:
     void downloadByAccountID(const QString &accountID, CallbackFunc callback = nullptr);
     //更新网络帐户数据
     void uploadNetWorkAccountData(CallbackFunc callback = nullptr);
+    void validateCalDavAccount(int providerType, const QString &serverUrl, const QString &username,
+                                const QString &credentialRef);
+    void getCalDavAccountConfig(const QString &accountID);
+    void validateCalDavAccountForUpdate(const QString &accountID, int providerType,
+                                        const QString &serverUrl, const QString &username,
+                                        const QString &credentialRef);
+    void deleteCalDavAccountWithLocalDataOption(const QString &accountID, bool deleteLocalData);
+    void resolveAllCalDavConflicts(const QString &accountID, bool keepLocal);
+    void createCalDavAccount(int providerType, const QString &serverUrl, const QString &username,
+                             const QString &credentialRef, const QString &displayName);
+    void updateCalDavAccount(const QString &accountID, int providerType,
+                             const QString &serverUrl, const QString &username,
+                             const QString &credentialRef, const QString &displayName);
 
     //设置一周首日
     void setFirstDayofWeek(int);
@@ -52,6 +68,8 @@ public:
     void loginout();
 
     bool getIsSupportUid() const;
+    DCalDavAccountStatus getCalDavAccountStatus(const QString &accountID) const;
+    bool canWriteCalDavAccount(const QString &accountID) const;
 
 signals:
     void signalDataInitFinished();
@@ -63,6 +81,19 @@ signals:
     void signalScheduleTypeUpdate();
     void signalSearchScheduleUpdate();
     void signalAccountStateChange();
+    void signalCalDavAccountStatusChanged(const QString &accountID);
+    void signalCalDavAccountStatusReady();
+    void signalCalDavScheduleCreateFailed(const QString &accountID, int createFailure);
+    void signalCalDavAccountValidationStarted(const QString &requestID);
+    void signalCalDavAccountValidationForUpdateStarted(const QString &requestID);
+    void signalGetCalDavAccountConfigFinish(const QString &config);
+    void signalCalDavAccountValidationFinished(const QString &requestID, bool success,
+                                               int validationError, const QString &errorMessage,
+                                               const QString &principalDisplayName);
+    void signalCreateCalDavAccountFinish(const QString &accountID);
+    void signalDeleteCalDavAccountFinish(bool success);
+    void signalUpdateCalDavAccountFinish(bool success);
+    void signalCalDavAccountRequestFailed(const QString &method, const QString &errorMessage);
 
     //正在同步
     void signalSyncNum(const int num = -1);
@@ -77,6 +108,7 @@ public slots:
     void slotGetGeneralSettingsFinish(DCalendarGeneralSettings::Ptr ptr);
     //获取是否支持UID完成事件
     void slotGetIsSupportUidFinish(bool supported);
+    void slotGetCalDavAccountStatusListFinish(DCalDavAccountStatus::List statusList);
 
 protected:
     explicit AccountManager(QObject *parent = nullptr);
@@ -88,6 +120,12 @@ private:
     static AccountManager *m_accountManager;
     AccountItem::Ptr  m_localAccountItem;
     AccountItem::Ptr  m_unionAccountItem;
+    QList<AccountItem::Ptr> m_calDavAccountItems;
+    QHash<QString, DCalDavAccountStatus> m_calDavAccountStatuses;
+    bool m_calDavStatusesInitialized = false;
+    QHash<QString, int> m_calDavProviderTypeOverrides;
+    int m_pendingCalDavProviderType = -1;
+    QString m_pendingCalDavDeleteAccountID;
     DCalendarGeneralSettings::Ptr m_settings;
 
     DbusAccountManagerRequest *m_dbusRequest;

--- a/src/calendar-client/src/dbus/dbusaccountmanagerrequest.cpp
+++ b/src/calendar-client/src/dbus/dbusaccountmanagerrequest.cpp
@@ -12,7 +12,17 @@
 DbusAccountManagerRequest::DbusAccountManagerRequest(QObject *parent)
     : DbusRequestBase("/com/deepin/dataserver/Calendar/AccountManager", "com.deepin.dataserver.Calendar.AccountManager", QDBusConnection::sessionBus(), parent)
 {
-
+    const auto connectSignal = [this](const char *signal, const char *signature) {
+        if (!QDBusConnection::sessionBus().connect(this->service(), this->path(),
+                                                   this->interface(), signal, signature, this,
+                                                   SLOT(slotDbusCall(QDBusMessage)))) {
+            qCWarning(ClientLogger) << "Failed to connect account manager DBus signal:"
+                                    << signal << "path:" << this->path();
+        }
+    };
+    connectSignal("accountUpdate", "");
+    connectSignal("calDavAccountStatusChanged", "s");
+    connectSignal("calDavAccountValidationFinished", "sbiss");
 }
 
 /**
@@ -122,6 +132,66 @@ void DbusAccountManagerRequest::downloadByAccountID(const QString &accountID)
  * @brief DbusAccountManagerRequest::uploadNetWorkAccountData
  * 更新网络帐户数据
  */
+void DbusAccountManagerRequest::getCalDavAccountStatusList()
+{
+    asyncCall("getCalDavAccountStatusList");
+}
+
+void DbusAccountManagerRequest::validateCalDavAccount(int providerType, const QString &serverUrl,
+                                                        const QString &username, const QString &credentialRef)
+{
+    asyncCall("validateCalDavAccount", {providerType, serverUrl, username, credentialRef});
+}
+
+void DbusAccountManagerRequest::getCalDavAccountConfig(const QString &accountID)
+{
+    asyncCall("getCalDavAccountConfig", {accountID});
+}
+
+void DbusAccountManagerRequest::validateCalDavAccountForUpdate(
+    const QString &accountID, int providerType, const QString &serverUrl,
+    const QString &username, const QString &credentialRef)
+{
+    asyncCall("validateCalDavAccountForUpdate",
+              {accountID, providerType, serverUrl, username, credentialRef});
+}
+
+void DbusAccountManagerRequest::updateCalDavCredentialReference(const QString &accountID, const QString &credentialRef)
+{
+    asyncCall("updateCalDavCredentialReference", {accountID, credentialRef});
+}
+
+void DbusAccountManagerRequest::createCalDavAccount(int providerType, const QString &serverUrl,
+                                                     const QString &username, const QString &credentialRef,
+                                                     const QString &displayName)
+{
+    asyncCall("createCalDavAccount", {providerType, serverUrl, username, credentialRef, displayName});
+}
+
+void DbusAccountManagerRequest::updateCalDavAccount(const QString &accountID, int providerType,
+                                                     const QString &serverUrl, const QString &username,
+                                                     const QString &credentialRef, const QString &displayName)
+{
+    asyncCall("updateCalDavAccount", {accountID, providerType, serverUrl, username, credentialRef,
+                                        displayName});
+}
+
+void DbusAccountManagerRequest::deleteCalDavAccount(const QString &accountID)
+{
+    asyncCall("deleteCalDavAccount", {accountID});
+}
+
+void DbusAccountManagerRequest::deleteCalDavAccountWithLocalDataOption(const QString &accountID,
+                                                                    bool deleteLocalData)
+{
+    asyncCall("deleteCalDavAccountWithLocalDataOption", {accountID, deleteLocalData});
+}
+
+void DbusAccountManagerRequest::resolveAllCalDavConflicts(const QString &accountID, bool keepLocal)
+{
+    asyncCall("resolveAllCalDavConflicts", {accountID, keepLocal});
+}
+
 void DbusAccountManagerRequest::uploadNetWorkAccountData()
 {
     asyncCall("uploadNetWorkAccountData");
@@ -193,8 +263,14 @@ void DbusAccountManagerRequest::slotCallFinished(CDBusPendingCallWatcher *call)
     
     //错误处理
     if (call->isError()) {
-        qCWarning(ClientLogger) << "DBus call error - Method:" << call->reply().member()
-                               << "Error:" << call->error().message();
+        qCWarning(ClientLogger) << "DBus call error - Method:" << call->getmember()
+                                << "Error:" << call->error().message();
+        if (call->getmember() == QStringLiteral("validateCalDavAccount")
+            || call->getmember() == QStringLiteral("validateCalDavAccountForUpdate")
+            || call->getmember() == QStringLiteral("createCalDavAccount")
+            || call->getmember() == QStringLiteral("updateCalDavAccount")) {
+            emit signalCalDavAccountRequestFailed(call->getmember(), call->error().message());
+        }
         // Retry critical calls synchronously on failure
         if (call->getmember() == "getAccountList") {
             qCInfo(ClientLogger) << "Retrying getAccountList synchronously";
@@ -261,6 +337,61 @@ void DbusAccountManagerRequest::slotCallFinished(CDBusPendingCallWatcher *call)
         QDBusPendingReply<bool> reply = *call;
         const bool supported = reply.argumentAt<0>();
         emit signalGetIsSupportUidFinish(supported);
+    } else if (call->getmember() == "validateCalDavAccount") {
+        QDBusPendingReply<QString> reply = *call;
+        const QString requestID = reply.argumentAt<0>();
+        qCDebug(ClientLogger) << "CalDAV validation DBus method returned"
+                                << "requestIdPresent:" << !requestID.isEmpty();
+        emit signalValidateCalDavAccountStart(requestID);
+        ret = requestID.isEmpty() ? 1 : 0;
+    } else if (call->getmember() == "getCalDavAccountConfig") {
+        QDBusPendingReply<QString> reply = *call;
+        emit signalGetCalDavAccountConfigFinish(reply.argumentAt<0>());
+        ret = reply.argumentAt<0>().isEmpty() ? 1 : 0;
+    } else if (call->getmember() == "validateCalDavAccountForUpdate") {
+        QDBusPendingReply<QString> reply = *call;
+        const QString requestID = reply.argumentAt<0>();
+        qCDebug(ClientLogger) << "CalDAV update validation DBus method returned"
+                                << "requestIdPresent:" << !requestID.isEmpty();
+        emit signalValidateCalDavAccountForUpdateStart(requestID);
+        ret = requestID.isEmpty() ? 1 : 0;
+    } else if (call->getmember() == "getCalDavAccountStatusList") {
+        QDBusPendingReply<QString> reply = *call;
+        DCalDavAccountStatus::List statusList;
+        if (DCalDavAccountStatus::fromJsonListString(statusList, reply.argumentAt<0>())) {
+            emit signalGetCalDavAccountStatusListFinish(statusList);
+        } else {
+            qCWarning(ClientLogger) << "Failed to parse CalDAV account status list";
+            ret = 2;
+        }
+    } else if (call->getmember() == "updateCalDavCredentialReference") {
+        QDBusPendingReply<bool> reply = *call;
+        ret = reply.argumentAt<0>() ? 0 : 1;
+    } else if (call->getmember() == "createCalDavAccount") {
+        QDBusPendingReply<QString> reply = *call;
+        const QString accountID = reply.argumentAt<0>();
+        qCDebug(ClientLogger) << "CalDAV account creation DBus method returned"
+                                << "accountIdPresent:" << !accountID.isEmpty();
+        emit signalCreateCalDavAccountFinish(accountID);
+        ret = accountID.isEmpty() ? 1 : 0;
+    } else if (call->getmember() == "updateCalDavAccount") {
+        QDBusPendingReply<bool> reply = *call;
+        const bool success = reply.argumentAt<0>();
+        emit signalUpdateCalDavAccountFinish(success);
+        ret = success ? 0 : 1;
+    } else if (call->getmember() == "deleteCalDavAccount") {
+        QDBusPendingReply<bool> reply = *call;
+        const bool success = reply.argumentAt<0>();
+        emit signalDeleteCalDavAccountFinish(success);
+        ret = success ? 0 : 1;
+    } else if (call->getmember() == "deleteCalDavAccountWithLocalDataOption") {
+        QDBusPendingReply<bool> reply = *call;
+        const bool success = reply.argumentAt<0>();
+        emit signalDeleteCalDavAccountFinish(success);
+        ret = success ? 0 : 1;
+    } else if (call->getmember() == "resolveAllCalDavConflicts") {
+        QDBusPendingReply<bool> reply = *call;
+        ret = reply.argumentAt<0>() ? 0 : 1;
     } else if (call->getmember() == "setCalendarGeneralSettings") {
         qCDebug(ClientLogger) << "Processing setCalendarGeneralSettings response";
         canCall = false;
@@ -283,6 +414,22 @@ void DbusAccountManagerRequest::slotDbusCall(const QDBusMessage &msg)
     if (msg.member() == "accountUpdate") {
         qCDebug(ClientLogger) << "Account update signal received, refreshing account list";
         getAccountList();
+    } else if (msg.member() == "calDavAccountStatusChanged") {
+        getCalDavAccountStatusList();
+    } else if (msg.member() == "calDavAccountValidationFinished") {
+        const QString requestID = msg.arguments().value(0).toString();
+        const bool success = msg.arguments().value(1).toBool();
+        const int validationError = msg.arguments().value(2).toInt();
+        const QString errorMessage = msg.arguments().value(3).toString();
+        const QString principalDisplayName = msg.arguments().value(4).toString();
+        qCDebug(ClientLogger) << "Received CalDAV validation result signal"
+                                << "requestIdPresent:" << !requestID.isEmpty()
+                                << "success:" << success
+                                << "validationError:" << validationError
+                                << "errorPresent:" << !errorMessage.isEmpty()
+                                << "principalDisplayNamePresent:" << !principalDisplayName.isEmpty();
+        emit signalCalDavAccountValidationFinished(requestID, success, validationError, errorMessage,
+                                                    principalDisplayName);
     } else if (msg.member() == "PropertiesChanged") {
         qCDebug(ClientLogger) << "Properties changed signal received";
         QDBusPendingReply<QString, QVariantMap, QStringList> reply = msg;

--- a/src/calendar-client/src/dbus/dbusaccountmanagerrequest.h
+++ b/src/calendar-client/src/dbus/dbusaccountmanagerrequest.h
@@ -8,6 +8,7 @@
 #include "dbusrequestbase.h"
 #include "daccount.h"
 #include "dcalendargeneralsettings.h"
+#include "dcaldavaccountstatus.h"
 
 //所有帐户信息管理类
 class DbusAccountManagerRequest : public DbusRequestBase
@@ -35,6 +36,22 @@ public:
     void downloadByAccountID(const QString &accountID);
     //更新网络帐户数据
     void uploadNetWorkAccountData();
+    void getCalDavAccountStatusList();
+    void getCalDavAccountConfig(const QString &accountID);
+    void validateCalDavAccountForUpdate(const QString &accountID, int providerType,
+                                        const QString &serverUrl, const QString &username,
+                                        const QString &credentialRef);
+    void validateCalDavAccount(int providerType, const QString &serverUrl,
+                               const QString &username, const QString &credentialRef);
+    void updateCalDavCredentialReference(const QString &accountID, const QString &credentialRef);
+    void createCalDavAccount(int providerType, const QString &serverUrl, const QString &username,
+                             const QString &credentialRef, const QString &displayName);
+    void updateCalDavAccount(const QString &accountID, int providerType, const QString &serverUrl,
+                             const QString &username, const QString &credentialRef,
+                             const QString &displayName);
+    void deleteCalDavAccount(const QString &accountID);
+    void deleteCalDavAccountWithLocalDataOption(const QString &accountID, bool deleteLocalData);
+    void resolveAllCalDavConflicts(const QString &accountID, bool keepLocal);
     //获取通用设置
     void getCalendarGeneralSettings();
     //
@@ -56,6 +73,17 @@ signals:
     void signalGetGeneralSettingsFinish(DCalendarGeneralSettings::Ptr ptr);
     //获取是否支持UID完成信号
     void signalGetIsSupportUidFinish(bool supported);
+    void signalGetCalDavAccountStatusListFinish(DCalDavAccountStatus::List statusList);
+    void signalGetCalDavAccountConfigFinish(const QString &config);
+    void signalValidateCalDavAccountForUpdateStart(const QString &requestID);
+    void signalValidateCalDavAccountStart(const QString &requestID);
+    void signalCalDavAccountValidationFinished(const QString &requestID, bool success,
+                                               int validationError, const QString &errorMessage,
+                                               const QString &principalDisplayName);
+    void signalCreateCalDavAccountFinish(const QString &accountID);
+    void signalUpdateCalDavAccountFinish(bool success);
+    void signalDeleteCalDavAccountFinish(bool success);
+    void signalCalDavAccountRequestFailed(const QString &method, const QString &errorMessage);
 
 public slots:
     //dbus调用完成事件

--- a/src/calendar-client/src/dbus/dbusaccountrequest.cpp
+++ b/src/calendar-client/src/dbus/dbusaccountrequest.cpp
@@ -12,6 +12,17 @@
 DbusAccountRequest::DbusAccountRequest(const QString &path, const QString &interface, QObject *parent)
     : DbusRequestBase(path, interface, QDBusConnection::sessionBus(), parent)
 {
+    const auto connectSignal = [this](const char *signal, const char *signature) {
+        if (!QDBusConnection::sessionBus().connect(this->service(), this->path(),
+                                                   this->interface(), signal, signature, this,
+                                                   SLOT(slotDbusCall(QDBusMessage)))) {
+            qCWarning(ClientLogger) << "Failed to connect account DBus signal:"
+                                    << signal << "path:" << this->path();
+        }
+    };
+    connectSignal("scheduleUpdate", "");
+    connectSignal("scheduleTypeUpdate", "");
+    connectSignal("calDavScheduleCreateFailed", "i");
 }
 
 /**
@@ -271,7 +282,10 @@ QString DbusAccountRequest::getDtLastUpdate()
 
 void DbusAccountRequest::slotCallFinished(CDBusPendingCallWatcher *call)
 {
-    qCDebug(ClientLogger) << "DBus call finished for method:" << call->getmember() << "path:" << this->path();
+    qCDebug(ClientLogger) << "DBus account call finished"
+                            << "method:" << call->getmember()
+                            << "path:" << this->path()
+                            << "error:" << call->isError();
     int ret = 0;
     bool canCall = true;
     QVariant msg;
@@ -312,7 +326,14 @@ void DbusAccountRequest::slotCallFinished(CDBusPendingCallWatcher *call)
             QDBusPendingReply<QString> reply = *call;
             QString str = reply.argumentAt<0>();
             QMap<QDate, DSchedule::List> map = DSchedule::fromQueryResult(str);
-            qCDebug(ClientLogger) << "Query returned schedules for" << map.size() << "dates";
+            int scheduleCount = 0;
+            for (const DSchedule::List &schedules : map) {
+                scheduleCount += schedules.size();
+            }
+            qCDebug(ClientLogger) << "Query returned schedules"
+                                    << "path:" << this->path()
+                                    << "dateCount:" << map.size()
+                                    << "scheduleCount:" << scheduleCount;
             emit signalGetScheduleListFinish(map);
         } else if (call->getmember() == "searchSchedulesWithParameter") {
             qCDebug(ClientLogger) << "Processing schedule search response for path:" << this->path();
@@ -361,9 +382,25 @@ void DbusAccountRequest::slotDbusCall(const QDBusMessage &msg)
     } else if (msg.member() == "scheduleTypeUpdate") {
         qCDebug(ClientLogger) << "Schedule type update signal received, refreshing type list";
         getScheduleTypeList();
+    } else if (msg.member() == "calDavScheduleCreateFailed") {
+        const int createFailure = msg.arguments().value(0).toInt();
+        qCWarning(ClientLogger) << "CalDAV schedule creation failed"
+                                << "path:" << this->path()
+                                << "createFailure:" << createFailure;
+        emit signalCalDavScheduleCreateFailed(createFailure);
     } else if (msg.member() == "scheduleUpdate") {
         //更新全局数据
         qCDebug(ClientLogger) << "Schedule update signal received, refreshing data";
+        if (m_priParams.isNull()) {
+            const QDate currentDate = QDate::currentDate();
+            const QDate startDate = currentDate.addMonths(-3);
+            const QDate endDate = currentDate.addMonths(3);
+            m_priParams.reset(new DScheduleQueryPar);
+            m_priParams->setDtStart(QDateTime(startDate, QTime(0, 0, 0)));
+            m_priParams->setDtEnd(QDateTime(endDate, QTime(23, 59, 59)));
+            qCWarning(ClientLogger) << "Schedule update arrived before initial query; using default refresh range"
+                                    << m_priParams->dtStart() << m_priParams->dtEnd();
+        }
         querySchedulesWithParameter(m_priParams);
         //更新搜索数据
         emit signalSearchUpdate();

--- a/src/calendar-client/src/dbus/dbusaccountrequest.h
+++ b/src/calendar-client/src/dbus/dbusaccountrequest.h
@@ -141,6 +141,7 @@ signals:
     void signalSyncStateChange(DAccount::AccountSyncState);
     void signalAccountStateChange(DAccount::AccountStates);
     void signalSearchUpdate();
+    void signalCalDavScheduleCreateFailed(int createFailure);
 
 public slots:
     //dbus服务端调用

--- a/src/calendar-client/src/dbus/dbusrequestbase.cpp
+++ b/src/calendar-client/src/dbus/dbusrequestbase.cpp
@@ -9,19 +9,20 @@
 DbusRequestBase::DbusRequestBase(const QString &path, const QString &interface, const QDBusConnection &connection, QObject *parent)
     : QDBusAbstractInterface(DBUS_SERVER_NAME, path, interface.toStdString().c_str(), connection, parent)
 {
-    //关联后端dbus触发信号
-    if (!QDBusConnection::sessionBus().connect(this->service(), this->path(), this->interface(), "", this, SLOT(slotDbusCall(QDBusMessage)))) {
-        qCWarning(ClientLogger) << "Failed to connect DBus signal:" 
-                                << "service:" << this->service()
-                                << "path:" << this->path()
-                                << "interface:" << this->interface();
-    };
-    //关联后端dbus触发信号
-    if (!QDBusConnection::sessionBus().connect(this->service(), this->path(), "org.freedesktop.DBus.Properties", "", this, SLOT(slotDbusCall(QDBusMessage)))) {
+    // Do not subscribe to every signal on the interface. QtDBus tries to
+    // resolve every signal argument type for a wildcard subscription, while
+    // this client deliberately handles service signals as QDBusMessage.
+    // Custom signal argument types are not registered in the client and make
+    // the wildcard subscription fail, which also prevents scheduleUpdate from
+    // reaching the account request.
+    if (!QDBusConnection::sessionBus().connect(this->service(), this->path(),
+                                               "org.freedesktop.DBus.Properties",
+                                               "PropertiesChanged", "sa{sv}as", this,
+                                               SLOT(slotDbusCall(QDBusMessage)))) {
         qCWarning(ClientLogger) << "Failed to connect DBus Properties signal:"
                                 << "service:" << this->service()
                                 << "path:" << this->path();
-    };
+    }
 }
 
 void DbusRequestBase::setCallbackFunc(CallbackFunc func)
@@ -64,4 +65,5 @@ void DbusRequestBase::asyncCall(const QString &method, const QString &callName, 
  */
 void DbusRequestBase::slotDbusCall(const QDBusMessage &msg)
 {
+    Q_UNUSED(msg);
 }


### PR DESCRIPTION
Add CalDAV account status caching, DBus requests, and account data refresh.

增加 CalDAV 账户状态缓存、DBus 请求及账户数据刷新能力。

Log: 增加 CalDAV 客户端数据和 DBus 模块
PMS: TASK-393989
Influence: 客户端可管理 CalDAV 账户状态并接收服务端同步结果。

## Summary by Sourcery

Add CalDAV account management, cached status updates, and DBus event handling to the calendar client.

New Features:
- Add CalDAV account status caching and write-capability checks to the calendar client.
- Expose CalDAV account validation, configuration, creation, update, deletion, credential, and conflict-resolution operations through the client account manager.
- Refresh and manage CalDAV account data and propagate schedule-creation failures and server-side validation/status events to consumers.

Bug Fixes:
- Ensure DBus schedule updates are received reliably and refresh schedules even when an initial query has not completed.
- Prevent the initial CalDAV status snapshot from being reported as a status-change event.

Enhancements:
- Improve account lifecycle handling by updating existing CalDAV account items and installing signal forwarding before asynchronous data loading.

Chores:
- Improve diagnostic logging for account, schedule, and DBus operations.