### PR TITLE
i18n(caldav): update calendar account translations

### DIFF
--- a/translations/dde-calendar-service.ts
+++ b/translations/dde-calendar-service.ts
@@ -1,1230 +1,1047 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE TS>
 <TS version="2.1" language="en_US">
-<context>
-    <name>AccountItem</name>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="41"/>
-        <source>Sync successful</source>
-        <translation>Sync successful</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="42"/>
-        <source>Network error</source>
-        <translation>Network error</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="43"/>
-        <source>Server exception</source>
-        <translation>Server exception</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="44"/>
-        <source>Storage full</source>
-        <translation>Storage full</translation>
-    </message>
-</context>
-<context>
-    <name>AccountManager</name>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="227"/>
-        <source>Local account</source>
-        <translation>Local account</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="229"/>
-        <source>Event types</source>
-        <translation>Event types</translation>
-    </message>
-</context>
-<context>
-    <name>CColorPickerWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="77"/>
-        <source>Color</source>
-        <translation>Color</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="90"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="92"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>Save</translation>
-    </message>
-</context>
-<context>
-    <name>CDayMonthView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="33"/>
-        <source>Monday</source>
-        <translation>Monday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="34"/>
-        <source>Tuesday</source>
-        <translation>Tuesday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35"/>
-        <source>Wednesday</source>
-        <translation>Wednesday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36"/>
-        <source>Thursday</source>
-        <translation>Thursday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37"/>
-        <source>Friday</source>
-        <translation>Friday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38"/>
-        <source>Saturday</source>
-        <translation>Saturday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39"/>
-        <source>Sunday</source>
-        <translation>Sunday</translation>
-    </message>
-</context>
-<context>
-    <name>CDayWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="112"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="113"/>
-        <source>M</source>
-        <translation>M</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="114"/>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="170"/>
-        <source>Lunar</source>
-        <translation>Lunar</translation>
-    </message>
-</context>
-<context>
-    <name>CGraphicsView</name>
-    <message>
-        <location filename="../calendar-client/src/view/graphicsview.cpp" line="628"/>
-        <source>New Event</source>
-        <translation>New Event</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthScheduleNumItem</name>
-    <message>
-        <location filename="../calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="80"/>
-        <source>%1 more</source>
-        <translation>%1 more</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="50"/>
-        <source>New event</source>
-        <translation>New event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="230"/>
-        <source>New Event</source>
-        <translation>New Event</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-</context>
-<context>
-    <name>CMyScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="284"/>
-        <source>My Event</source>
-        <translation>My Event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="326"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="331"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>Delete</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="332"/>
-        <source>Edit</source>
-        <comment>button</comment>
-        <translation>Edit</translation>
-    </message>
-</context>
-<context>
-    <name>CPushButton</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/cpushbutton.cpp" line="17"/>
-        <source>New event type</source>
-        <translation>New event type</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleDlg</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="46"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="625"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="921"/>
-        <source>New Event</source>
-        <translation>New Event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="60"/>
-        <source>Edit Event</source>
-        <translation>Edit Event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="270"/>
-        <source>End time must be greater than start time</source>
-        <translation>End time must be greater than start time</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="271"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="506"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="535"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1133"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1168"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1422"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1426"/>
-        <source>Never</source>
-        <translation>Never</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="507"/>
-        <source>At time of event</source>
-        <translation>At time of event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="508"/>
-        <source>15 minutes before</source>
-        <translation>15 minutes before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="509"/>
-        <source>30 minutes before</source>
-        <translation>30 minutes before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="510"/>
-        <source>1 hour before</source>
-        <translation>1 hour before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="511"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="537"/>
-        <source>1 day before</source>
-        <translation>1 day before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="512"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="538"/>
-        <source>2 days before</source>
-        <translation>2 days before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="513"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="539"/>
-        <source>1 week before</source>
-        <translation>1 week before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="536"/>
-        <source>On start day (9:00 AM)</source>
-        <translation>On start day (9:00 AM)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="583"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="791"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1189"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1190"/>
-        <source>time(s)</source>
-        <translation>time(s)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="598"/>
-        <source>Enter a name please</source>
-        <translation>Enter a name please</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="693"/>
-        <source>The name can not only contain whitespaces</source>
-        <translation>The name can not only contain whitespaces</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="749"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="871"/>
-        <source>Type:</source>
-        <translation>Type:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="754"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="906"/>
-        <source>Description:</source>
-        <translation>Description:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="759"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="943"/>
-        <source>All Day:</source>
-        <translation>All Day:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="764"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1009"/>
-        <source>Starts:</source>
-        <translation>Starts:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="769"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1050"/>
-        <source>Ends:</source>
-        <translation>Ends:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="774"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1090"/>
-        <source>Remind Me:</source>
-        <translation>Remind Me:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="779"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1122"/>
-        <source>Repeat:</source>
-        <translation>Repeat:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="784"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1156"/>
-        <source>End Repeat:</source>
-        <translation>End Repeat:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="840"/>
-        <source>Calendar account:</source>
-        <translation>Calendar account:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="841"/>
-        <source>Calendar account</source>
-        <translation>Calendar account</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="868"/>
-        <source>Type</source>
-        <translation>Type</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="910"/>
-        <source>Description</source>
-        <translation>Description</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="940"/>
-        <source>All Day</source>
-        <translation>All Day</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="964"/>
-        <source>Time:</source>
-        <translation>Time:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="965"/>
-        <source>Time</source>
-        <translation>Time</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="972"/>
-        <source>Solar</source>
-        <translation>Solar</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="973"/>
-        <source>Lunar</source>
-        <translation>Lunar</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1006"/>
-        <source>Starts</source>
-        <translation>Starts</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1047"/>
-        <source>Ends</source>
-        <translation>Ends</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1092"/>
-        <source>Remind Me</source>
-        <translation>Remind Me</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1119"/>
-        <source>Repeat</source>
-        <translation>Repeat</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1134"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1427"/>
-        <source>Daily</source>
-        <translation>Daily</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1135"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1428"/>
-        <source>Weekdays</source>
-        <translation>Weekdays</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1136"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1429"/>
-        <source>Weekly</source>
-        <translation>Weekly</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1137"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1423"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1430"/>
-        <source>Monthly</source>
-        <translation>Monthly</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1138"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1424"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1431"/>
-        <source>Yearly</source>
-        <translation>Yearly</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1158"/>
-        <source>End Repeat</source>
-        <translation>End Repeat</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1169"/>
-        <source>After</source>
-        <translation>After</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1170"/>
-        <source>On</source>
-        <translation>On</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1240"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1241"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>Save</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleOperation</name>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74"/>
-        <source>All occurrences of a repeating event must have the same all-day status.</source>
-        <translation>All occurrences of a repeating event must have the same all-day status.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="95"/>
-        <source>Do you want to change all occurrences?</source>
-        <translation>Do you want to change all occurrences?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="96"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="129"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="151"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="174"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="259"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="292"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="97"/>
-        <source>Change All</source>
-        <translation>Change All</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94"/>
-        <source>You are changing the repeating rule of this event.</source>
-        <translation>You are changing the repeating rule of this event.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="149"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="172"/>
-        <source>You are deleting an event.</source>
-        <translation>You are deleting an event.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128"/>
-        <source>Are you sure you want to delete this event?</source>
-        <translation>Are you sure you want to delete this event?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>Delete</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150"/>
-        <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
-        <translation>Do you want to delete all occurrences of this event, or only the selected occurrence?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152"/>
-        <source>Delete All</source>
-        <translation>Delete All</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="176"/>
-        <source>Delete Only This Event</source>
-        <translation>Delete Only This Event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173"/>
-        <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
-        <translation>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175"/>
-        <source>Delete All Future Events</source>
-        <translation>Delete All Future Events</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="288"/>
-        <source>You are changing a repeating event.</source>
-        <translation>You are changing a repeating event.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257"/>
-        <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
-        <translation>Do you want to change only this occurrence of the event, or all occurrences?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260"/>
-        <source>All</source>
-        <translation>All</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="294"/>
-        <source>Only This Event</source>
-        <translation>Only This Event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290"/>
-        <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
-        <translation>Do you want to change only this occurrence of the event, or this and all future occurrences?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293"/>
-        <source>All Future Events</source>
-        <translation>All Future Events</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416"/>
-        <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
-        <translation>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OK</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchDateItem</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>M</source>
-        <translation>M</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchItem</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="42"/>
-        <source>Edit</source>
-        <translation>Edit</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="43"/>
-        <source>Delete</source>
-        <translation>Delete</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="267"/>
-        <source>All Day</source>
-        <translation>All Day</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="648"/>
-        <source>No search results</source>
-        <translation>No search results</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/scheduleview.cpp" line="316"/>
-        <source>ALL DAY</source>
-        <translation>ALL DAY</translation>
-    </message>
-</context>
-<context>
-    <name>CSettingDialog</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="389"/>
-        <source>import ICS file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="403"/>
-        <source>Manual</source>
-        <translation>Manual</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="404"/>
-        <source>15 mins</source>
-        <translation>15 mins</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="405"/>
-        <source>30 mins</source>
-        <translation>30 mins</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="406"/>
-        <source>1 hour</source>
-        <translation>1 hour</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="407"/>
-        <source>24 hours</source>
-        <translation>24 hours</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="418"/>
-        <source>Sync Now</source>
-        <translation>Sync Now</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="585"/>
-        <source>Last sync</source>
-        <translation>Last sync</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="779"/>
-        <source>Please go to the &lt;a href='/'&gt;Control Center&lt;/a&gt; to change system settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="346"/>
-        <source>Monday</source>
-        <translation>Monday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="345"/>
-        <source>Sunday</source>
-        <translation>Sunday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="347"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="366"/>
-        <source>Use System Setting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="365"/>
-        <source>12-hour clock</source>
-        <translation>12-hour clock</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="364"/>
-        <source>24-hour clock</source>
-        <translation>24-hour clock</translation>
-    </message>
-</context>
-<context>
-    <name>CTimeEdit</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="71"/>
-        <source>(%1 mins)</source>
-        <translation>(%1 mins)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="73"/>
-        <source>(%1 hour)</source>
-        <translation>(%1 hour)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="75"/>
-        <source>(%1 hours)</source>
-        <translation>(%1 hours)</translation>
-    </message>
-</context>
-<context>
-    <name>CTitleWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="30"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="42"/>
-        <source>M</source>
-        <translation>M</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="50"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="58"/>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="92"/>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="93"/>
-        <source>Search events and festivals</source>
-        <translation>Search events and festivals</translation>
-    </message>
-</context>
-<context>
-    <name>CWeekWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="90"/>
-        <source>Week</source>
-        <translation>Week</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="280"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-</context>
-<context>
-    <name>CYearScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="268"/>
-        <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="271"/>
-        <source>All Day</source>
-        <translation>All Day</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="288"/>
-        <source>No event</source>
-        <translation>No event</translation>
-    </message>
-</context>
-<context>
-    <name>CYearWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="615"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-</context>
-<context>
-    <name>CalendarWindow</name>
-    <message>
-        <location filename="../calendar-client/src/main.cpp" line="66"/>
-        <source>Calendar</source>
-        <translation>Calendar</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/main.cpp" line="69"/>
-        <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
-        <translation>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </translation>
-    </message>
-</context>
-<context>
-    <name>Calendarmainwindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="89"/>
-        <source>Calendar</source>
-        <translation>Calendar</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="372"/>
-        <source>Manage</source>
-        <translation>Manage</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="379"/>
-        <source>Privacy Policy</source>
-        <translation>Privacy Policy</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="962"/>
-        <source>Syncing...</source>
-        <translation>Syncing...</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="973"/>
-        <source>Sync successful</source>
-        <translation>Sync successful</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="982"/>
-        <source>Sync failed, please try later</source>
-        <translation>Sync failed, please try later</translation>
-    </message>
-</context>
-<context>
-    <name>CenterWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="174"/>
-        <source>All Day</source>
-        <translation>All Day</translation>
-    </message>
-</context>
-<context>
-    <name>DAccountDataBase</name>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1155"/>
-        <source>Work</source>
-        <translation>Work</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1157"/>
-        <source>Life</source>
-        <translation>Life</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1159"/>
-        <source>Other</source>
-        <translation>Other</translation>
-    </message>
-</context>
-<context>
-    <name>DAlarmManager</name>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="187"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="196"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="201"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="212"/>
-        <source>Close</source>
-        <comment>button</comment>
-        <translation>Close</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="191"/>
-        <source>One day before start</source>
-        <translation>One day before start</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="197"/>
-        <source>Remind me tomorrow</source>
-        <translation>Remind me tomorrow</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="202"/>
-        <source>Remind me later</source>
-        <translation>Remind me later</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="204"/>
-        <source>15 mins later</source>
-        <translation>15 mins later</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="205"/>
-        <source>1 hour later</source>
-        <translation>1 hour later</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="206"/>
-        <source>4 hours later</source>
-        <translation>4 hours later</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="207"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="300"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="313"/>
-        <source>Tomorrow</source>
-        <translation>Tomorrow</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="215"/>
-        <source>Schedule Reminder</source>
-        <translation>Schedule Reminder</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="258"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="270"/>
-        <source>%1 to %2</source>
-        <translation>%1 to %2</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="296"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="309"/>
-        <source>Today</source>
-        <translation>Today</translation>
-    </message>
-</context>
-<context>
-    <name>DragInfoGraphicsView</name>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="48"/>
-        <source>Edit</source>
-        <translation>Edit</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="49"/>
-        <source>Delete</source>
-        <translation>Delete</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="50"/>
-        <source>New event</source>
-        <translation>New event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="759"/>
-        <source>New Event</source>
-        <translation>New Event</translation>
-    </message>
-</context>
-<context>
-    <name>JobTypeListView</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="144"/>
-        <source>export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="219"/>
-        <source>import ICS file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="450"/>
-        <source>You are deleting an event type.</source>
-        <translation>You are deleting an event type.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="451"/>
-        <source>All events under this type will be deleted and cannot be recovered.</source>
-        <translation>All events under this type will be deleted and cannot be recovered.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="452"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="453"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>Delete</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="38"/>
-        <source>Account settings</source>
-        <translation>Account settings</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="42"/>
-        <source>Account</source>
-        <translation>Account</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="53"/>
-        <source>Select items to be synced</source>
-        <translation>Select items to be synced</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="56"/>
-        <source>Events</source>
-        <translation>Events</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="63"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="146"/>
-        <source>General settings</source>
-        <translation>General settings</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="74"/>
-        <source>Sync interval</source>
-        <translation>Sync interval</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="96"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="127"/>
-        <source>Manage calendar</source>
-        <translation>Manage calendar</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="104"/>
-        <source>Calendar account</source>
-        <translation>Calendar account</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="112"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="131"/>
-        <source>Event types</source>
-        <translation>Event types</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="150"/>
-        <source>General</source>
-        <translation>General</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="152"/>
-        <source>First day of week</source>
-        <translation>First day of week</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="153"/>
-        <source>Time</source>
-        <translation>Time</translation>
-    </message>
-</context>
-<context>
-    <name>Return</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="611"/>
-        <source>Today</source>
-        <comment>Return</comment>
-        <translation>Today</translation>
-    </message>
-</context>
-<context>
-    <name>Return Today</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="339"/>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="95"/>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="277"/>
-        <source>Today</source>
-        <comment>Return Today</comment>
-        <translation>Today</translation>
-    </message>
-</context>
-<context>
-    <name>ScheduleTypeEditDlg</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22"/>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="48"/>
-        <source>New event type</source>
-        <translation>New event type</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="32"/>
-        <source>Edit event type</source>
-        <translation>Edit event type</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="43"/>
-        <source>Import ICS file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="151"/>
-        <source>Name:</source>
-        <translation>Name:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="152"/>
-        <source>Color:</source>
-        <translation>Color:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="156"/>
-        <source>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt; File:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="167"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="168"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>Save</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="219"/>
-        <source>The name can not only contain whitespaces</source>
-        <translation>The name can not only contain whitespaces</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="256"/>
-        <source>Enter a name please</source>
-        <translation>Enter a name please</translation>
-    </message>
-</context>
-<context>
-    <name>Shortcut</name>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="16"/>
-        <source>Help</source>
-        <translation>Help</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="17"/>
-        <source>Delete event</source>
-        <translation>Delete event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="20"/>
-        <source>Copy</source>
-        <translation>Copy</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="21"/>
-        <source>Cut</source>
-        <translation>Cut</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="22"/>
-        <source>Paste</source>
-        <translation>Paste</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="25"/>
-        <source>Delete</source>
-        <translation>Delete</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="26"/>
-        <source>Select all</source>
-        <translation>Select all</translation>
-    </message>
-</context>
-<context>
-    <name>SidebarCalendarWidget</name>
-    <message>
-        <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
-        <source>M</source>
-        <translation>M</translation>
-    </message>
-</context>
-<context>
-    <name>TimeJumpDialog</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/timejumpdialog.cpp" line="29"/>
-        <source>Go</source>
-        <comment>button</comment>
-        <translation>Go</translation>
-    </message>
-</context>
-<context>
-    <name>UserloginWidget</name>
-    <message>
-        <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="48"/>
-        <source>Sign In</source>
-        <comment>button</comment>
-        <translation>Sign In</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="49"/>
-        <source>Sign Out</source>
-        <comment>button</comment>
-        <translation>Sign Out</translation>
-    </message>
-</context>
-<context>
-    <name>YearFrame</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="928"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-</context>
-<context>
-    <name>today</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="188"/>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="337"/>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="93"/>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="230"/>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="57"/>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="275"/>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="261"/>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="609"/>
-        <source>Today</source>
-        <comment>Today</comment>
-        <translation>Today</translation>
-    </message>
-</context>
+    <context>
+        <name>AccountItem</name>
+        <message>
+            <source>Sync successful</source>
+            <translation type="vanished">Sync successful</translation>
+        </message>
+        <message>
+            <source>Network error</source>
+            <translation type="vanished">Network error</translation>
+        </message>
+        <message>
+            <source>Server exception</source>
+            <translation type="vanished">Server exception</translation>
+        </message>
+        <message>
+            <source>Storage full</source>
+            <translation type="vanished">Storage full</translation>
+        </message>
+    </context>
+    <context>
+        <name>AccountManager</name>
+        <message>
+            <source>Local account</source>
+            <translation type="vanished">Local account</translation>
+        </message>
+        <message>
+            <source>Event types</source>
+            <translation type="vanished">Event types</translation>
+        </message>
+    </context>
+    <context>
+        <name>CColorPickerWidget</name>
+        <message>
+            <source>Color</source>
+            <translation type="vanished">Color</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation type="vanished">Cancel</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <comment>button</comment>
+            <translation type="vanished">Save</translation>
+        </message>
+    </context>
+    <context>
+        <name>CDayMonthView</name>
+        <message>
+            <source>Monday</source>
+            <translation type="vanished">Monday</translation>
+        </message>
+        <message>
+            <source>Tuesday</source>
+            <translation type="vanished">Tuesday</translation>
+        </message>
+        <message>
+            <source>Wednesday</source>
+            <translation type="vanished">Wednesday</translation>
+        </message>
+        <message>
+            <source>Thursday</source>
+            <translation type="vanished">Thursday</translation>
+        </message>
+        <message>
+            <source>Friday</source>
+            <translation type="vanished">Friday</translation>
+        </message>
+        <message>
+            <source>Saturday</source>
+            <translation type="vanished">Saturday</translation>
+        </message>
+        <message>
+            <source>Sunday</source>
+            <translation type="vanished">Sunday</translation>
+        </message>
+    </context>
+    <context>
+        <name>CDayWindow</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">Y</translation>
+        </message>
+        <message>
+            <source>M</source>
+            <translation type="vanished">M</translation>
+        </message>
+        <message>
+            <source>D</source>
+            <translation type="vanished">D</translation>
+        </message>
+        <message>
+            <source>Lunar</source>
+            <translation type="vanished">Lunar</translation>
+        </message>
+    </context>
+    <context>
+        <name>CGraphicsView</name>
+        <message>
+            <source>New Event</source>
+            <translation type="vanished">New Event</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthScheduleNumItem</name>
+        <message>
+            <source>%1 more</source>
+            <translation type="vanished">%1 more</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthView</name>
+        <message>
+            <source>New event</source>
+            <translation type="vanished">New event</translation>
+        </message>
+        <message>
+            <source>New Event</source>
+            <translation type="vanished">New Event</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthWindow</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">Y</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMyScheduleView</name>
+        <message>
+            <source>My Event</source>
+            <translation type="vanished">My Event</translation>
+        </message>
+        <message>
+            <source>OK</source>
+            <comment>button</comment>
+            <translation type="vanished">OK</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation type="vanished">Delete</translation>
+        </message>
+        <message>
+            <source>Edit</source>
+            <comment>button</comment>
+            <translation type="vanished">Edit</translation>
+        </message>
+    </context>
+    <context>
+        <name>CPushButton</name>
+        <message>
+            <source>New event type</source>
+            <translation type="vanished">New event type</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleDlg</name>
+        <message>
+            <source>New Event</source>
+            <translation type="vanished">New Event</translation>
+        </message>
+        <message>
+            <source>Edit Event</source>
+            <translation type="vanished">Edit Event</translation>
+        </message>
+        <message>
+            <source>End time must be greater than start time</source>
+            <translation type="vanished">End time must be greater than start time</translation>
+        </message>
+        <message>
+            <source>OK</source>
+            <comment>button</comment>
+            <translation type="vanished">OK</translation>
+        </message>
+        <message>
+            <source>Never</source>
+            <translation type="vanished">Never</translation>
+        </message>
+        <message>
+            <source>At time of event</source>
+            <translation type="vanished">At time of event</translation>
+        </message>
+        <message>
+            <source>15 minutes before</source>
+            <translation type="vanished">15 minutes before</translation>
+        </message>
+        <message>
+            <source>30 minutes before</source>
+            <translation type="vanished">30 minutes before</translation>
+        </message>
+        <message>
+            <source>1 hour before</source>
+            <translation type="vanished">1 hour before</translation>
+        </message>
+        <message>
+            <source>1 day before</source>
+            <translation type="vanished">1 day before</translation>
+        </message>
+        <message>
+            <source>2 days before</source>
+            <translation type="vanished">2 days before</translation>
+        </message>
+        <message>
+            <source>1 week before</source>
+            <translation type="vanished">1 week before</translation>
+        </message>
+        <message>
+            <source>On start day (9:00 AM)</source>
+            <translation type="vanished">On start day (9:00 AM)</translation>
+        </message>
+        <message>
+            <source>time(s)</source>
+            <translation type="vanished">time(s)</translation>
+        </message>
+        <message>
+            <source>Enter a name please</source>
+            <translation type="vanished">Enter a name please</translation>
+        </message>
+        <message>
+            <source>The name can not only contain whitespaces</source>
+            <translation type="vanished">The name can not only contain whitespaces</translation>
+        </message>
+        <message>
+            <source>Type:</source>
+            <translation type="vanished">Type:</translation>
+        </message>
+        <message>
+            <source>Description:</source>
+            <translation type="vanished">Description:</translation>
+        </message>
+        <message>
+            <source>All Day:</source>
+            <translation type="vanished">All Day:</translation>
+        </message>
+        <message>
+            <source>Starts:</source>
+            <translation type="vanished">Starts:</translation>
+        </message>
+        <message>
+            <source>Ends:</source>
+            <translation type="vanished">Ends:</translation>
+        </message>
+        <message>
+            <source>Remind Me:</source>
+            <translation type="vanished">Remind Me:</translation>
+        </message>
+        <message>
+            <source>Repeat:</source>
+            <translation type="vanished">Repeat:</translation>
+        </message>
+        <message>
+            <source>End Repeat:</source>
+            <translation type="vanished">End Repeat:</translation>
+        </message>
+        <message>
+            <source>Calendar account:</source>
+            <translation type="vanished">Calendar account:</translation>
+        </message>
+        <message>
+            <source>Calendar account</source>
+            <translation type="vanished">Calendar account</translation>
+        </message>
+        <message>
+            <source>Type</source>
+            <translation type="vanished">Type</translation>
+        </message>
+        <message>
+            <source>Description</source>
+            <translation type="vanished">Description</translation>
+        </message>
+        <message>
+            <source>All Day</source>
+            <translation type="vanished">All Day</translation>
+        </message>
+        <message>
+            <source>Time:</source>
+            <translation type="vanished">Time:</translation>
+        </message>
+        <message>
+            <source>Time</source>
+            <translation type="vanished">Time</translation>
+        </message>
+        <message>
+            <source>Solar</source>
+            <translation type="vanished">Solar</translation>
+        </message>
+        <message>
+            <source>Lunar</source>
+            <translation type="vanished">Lunar</translation>
+        </message>
+        <message>
+            <source>Starts</source>
+            <translation type="vanished">Starts</translation>
+        </message>
+        <message>
+            <source>Ends</source>
+            <translation type="vanished">Ends</translation>
+        </message>
+        <message>
+            <source>Remind Me</source>
+            <translation type="vanished">Remind Me</translation>
+        </message>
+        <message>
+            <source>Repeat</source>
+            <translation type="vanished">Repeat</translation>
+        </message>
+        <message>
+            <source>Daily</source>
+            <translation type="vanished">Daily</translation>
+        </message>
+        <message>
+            <source>Weekdays</source>
+            <translation type="vanished">Weekdays</translation>
+        </message>
+        <message>
+            <source>Weekly</source>
+            <translation type="vanished">Weekly</translation>
+        </message>
+        <message>
+            <source>Monthly</source>
+            <translation type="vanished">Monthly</translation>
+        </message>
+        <message>
+            <source>Yearly</source>
+            <translation type="vanished">Yearly</translation>
+        </message>
+        <message>
+            <source>End Repeat</source>
+            <translation type="vanished">End Repeat</translation>
+        </message>
+        <message>
+            <source>After</source>
+            <translation type="vanished">After</translation>
+        </message>
+        <message>
+            <source>On</source>
+            <translation type="vanished">On</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation type="vanished">Cancel</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <comment>button</comment>
+            <translation type="vanished">Save</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleOperation</name>
+        <message>
+            <source>All occurrences of a repeating event must have the same all-day status.</source>
+            <translation type="vanished">All occurrences of a repeating event must have the same all-day status.</translation>
+        </message>
+        <message>
+            <source>Do you want to change all occurrences?</source>
+            <translation type="vanished">Do you want to change all occurrences?</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation type="vanished">Cancel</translation>
+        </message>
+        <message>
+            <source>Change All</source>
+            <translation type="vanished">Change All</translation>
+        </message>
+        <message>
+            <source>You are changing the repeating rule of this event.</source>
+            <translation type="vanished">You are changing the repeating rule of this event.</translation>
+        </message>
+        <message>
+            <source>You are deleting an event.</source>
+            <translation type="vanished">You are deleting an event.</translation>
+        </message>
+        <message>
+            <source>Are you sure you want to delete this event?</source>
+            <translation type="vanished">Are you sure you want to delete this event?</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation type="vanished">Delete</translation>
+        </message>
+        <message>
+            <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
+            <translation type="vanished">Do you want to delete all occurrences of this event, or only the selected occurrence?</translation>
+        </message>
+        <message>
+            <source>Delete All</source>
+            <translation type="vanished">Delete All</translation>
+        </message>
+        <message>
+            <source>Delete Only This Event</source>
+            <translation type="vanished">Delete Only This Event</translation>
+        </message>
+        <message>
+            <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
+            <translation type="vanished">Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</translation>
+        </message>
+        <message>
+            <source>Delete All Future Events</source>
+            <translation type="vanished">Delete All Future Events</translation>
+        </message>
+        <message>
+            <source>You are changing a repeating event.</source>
+            <translation type="vanished">You are changing a repeating event.</translation>
+        </message>
+        <message>
+            <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
+            <translation type="vanished">Do you want to change only this occurrence of the event, or all occurrences?</translation>
+        </message>
+        <message>
+            <source>All</source>
+            <translation type="vanished">All</translation>
+        </message>
+        <message>
+            <source>Only This Event</source>
+            <translation type="vanished">Only This Event</translation>
+        </message>
+        <message>
+            <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
+            <translation type="vanished">Do you want to change only this occurrence of the event, or this and all future occurrences?</translation>
+        </message>
+        <message>
+            <source>All Future Events</source>
+            <translation type="vanished">All Future Events</translation>
+        </message>
+        <message>
+            <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
+            <translation type="vanished">You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</translation>
+        </message>
+        <message>
+            <source>OK</source>
+            <comment>button</comment>
+            <translation type="vanished">OK</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchDateItem</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">Y</translation>
+        </message>
+        <message>
+            <source>M</source>
+            <translation type="vanished">M</translation>
+        </message>
+        <message>
+            <source>D</source>
+            <translation type="vanished">D</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchItem</name>
+        <message>
+            <source>Edit</source>
+            <translation type="vanished">Edit</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <translation type="vanished">Delete</translation>
+        </message>
+        <message>
+            <source>All Day</source>
+            <translation type="vanished">All Day</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchView</name>
+        <message>
+            <source>No search results</source>
+            <translation type="vanished">No search results</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleView</name>
+        <message>
+            <source>ALL DAY</source>
+            <translation type="vanished">ALL DAY</translation>
+        </message>
+    </context>
+    <context>
+        <name>CSettingDialog</name>
+        <message>
+            <source>Manual</source>
+            <translation type="vanished">Manual</translation>
+        </message>
+        <message>
+            <source>15 mins</source>
+            <translation type="vanished">15 mins</translation>
+        </message>
+        <message>
+            <source>30 mins</source>
+            <translation type="vanished">30 mins</translation>
+        </message>
+        <message>
+            <source>1 hour</source>
+            <translation type="vanished">1 hour</translation>
+        </message>
+        <message>
+            <source>24 hours</source>
+            <translation type="vanished">24 hours</translation>
+        </message>
+        <message>
+            <source>Sync Now</source>
+            <translation type="vanished">Sync Now</translation>
+        </message>
+        <message>
+            <source>Last sync</source>
+            <translation type="vanished">Last sync</translation>
+        </message>
+        <message>
+            <source>Monday</source>
+            <translation type="vanished">Monday</translation>
+        </message>
+        <message>
+            <source>Sunday</source>
+            <translation type="vanished">Sunday</translation>
+        </message>
+        <message>
+            <source>12-hour clock</source>
+            <translation type="vanished">12-hour clock</translation>
+        </message>
+        <message>
+            <source>24-hour clock</source>
+            <translation type="vanished">24-hour clock</translation>
+        </message>
+    </context>
+    <context>
+        <name>CTimeEdit</name>
+        <message>
+            <source>(%1 mins)</source>
+            <translation type="vanished">(%1 mins)</translation>
+        </message>
+        <message>
+            <source>(%1 hour)</source>
+            <translation type="vanished">(%1 hour)</translation>
+        </message>
+        <message>
+            <source>(%1 hours)</source>
+            <translation type="vanished">(%1 hours)</translation>
+        </message>
+    </context>
+    <context>
+        <name>CTitleWidget</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">Y</translation>
+        </message>
+        <message>
+            <source>M</source>
+            <translation type="vanished">M</translation>
+        </message>
+        <message>
+            <source>W</source>
+            <translation type="vanished">W</translation>
+        </message>
+        <message>
+            <source>D</source>
+            <translation type="vanished">D</translation>
+        </message>
+        <message>
+            <source>Search events and festivals</source>
+            <translation type="vanished">Search events and festivals</translation>
+        </message>
+    </context>
+    <context>
+        <name>CWeekWindow</name>
+        <message>
+            <source>Week</source>
+            <translation type="vanished">Week</translation>
+        </message>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">Y</translation>
+        </message>
+    </context>
+    <context>
+        <name>CYearScheduleView</name>
+        <message>
+            <source>All Day</source>
+            <translation type="vanished">All Day</translation>
+        </message>
+        <message>
+            <source>No event</source>
+            <translation type="vanished">No event</translation>
+        </message>
+    </context>
+    <context>
+        <name>CYearWindow</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">Y</translation>
+        </message>
+    </context>
+    <context>
+        <name>CalendarWindow</name>
+        <message>
+            <source>Calendar</source>
+            <translation type="vanished">Calendar</translation>
+        </message>
+        <message>
+            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
+            <translation type="vanished">Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </translation>
+        </message>
+    </context>
+    <context>
+        <name>Calendarmainwindow</name>
+        <message>
+            <source>Calendar</source>
+            <translation type="vanished">Calendar</translation>
+        </message>
+        <message>
+            <source>Manage</source>
+            <translation type="vanished">Manage</translation>
+        </message>
+        <message>
+            <source>Privacy Policy</source>
+            <translation type="vanished">Privacy Policy</translation>
+        </message>
+        <message>
+            <source>Syncing...</source>
+            <translation type="vanished">Syncing...</translation>
+        </message>
+        <message>
+            <source>Sync successful</source>
+            <translation type="vanished">Sync successful</translation>
+        </message>
+        <message>
+            <source>Sync failed, please try later</source>
+            <translation type="vanished">Sync failed, please try later</translation>
+        </message>
+    </context>
+    <context>
+        <name>CenterWidget</name>
+        <message>
+            <source>All Day</source>
+            <translation type="vanished">All Day</translation>
+        </message>
+    </context>
+    <context>
+        <name>DAccountDataBase</name>
+        <message>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1304" />
+            <source>Work</source>
+            <translation>Work</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1306" />
+            <source>Life</source>
+            <translation>Life</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1308" />
+            <source>Other</source>
+            <translation>Other</translation>
+        </message>
+    </context>
+    <context>
+        <name>DAccountManageModule</name>
+        <message>
+            <location filename="../src/calendar-service/src/calendarDataManager/daccountmanagemodule.cpp" line="125" />
+            <source>[Original Type: %1]</source>
+            <translation>[Original Type: %1]</translation>
+        </message>
+    </context>
+    <context>
+        <name>DAlarmManager</name>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="194" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="203" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="208" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="219" />
+            <source>Close</source>
+            <comment>button</comment>
+            <translation>Close</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="198" />
+            <source>One day before start</source>
+            <translation>One day before start</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="204" />
+            <source>Remind me tomorrow</source>
+            <translation>Remind me tomorrow</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="209" />
+            <source>Remind me later</source>
+            <translation>Remind me later</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="211" />
+            <source>15 mins later</source>
+            <translation>15 mins later</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="212" />
+            <source>1 hour later</source>
+            <translation>1 hour later</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="213" />
+            <source>4 hours later</source>
+            <translation>4 hours later</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="214" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="311" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="324" />
+            <source>Tomorrow</source>
+            <translation>Tomorrow</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="222" />
+            <source>Schedule Reminder</source>
+            <translation>Schedule Reminder</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="268" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="280" />
+            <source>%1 to %2</source>
+            <translation>%1 to %2</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="307" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="320" />
+            <source>Today</source>
+            <translation>Today</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavAccountRegistrar</name>
+        <message>
+            <location filename="../src/calendar-service/src/caldav/dcaldavaccountregistrar.cpp" line="60" />
+            <source>Calendar</source>
+            <translation>Calendar</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavProviderProfile</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="37" />
+            <source>DingTalk</source>
+            <translation>DingTalk</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="39" />
+            <source>WeCom</source>
+            <translation>WeCom</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="41" />
+            <source>Tencent Meeting</source>
+            <translation>Tencent Meeting</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="43" />
+            <source>QQ Mail</source>
+            <translation>QQ Mail</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="45" />
+            <source>Feishu</source>
+            <translation>Feishu</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="48" />
+            <source>Other CalDAV</source>
+            <translation>Other CalDAV</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavSyncStatus</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server certificate is invalid.</source>
+            <translation>The server certificate is invalid.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="54" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>Incorrect username or password. Please try again.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="57" />
+            <source>This server does not support CalDAV.</source>
+            <translation>This server does not support CalDAV.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="61" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>Unable to parse the data returned by the server. Please verify the server address or try again later.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="65" />
+            <source>The server denied access.</source>
+            <translation>The server denied access.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="68" />
+            <source>The server request timed out.</source>
+            <translation>The server request timed out.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="72" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>Unable to connect to the server. Please check your network connection and server address.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76" />
+            <source>Synchronization failed.</source>
+            <translation>Synchronization failed.</translation>
+        </message>
+    </context>
+    <context>
+        <name>DragInfoGraphicsView</name>
+        <message>
+            <source>Edit</source>
+            <translation type="vanished">Edit</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <translation type="vanished">Delete</translation>
+        </message>
+        <message>
+            <source>New event</source>
+            <translation type="vanished">New event</translation>
+        </message>
+        <message>
+            <source>New Event</source>
+            <translation type="vanished">New Event</translation>
+        </message>
+    </context>
+    <context>
+        <name>JobTypeListView</name>
+        <message>
+            <source>You are deleting an event type.</source>
+            <translation type="vanished">You are deleting an event type.</translation>
+        </message>
+        <message>
+            <source>All events under this type will be deleted and cannot be recovered.</source>
+            <translation type="vanished">All events under this type will be deleted and cannot be recovered.</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation type="vanished">Cancel</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation type="vanished">Delete</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <source>Account settings</source>
+            <translation type="vanished">Account settings</translation>
+        </message>
+        <message>
+            <source>Account</source>
+            <translation type="vanished">Account</translation>
+        </message>
+        <message>
+            <source>Select items to be synced</source>
+            <translation type="vanished">Select items to be synced</translation>
+        </message>
+        <message>
+            <source>Events</source>
+            <translation type="vanished">Events</translation>
+        </message>
+        <message>
+            <source>General settings</source>
+            <translation type="vanished">General settings</translation>
+        </message>
+        <message>
+            <source>Sync interval</source>
+            <translation type="vanished">Sync interval</translation>
+        </message>
+        <message>
+            <source>Manage calendar</source>
+            <translation type="vanished">Manage calendar</translation>
+        </message>
+        <message>
+            <source>Calendar account</source>
+            <translation type="vanished">Calendar account</translation>
+        </message>
+        <message>
+            <source>Event types</source>
+            <translation type="vanished">Event types</translation>
+        </message>
+        <message>
+            <source>General</source>
+            <translation type="vanished">General</translation>
+        </message>
+        <message>
+            <source>First day of week</source>
+            <translation type="vanished">First day of week</translation>
+        </message>
+        <message>
+            <source>Time</source>
+            <translation type="vanished">Time</translation>
+        </message>
+    </context>
+    <context>
+        <name>Return</name>
+        <message>
+            <source>Today</source>
+            <comment>Return</comment>
+            <translation type="vanished">Today</translation>
+        </message>
+    </context>
+    <context>
+        <name>Return Today</name>
+        <message>
+            <source>Today</source>
+            <comment>Return Today</comment>
+            <translation type="vanished">Today</translation>
+        </message>
+    </context>
+    <context>
+        <name>ScheduleTypeEditDlg</name>
+        <message>
+            <source>New event type</source>
+            <translation type="vanished">New event type</translation>
+        </message>
+        <message>
+            <source>Edit event type</source>
+            <translation type="vanished">Edit event type</translation>
+        </message>
+        <message>
+            <source>Name:</source>
+            <translation type="vanished">Name:</translation>
+        </message>
+        <message>
+            <source>Color:</source>
+            <translation type="vanished">Color:</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation type="vanished">Cancel</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <comment>button</comment>
+            <translation type="vanished">Save</translation>
+        </message>
+        <message>
+            <source>The name can not only contain whitespaces</source>
+            <translation type="vanished">The name can not only contain whitespaces</translation>
+        </message>
+        <message>
+            <source>Enter a name please</source>
+            <translation type="vanished">Enter a name please</translation>
+        </message>
+    </context>
+    <context>
+        <name>Shortcut</name>
+        <message>
+            <source>Help</source>
+            <translation type="vanished">Help</translation>
+        </message>
+        <message>
+            <source>Delete event</source>
+            <translation type="vanished">Delete event</translation>
+        </message>
+        <message>
+            <source>Copy</source>
+            <translation type="vanished">Copy</translation>
+        </message>
+        <message>
+            <source>Cut</source>
+            <translation type="vanished">Cut</translation>
+        </message>
+        <message>
+            <source>Paste</source>
+            <translation type="vanished">Paste</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <translation type="vanished">Delete</translation>
+        </message>
+        <message>
+            <source>Select all</source>
+            <translation type="vanished">Select all</translation>
+        </message>
+    </context>
+    <context>
+        <name>SidebarCalendarWidget</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">Y</translation>
+        </message>
+        <message>
+            <source>M</source>
+            <translation type="vanished">M</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimeJumpDialog</name>
+        <message>
+            <source>Go</source>
+            <comment>button</comment>
+            <translation type="vanished">Go</translation>
+        </message>
+    </context>
+    <context>
+        <name>UserloginWidget</name>
+        <message>
+            <source>Sign In</source>
+            <comment>button</comment>
+            <translation type="vanished">Sign In</translation>
+        </message>
+        <message>
+            <source>Sign Out</source>
+            <comment>button</comment>
+            <translation type="vanished">Sign Out</translation>
+        </message>
+    </context>
+    <context>
+        <name>YearFrame</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">Y</translation>
+        </message>
+    </context>
+    <context>
+        <name>today</name>
+        <message>
+            <source>Today</source>
+            <comment>Today</comment>
+            <translation type="vanished">Today</translation>
+        </message>
+    </context>
 </TS>

--- a/translations/dde-calendar-service_zh_CN.ts
+++ b/translations/dde-calendar-service_zh_CN.ts
@@ -1,1166 +1,1075 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
-<context>
-    <name>AccountItem</name>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="41"/>
-        <source>Sync successful</source>
-        <translation>同步成功</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="42"/>
-        <source>Network error</source>
-        <translation>网络异常</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="43"/>
-        <source>Server exception</source>
-        <translation>服务器异常</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="44"/>
-        <source>Storage full</source>
-        <translation>存储已满</translation>
-    </message>
-</context>
-<context>
-    <name>AccountManager</name>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="227"/>
-        <source>Local account</source>
-        <translation>本地帐户</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="229"/>
-        <source>Event types</source>
-        <translation>日程类型</translation>
-    </message>
-</context>
-<context>
-    <name>CColorPickerWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="77"/>
-        <source>Color</source>
-        <translation>颜色</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="90"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="92"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>保 存</translation>
-    </message>
-</context>
-<context>
-    <name>CDayMonthView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="33"/>
-        <source>Monday</source>
-        <translation>星期一</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="34"/>
-        <source>Tuesday</source>
-        <translation>星期二</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35"/>
-        <source>Wednesday</source>
-        <translation>星期三</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36"/>
-        <source>Thursday</source>
-        <translation>星期四</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37"/>
-        <source>Friday</source>
-        <translation>星期五</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38"/>
-        <source>Saturday</source>
-        <translation>星期六</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39"/>
-        <source>Sunday</source>
-        <translation>星期日</translation>
-    </message>
-</context>
-<context>
-    <name>CDayWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="112"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="113"/>
-        <source>M</source>
-        <translation>月</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="114"/>
-        <source>D</source>
-        <translation>日</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="170"/>
-        <source>Lunar</source>
-        <translation>农历</translation>
-    </message>
-</context>
-<context>
-    <name>CGraphicsView</name>
-    <message>
-        <location filename="../calendar-client/src/view/graphicsview.cpp" line="628"/>
-        <source>New Event</source>
-        <translation>新建日程</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthScheduleNumItem</name>
-    <message>
-        <location filename="../calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="80"/>
-        <source>%1 more</source>
-        <translation>还有%1项</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="50"/>
-        <source>New event</source>
-        <translation>新建日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="230"/>
-        <source>New Event</source>
-        <translation>新建日程</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-</context>
-<context>
-    <name>CMyScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="284"/>
-        <source>My Event</source>
-        <translation>我的日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="326"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>确 定</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="331"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>删 除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="332"/>
-        <source>Edit</source>
-        <comment>button</comment>
-        <translation>编 辑</translation>
-    </message>
-</context>
-<context>
-    <name>CPushButton</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/cpushbutton.cpp" line="17"/>
-        <source>New event type</source>
-        <translation>新增日程类型</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleDlg</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="46"/>
-        <source>New Event</source>
-        <translation>新建日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="60"/>
-        <source>Edit Event</source>
-        <translation>编辑日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="270"/>
-        <source>End time must be greater than start time</source>
-        <translation>结束时间需晚于开始时间</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="271"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>确 定</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="506"/>
-        <source>Never</source>
-        <translation>从不</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="507"/>
-        <source>At time of event</source>
-        <translation>日程开始时</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="508"/>
-        <source>15 minutes before</source>
-        <translation>15分钟前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="509"/>
-        <source>30 minutes before</source>
-        <translation>30分钟前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="510"/>
-        <source>1 hour before</source>
-        <translation>1小时前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="511"/>
-        <source>1 day before</source>
-        <translation>1天前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="512"/>
-        <source>2 days before</source>
-        <translation>2天前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="513"/>
-        <source>1 week before</source>
-        <translation>1周前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="536"/>
-        <source>On start day (9:00 AM)</source>
-        <translation>日程发生当天（上午9点）</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="583"/>
-        <source>time(s)</source>
-        <translation>次后</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="598"/>
-        <source>Enter a name please</source>
-        <translation>名称不能为空</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="693"/>
-        <source>The name can not only contain whitespaces</source>
-        <translation>名称不能设置为全空格，请修改</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="749"/>
-        <source>Type:</source>
-        <translation>类型：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="754"/>
-        <source>Description:</source>
-        <translation>内容：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="759"/>
-        <source>All Day:</source>
-        <translation>全天：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="764"/>
-        <source>Starts:</source>
-        <translation>开始时间：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="769"/>
-        <source>Ends:</source>
-        <translation>结束时间：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="774"/>
-        <source>Remind Me:</source>
-        <translation>提醒：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="779"/>
-        <source>Repeat:</source>
-        <translation>重复：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="784"/>
-        <source>End Repeat:</source>
-        <translation>结束重复：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="840"/>
-        <source>Calendar account:</source>
-        <translation>日历帐户：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="841"/>
-        <source>Calendar account</source>
-        <translation>日历帐户</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="868"/>
-        <source>Type</source>
-        <translation>类型</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="910"/>
-        <source>Description</source>
-        <translation>内容</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="940"/>
-        <source>All Day</source>
-        <translation>全天</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="964"/>
-        <source>Time:</source>
-        <translation>时间：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="965"/>
-        <source>Time</source>
-        <translation>时间</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="972"/>
-        <source>Solar</source>
-        <translation>公历</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="973"/>
-        <source>Lunar</source>
-        <translation>农历</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1006"/>
-        <source>Starts</source>
-        <translation>开始时间</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1047"/>
-        <source>Ends</source>
-        <translation>结束时间</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1092"/>
-        <source>Remind Me</source>
-        <translation>提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1119"/>
-        <source>Repeat</source>
-        <translation>重复</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1134"/>
-        <source>Daily</source>
-        <translation>每天</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1135"/>
-        <source>Weekdays</source>
-        <translation>工作日</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1136"/>
-        <source>Weekly</source>
-        <translation>每周</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1137"/>
-        <source>Monthly</source>
-        <translation>每月</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1138"/>
-        <source>Yearly</source>
-        <translation>每年</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1158"/>
-        <source>End Repeat</source>
-        <translation>结束重复</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1169"/>
-        <source>After</source>
-        <translation>于</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1170"/>
-        <source>On</source>
-        <translation>于日期</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1240"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1241"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>保 存</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleOperation</name>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74"/>
-        <source>All occurrences of a repeating event must have the same all-day status.</source>
-        <translation>重复日程的所有重复必须具有相同的全天状态。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75"/>
-        <source>Do you want to change all occurrences?</source>
-        <translation>您要更改所有重复吗？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77"/>
-        <source>Change All</source>
-        <translation>全部更改</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94"/>
-        <source>You are changing the repeating rule of this event.</source>
-        <translation>您正在更改日程的重复规则。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127"/>
-        <source>You are deleting an event.</source>
-        <translation>您正在删除日程。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128"/>
-        <source>Are you sure you want to delete this event?</source>
-        <translation>您确定要删除此日程吗？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>删 除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150"/>
-        <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
-        <translation>您要删除此日程的所有重复，还是只删除所选重复？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152"/>
-        <source>Delete All</source>
-        <translation>全部删除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153"/>
-        <source>Delete Only This Event</source>
-        <translation>仅删除此日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173"/>
-        <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
-        <translation>您要删除此日程的这个重复和所有将来重复，还是只删除所选重复？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175"/>
-        <source>Delete All Future Events</source>
-        <translation>删除所有将来日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255"/>
-        <source>You are changing a repeating event.</source>
-        <translation>您正在更改重复日程。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257"/>
-        <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
-        <translation>您要更改此日程的仅这一个重复，还是更改它的所有重复？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260"/>
-        <source>All</source>
-        <translation>全部日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261"/>
-        <source>Only This Event</source>
-        <translation>仅此日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290"/>
-        <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
-        <translation>您要更改此日程的这个重复和所有将来重复，还是只更改所选重复？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293"/>
-        <source>All Future Events</source>
-        <translation>所有将来日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416"/>
-        <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
-        <translation>您选择的是闰月，将按照农历规则提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>确 定</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchDateItem</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>M</source>
-        <translation>月</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>D</source>
-        <translation>日</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchItem</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="42"/>
-        <source>Edit</source>
-        <translation>编辑</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="43"/>
-        <source>Delete</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="267"/>
-        <source>All Day</source>
-        <translation>全天</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="648"/>
-        <source>No search results</source>
-        <translation>无搜索结果</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/scheduleview.cpp" line="316"/>
-        <source>ALL DAY</source>
-        <translation>全天</translation>
-    </message>
-</context>
-<context>
-    <name>CSettingDialog</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="389"/>
-        <source>import ICS file</source>
-        <translation>导入ICS文件</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="403"/>
-        <source>Manual</source>
-        <translation>手动</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="404"/>
-        <source>15 mins</source>
-        <translation>每15分钟</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="405"/>
-        <source>30 mins</source>
-        <translation>每30分钟</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="406"/>
-        <source>1 hour</source>
-        <translation>每1小时</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="407"/>
-        <source>24 hours</source>
-        <translation>每24小时</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="418"/>
-        <source>Sync Now</source>
-        <translation>立即同步</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="585"/>
-        <source>Last sync</source>
-        <translation>最近同步时间</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="779"/>
-        <source>Please go to the Control Center to change system settings</source>
-        <translation>请前往控制中心更改系统设置</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="346"/>
-        <source>Monday</source>
-        <translation>周一</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="345"/>
-        <source>Sunday</source>
-        <translation>周日</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="347"/>
-        <source>Use System Setting</source>
-        <translation>使用系统设置</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="365"/>
-        <source>12-hour clock</source>
-        <translation>12小时制</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="364"/>
-        <source>24-hour clock</source>
-        <translation>24小时制</translation>
-    </message>
-</context>
-<context>
-    <name>CTimeEdit</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="71"/>
-        <source>(%1 mins)</source>
-        <translation>(%1分钟)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="73"/>
-        <source>(%1 hour)</source>
-        <translation>(%1小时)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="75"/>
-        <source>(%1 hours)</source>
-        <translation>(%1小时)</translation>
-    </message>
-</context>
-<context>
-    <name>CTitleWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="30"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="42"/>
-        <source>M</source>
-        <translation>月</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="50"/>
-        <source>W</source>
-        <translation>周</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="58"/>
-        <source>D</source>
-        <translation>日</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="92"/>
-        <source>Search events and festivals</source>
-        <translation>搜索日程/节日</translation>
-    </message>
-</context>
-<context>
-    <name>CWeekWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="90"/>
-        <source>Week</source>
-        <translation>周</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="280"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-</context>
-<context>
-    <name>CYearScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="268"/>
-        <source>All Day</source>
-        <translation>全天</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="288"/>
-        <source>No event</source>
-        <translation>无日程</translation>
-    </message>
-</context>
-<context>
-    <name>CYearWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="615"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-</context>
-<context>
-    <name>CalendarWindow</name>
-    <message>
-        <location filename="../calendar-client/src/main.cpp" line="66"/>
-        <source>Calendar</source>
-        <translation>日历</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/main.cpp" line="69"/>
-        <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
-        <translation>日历是一款查看日期、管理日程的小工具。</translation>
-    </message>
-</context>
-<context>
-    <name>Calendarmainwindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="89"/>
-        <source>Calendar</source>
-        <translation>日历</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="372"/>
-        <source>Manage</source>
-        <translation>管理</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="379"/>
-        <source>Privacy Policy</source>
-        <translation>隐私政策</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="962"/>
-        <source>Syncing...</source>
-        <translation>正在同步...</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="973"/>
-        <source>Sync successful</source>
-        <translation>同步成功</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="982"/>
-        <source>Sync failed, please try later</source>
-        <translation>同步失败，请稍后再试</translation>
-    </message>
-</context>
-<context>
-    <name>CenterWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="174"/>
-        <source>All Day</source>
-        <translation>全天</translation>
-    </message>
-</context>
-<context>
-    <name>DAccountDataBase</name>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1155"/>
-        <source>Work</source>
-        <translation>工作</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1157"/>
-        <source>Life</source>
-        <translation>生活</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1159"/>
-        <source>Other</source>
-        <translation>其他</translation>
-    </message>
-</context>
-<context>
-    <name>DAlarmManager</name>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="187"/>
-        <source>Close</source>
-        <comment>button</comment>
-        <translation>关 闭</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="191"/>
-        <source>One day before start</source>
-        <translation>提前1天提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="197"/>
-        <source>Remind me tomorrow</source>
-        <translation>明天提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="202"/>
-        <source>Remind me later</source>
-        <translation>稍后提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="204"/>
-        <source>15 mins later</source>
-        <translation>15分钟后</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="205"/>
-        <source>1 hour later</source>
-        <translation>1小时后</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="206"/>
-        <source>4 hours later</source>
-        <translation>4小时后</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="207"/>
-        <source>Tomorrow</source>
-        <translation>明天</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="215"/>
-        <source>Schedule Reminder</source>
-        <translation>日程提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="258"/>
-        <source>%1 to %2</source>
-        <translation>%1 至 %2</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="296"/>
-        <source>Today</source>
-        <translation>今天</translation>
-    </message>
-</context>
-<context>
-    <name>DragInfoGraphicsView</name>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="48"/>
-        <source>Edit</source>
-        <translation>编辑</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="49"/>
-        <source>Delete</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="50"/>
-        <source>New event</source>
-        <translation>新建日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="759"/>
-        <source>New Event</source>
-        <translation>新建日程</translation>
-    </message>
-</context>
-<context>
-    <name>JobTypeListView</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="144"/>
-        <source>export</source>
-        <translation>导出</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="219"/>
-        <source>import ICS file</source>
-        <translation>导入ICS文件</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="450"/>
-        <source>You are deleting an event type.</source>
-        <translation>您正在删除日程类型。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="451"/>
-        <source>All events under this type will be deleted and cannot be recovered.</source>
-        <translation>此日程类型下的所有日程都会删除且不可恢复。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="452"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="453"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>删 除</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="38"/>
-        <source>Account settings</source>
-        <translation>帐户设置</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="42"/>
-        <source>Account</source>
-        <translation>帐户</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="53"/>
-        <source>Select items to be synced</source>
-        <translation>设置您的同步项</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="56"/>
-        <source>Events</source>
-        <translation>日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="63"/>
-        <source>General settings</source>
-        <translation>通用设置</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="74"/>
-        <source>Sync interval</source>
-        <translation>同步频率</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="96"/>
-        <source>Manage calendar</source>
-        <translation>日历管理</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="104"/>
-        <source>Calendar account</source>
-        <translation>日历帐户</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="112"/>
-        <source>Event types</source>
-        <translation>日程类型</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="150"/>
-        <source>General</source>
-        <translation>通用</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="152"/>
-        <source>First day of week</source>
-        <translation>每星期开始于</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="153"/>
-        <source>Time</source>
-        <translation>时间</translation>
-    </message>
-</context>
-<context>
-    <name>Return</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="611"/>
-        <source>Today</source>
-        <comment>Return</comment>
-        <translation>返回今天</translation>
-    </message>
-</context>
-<context>
-    <name>Return Today</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="339"/>
-        <source>Today</source>
-        <comment>Return Today</comment>
-        <translation>返回今天</translation>
-    </message>
-</context>
-<context>
-    <name>ScheduleTypeEditDlg</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22"/>
-        <source>New event type</source>
-        <translation>新增日程类型</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="32"/>
-        <source>Edit event type</source>
-        <translation>编辑日程类型</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="43"/>
-        <source>Import ICS file</source>
-        <translation>导入ICS文件</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="151"/>
-        <source>Name:</source>
-        <translation>名称：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="152"/>
-        <source>Color:</source>
-        <translation>颜色：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="156"/>
-        <source>ICS File:</source>
-        <translation>ICS文件：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="167"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="168"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>保 存</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="219"/>
-        <source>The name can not only contain whitespaces</source>
-        <translation>名称不能设置为全空格，请修改</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="256"/>
-        <source>Enter a name please</source>
-        <translation>名称不能为空</translation>
-    </message>
-</context>
-<context>
-    <name>Shortcut</name>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="16"/>
-        <source>Help</source>
-        <translation>帮助</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="17"/>
-        <source>Delete event</source>
-        <translation>删除日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="20"/>
-        <source>Copy</source>
-        <translation>复制</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="21"/>
-        <source>Cut</source>
-        <translation>剪切</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="22"/>
-        <source>Paste</source>
-        <translation>粘贴</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="25"/>
-        <source>Delete</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="26"/>
-        <source>Select all</source>
-        <translation>全选</translation>
-    </message>
-</context>
-<context>
-    <name>SidebarCalendarWidget</name>
-    <message>
-        <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
-        <source>M</source>
-        <translation>月</translation>
-    </message>
-</context>
-<context>
-    <name>TimeJumpDialog</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/timejumpdialog.cpp" line="29"/>
-        <source>Go</source>
-        <comment>button</comment>
-        <translation>跳 转</translation>
-    </message>
-</context>
-<context>
-    <name>UserloginWidget</name>
-    <message>
-        <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="48"/>
-        <source>Sign In</source>
-        <comment>button</comment>
-        <translation>登 录</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="49"/>
-        <source>Sign Out</source>
-        <comment>button</comment>
-        <translation>退出登录</translation>
-    </message>
-</context>
-<context>
-    <name>YearFrame</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="928"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-</context>
-<context>
-    <name>today</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="188"/>
-        <source>Today</source>
-        <comment>Today</comment>
-        <translation>今天</translation>
-    </message>
-</context>
+    <context>
+        <name>AccountItem</name>
+        <message>
+            <source>Sync successful</source>
+            <translation type="vanished">同步成功</translation>
+        </message>
+        <message>
+            <source>Network error</source>
+            <translation type="vanished">网络异常</translation>
+        </message>
+        <message>
+            <source>Server exception</source>
+            <translation type="vanished">服务器异常</translation>
+        </message>
+        <message>
+            <source>Storage full</source>
+            <translation type="vanished">存储已满</translation>
+        </message>
+    </context>
+    <context>
+        <name>AccountManager</name>
+        <message>
+            <source>Local account</source>
+            <translation type="vanished">本地帐户</translation>
+        </message>
+        <message>
+            <source>Event types</source>
+            <translation type="vanished">日程类型</translation>
+        </message>
+    </context>
+    <context>
+        <name>CColorPickerWidget</name>
+        <message>
+            <source>Color</source>
+            <translation type="vanished">颜色</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation type="vanished">取 消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <comment>button</comment>
+            <translation type="vanished">保 存</translation>
+        </message>
+    </context>
+    <context>
+        <name>CDayMonthView</name>
+        <message>
+            <source>Monday</source>
+            <translation type="vanished">星期一</translation>
+        </message>
+        <message>
+            <source>Tuesday</source>
+            <translation type="vanished">星期二</translation>
+        </message>
+        <message>
+            <source>Wednesday</source>
+            <translation type="vanished">星期三</translation>
+        </message>
+        <message>
+            <source>Thursday</source>
+            <translation type="vanished">星期四</translation>
+        </message>
+        <message>
+            <source>Friday</source>
+            <translation type="vanished">星期五</translation>
+        </message>
+        <message>
+            <source>Saturday</source>
+            <translation type="vanished">星期六</translation>
+        </message>
+        <message>
+            <source>Sunday</source>
+            <translation type="vanished">星期日</translation>
+        </message>
+    </context>
+    <context>
+        <name>CDayWindow</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">年</translation>
+        </message>
+        <message>
+            <source>M</source>
+            <translation type="vanished">月</translation>
+        </message>
+        <message>
+            <source>D</source>
+            <translation type="vanished">日</translation>
+        </message>
+        <message>
+            <source>Lunar</source>
+            <translation type="vanished">农历</translation>
+        </message>
+    </context>
+    <context>
+        <name>CGraphicsView</name>
+        <message>
+            <source>New Event</source>
+            <translation type="vanished">新建日程</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthScheduleNumItem</name>
+        <message>
+            <source>%1 more</source>
+            <translation type="vanished">还有%1项</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthView</name>
+        <message>
+            <source>New event</source>
+            <translation type="vanished">新建日程</translation>
+        </message>
+        <message>
+            <source>New Event</source>
+            <translation type="vanished">新建日程</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthWindow</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">年</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMyScheduleView</name>
+        <message>
+            <source>My Event</source>
+            <translation type="vanished">我的日程</translation>
+        </message>
+        <message>
+            <source>OK</source>
+            <comment>button</comment>
+            <translation type="vanished">确 定</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation type="vanished">删 除</translation>
+        </message>
+        <message>
+            <source>Edit</source>
+            <comment>button</comment>
+            <translation type="vanished">编 辑</translation>
+        </message>
+    </context>
+    <context>
+        <name>CPushButton</name>
+        <message>
+            <source>New event type</source>
+            <translation type="vanished">新增日程类型</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleDlg</name>
+        <message>
+            <source>New Event</source>
+            <translation type="vanished">新建日程</translation>
+        </message>
+        <message>
+            <source>Edit Event</source>
+            <translation type="vanished">编辑日程</translation>
+        </message>
+        <message>
+            <source>End time must be greater than start time</source>
+            <translation type="vanished">结束时间需晚于开始时间</translation>
+        </message>
+        <message>
+            <source>OK</source>
+            <comment>button</comment>
+            <translation type="vanished">确 定</translation>
+        </message>
+        <message>
+            <source>Never</source>
+            <translation type="vanished">从不</translation>
+        </message>
+        <message>
+            <source>At time of event</source>
+            <translation type="vanished">日程开始时</translation>
+        </message>
+        <message>
+            <source>15 minutes before</source>
+            <translation type="vanished">15分钟前</translation>
+        </message>
+        <message>
+            <source>30 minutes before</source>
+            <translation type="vanished">30分钟前</translation>
+        </message>
+        <message>
+            <source>1 hour before</source>
+            <translation type="vanished">1小时前</translation>
+        </message>
+        <message>
+            <source>1 day before</source>
+            <translation type="vanished">1天前</translation>
+        </message>
+        <message>
+            <source>2 days before</source>
+            <translation type="vanished">2天前</translation>
+        </message>
+        <message>
+            <source>1 week before</source>
+            <translation type="vanished">1周前</translation>
+        </message>
+        <message>
+            <source>On start day (9:00 AM)</source>
+            <translation type="vanished">日程发生当天（上午9点）</translation>
+        </message>
+        <message>
+            <source>time(s)</source>
+            <translation type="vanished">次后</translation>
+        </message>
+        <message>
+            <source>Enter a name please</source>
+            <translation type="vanished">名称不能为空</translation>
+        </message>
+        <message>
+            <source>The name can not only contain whitespaces</source>
+            <translation type="vanished">名称不能设置为全空格，请修改</translation>
+        </message>
+        <message>
+            <source>Type:</source>
+            <translation type="vanished">类型：</translation>
+        </message>
+        <message>
+            <source>Description:</source>
+            <translation type="vanished">内容：</translation>
+        </message>
+        <message>
+            <source>All Day:</source>
+            <translation type="vanished">全天：</translation>
+        </message>
+        <message>
+            <source>Starts:</source>
+            <translation type="vanished">开始时间：</translation>
+        </message>
+        <message>
+            <source>Ends:</source>
+            <translation type="vanished">结束时间：</translation>
+        </message>
+        <message>
+            <source>Remind Me:</source>
+            <translation type="vanished">提醒：</translation>
+        </message>
+        <message>
+            <source>Repeat:</source>
+            <translation type="vanished">重复：</translation>
+        </message>
+        <message>
+            <source>End Repeat:</source>
+            <translation type="vanished">结束重复：</translation>
+        </message>
+        <message>
+            <source>Calendar account:</source>
+            <translation type="vanished">日历帐户：</translation>
+        </message>
+        <message>
+            <source>Calendar account</source>
+            <translation type="vanished">日历帐户</translation>
+        </message>
+        <message>
+            <source>Type</source>
+            <translation type="vanished">类型</translation>
+        </message>
+        <message>
+            <source>Description</source>
+            <translation type="vanished">内容</translation>
+        </message>
+        <message>
+            <source>All Day</source>
+            <translation type="vanished">全天</translation>
+        </message>
+        <message>
+            <source>Time:</source>
+            <translation type="vanished">时间：</translation>
+        </message>
+        <message>
+            <source>Time</source>
+            <translation type="vanished">时间</translation>
+        </message>
+        <message>
+            <source>Solar</source>
+            <translation type="vanished">公历</translation>
+        </message>
+        <message>
+            <source>Lunar</source>
+            <translation type="vanished">农历</translation>
+        </message>
+        <message>
+            <source>Starts</source>
+            <translation type="vanished">开始时间</translation>
+        </message>
+        <message>
+            <source>Ends</source>
+            <translation type="vanished">结束时间</translation>
+        </message>
+        <message>
+            <source>Remind Me</source>
+            <translation type="vanished">提醒</translation>
+        </message>
+        <message>
+            <source>Repeat</source>
+            <translation type="vanished">重复</translation>
+        </message>
+        <message>
+            <source>Daily</source>
+            <translation type="vanished">每天</translation>
+        </message>
+        <message>
+            <source>Weekdays</source>
+            <translation type="vanished">工作日</translation>
+        </message>
+        <message>
+            <source>Weekly</source>
+            <translation type="vanished">每周</translation>
+        </message>
+        <message>
+            <source>Monthly</source>
+            <translation type="vanished">每月</translation>
+        </message>
+        <message>
+            <source>Yearly</source>
+            <translation type="vanished">每年</translation>
+        </message>
+        <message>
+            <source>End Repeat</source>
+            <translation type="vanished">结束重复</translation>
+        </message>
+        <message>
+            <source>After</source>
+            <translation type="vanished">于</translation>
+        </message>
+        <message>
+            <source>On</source>
+            <translation type="vanished">于日期</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation type="vanished">取 消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <comment>button</comment>
+            <translation type="vanished">保 存</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleOperation</name>
+        <message>
+            <source>All occurrences of a repeating event must have the same all-day status.</source>
+            <translation type="vanished">重复日程的所有重复必须具有相同的全天状态。</translation>
+        </message>
+        <message>
+            <source>Do you want to change all occurrences?</source>
+            <translation type="vanished">您要更改所有重复吗？</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation type="vanished">取 消</translation>
+        </message>
+        <message>
+            <source>Change All</source>
+            <translation type="vanished">全部更改</translation>
+        </message>
+        <message>
+            <source>You are changing the repeating rule of this event.</source>
+            <translation type="vanished">您正在更改日程的重复规则。</translation>
+        </message>
+        <message>
+            <source>You are deleting an event.</source>
+            <translation type="vanished">您正在删除日程。</translation>
+        </message>
+        <message>
+            <source>Are you sure you want to delete this event?</source>
+            <translation type="vanished">您确定要删除此日程吗？</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation type="vanished">删 除</translation>
+        </message>
+        <message>
+            <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
+            <translation type="vanished">您要删除此日程的所有重复，还是只删除所选重复？</translation>
+        </message>
+        <message>
+            <source>Delete All</source>
+            <translation type="vanished">全部删除</translation>
+        </message>
+        <message>
+            <source>Delete Only This Event</source>
+            <translation type="vanished">仅删除此日程</translation>
+        </message>
+        <message>
+            <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
+            <translation type="vanished">您要删除此日程的这个重复和所有将来重复，还是只删除所选重复？</translation>
+        </message>
+        <message>
+            <source>Delete All Future Events</source>
+            <translation type="vanished">删除所有将来日程</translation>
+        </message>
+        <message>
+            <source>You are changing a repeating event.</source>
+            <translation type="vanished">您正在更改重复日程。</translation>
+        </message>
+        <message>
+            <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
+            <translation type="vanished">您要更改此日程的仅这一个重复，还是更改它的所有重复？</translation>
+        </message>
+        <message>
+            <source>All</source>
+            <translation type="vanished">全部日程</translation>
+        </message>
+        <message>
+            <source>Only This Event</source>
+            <translation type="vanished">仅此日程</translation>
+        </message>
+        <message>
+            <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
+            <translation type="vanished">您要更改此日程的这个重复和所有将来重复，还是只更改所选重复？</translation>
+        </message>
+        <message>
+            <source>All Future Events</source>
+            <translation type="vanished">所有将来日程</translation>
+        </message>
+        <message>
+            <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
+            <translation type="vanished">您选择的是闰月，将按照农历规则提醒</translation>
+        </message>
+        <message>
+            <source>OK</source>
+            <comment>button</comment>
+            <translation type="vanished">确 定</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchDateItem</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">年</translation>
+        </message>
+        <message>
+            <source>M</source>
+            <translation type="vanished">月</translation>
+        </message>
+        <message>
+            <source>D</source>
+            <translation type="vanished">日</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchItem</name>
+        <message>
+            <source>Edit</source>
+            <translation type="vanished">编辑</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <translation type="vanished">删除</translation>
+        </message>
+        <message>
+            <source>All Day</source>
+            <translation type="vanished">全天</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchView</name>
+        <message>
+            <source>No search results</source>
+            <translation type="vanished">无搜索结果</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleView</name>
+        <message>
+            <source>ALL DAY</source>
+            <translation type="vanished">全天</translation>
+        </message>
+    </context>
+    <context>
+        <name>CSettingDialog</name>
+        <message>
+            <source>import ICS file</source>
+            <translation type="vanished">导入ICS文件</translation>
+        </message>
+        <message>
+            <source>Manual</source>
+            <translation type="vanished">手动</translation>
+        </message>
+        <message>
+            <source>15 mins</source>
+            <translation type="vanished">每15分钟</translation>
+        </message>
+        <message>
+            <source>30 mins</source>
+            <translation type="vanished">每30分钟</translation>
+        </message>
+        <message>
+            <source>1 hour</source>
+            <translation type="vanished">每1小时</translation>
+        </message>
+        <message>
+            <source>24 hours</source>
+            <translation type="vanished">每24小时</translation>
+        </message>
+        <message>
+            <source>Sync Now</source>
+            <translation type="vanished">立即同步</translation>
+        </message>
+        <message>
+            <source>Last sync</source>
+            <translation type="vanished">最近同步时间</translation>
+        </message>
+        <message>
+            <source>Please go to the Control Center to change system settings</source>
+            <translation type="vanished">请前往控制中心更改系统设置</translation>
+        </message>
+        <message>
+            <source>Monday</source>
+            <translation type="vanished">周一</translation>
+        </message>
+        <message>
+            <source>Sunday</source>
+            <translation type="vanished">周日</translation>
+        </message>
+        <message>
+            <source>Use System Setting</source>
+            <translation type="vanished">使用系统设置</translation>
+        </message>
+        <message>
+            <source>12-hour clock</source>
+            <translation type="vanished">12小时制</translation>
+        </message>
+        <message>
+            <source>24-hour clock</source>
+            <translation type="vanished">24小时制</translation>
+        </message>
+    </context>
+    <context>
+        <name>CTimeEdit</name>
+        <message>
+            <source>(%1 mins)</source>
+            <translation type="vanished">(%1分钟)</translation>
+        </message>
+        <message>
+            <source>(%1 hour)</source>
+            <translation type="vanished">(%1小时)</translation>
+        </message>
+        <message>
+            <source>(%1 hours)</source>
+            <translation type="vanished">(%1小时)</translation>
+        </message>
+    </context>
+    <context>
+        <name>CTitleWidget</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">年</translation>
+        </message>
+        <message>
+            <source>M</source>
+            <translation type="vanished">月</translation>
+        </message>
+        <message>
+            <source>W</source>
+            <translation type="vanished">周</translation>
+        </message>
+        <message>
+            <source>D</source>
+            <translation type="vanished">日</translation>
+        </message>
+        <message>
+            <source>Search events and festivals</source>
+            <translation type="vanished">搜索日程/节日</translation>
+        </message>
+    </context>
+    <context>
+        <name>CWeekWindow</name>
+        <message>
+            <source>Week</source>
+            <translation type="vanished">周</translation>
+        </message>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">年</translation>
+        </message>
+    </context>
+    <context>
+        <name>CYearScheduleView</name>
+        <message>
+            <source>All Day</source>
+            <translation type="vanished">全天</translation>
+        </message>
+        <message>
+            <source>No event</source>
+            <translation type="vanished">无日程</translation>
+        </message>
+    </context>
+    <context>
+        <name>CYearWindow</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">年</translation>
+        </message>
+    </context>
+    <context>
+        <name>CalendarWindow</name>
+        <message>
+            <source>Calendar</source>
+            <translation type="vanished">日历</translation>
+        </message>
+        <message>
+            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
+            <translation type="vanished">日历是一款查看日期、管理日程的小工具。</translation>
+        </message>
+    </context>
+    <context>
+        <name>Calendarmainwindow</name>
+        <message>
+            <source>Calendar</source>
+            <translation type="vanished">日历</translation>
+        </message>
+        <message>
+            <source>Manage</source>
+            <translation type="vanished">管理</translation>
+        </message>
+        <message>
+            <source>Privacy Policy</source>
+            <translation type="vanished">隐私政策</translation>
+        </message>
+        <message>
+            <source>Syncing...</source>
+            <translation type="vanished">同步中...</translation>
+        </message>
+        <message>
+            <source>Sync successful</source>
+            <translation type="vanished">同步成功</translation>
+        </message>
+        <message>
+            <source>Sync failed, please try later</source>
+            <translation type="vanished">同步失败，请稍后再试</translation>
+        </message>
+    </context>
+    <context>
+        <name>CenterWidget</name>
+        <message>
+            <source>All Day</source>
+            <translation type="vanished">全天</translation>
+        </message>
+    </context>
+    <context>
+        <name>DAccountDataBase</name>
+        <message>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1304" />
+            <source>Work</source>
+            <translation>工作</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1306" />
+            <source>Life</source>
+            <translation>生活</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1308" />
+            <source>Other</source>
+            <translation>其他</translation>
+        </message>
+    </context>
+    <context>
+        <name>DAccountManageModule</name>
+        <message>
+            <location filename="../src/calendar-service/src/calendarDataManager/daccountmanagemodule.cpp" line="125" />
+            <source>[Original Type: %1]</source>
+            <translation>[原类型: %1]</translation>
+        </message>
+    </context>
+    <context>
+        <name>DAlarmManager</name>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="194" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="203" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="208" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="219" />
+            <source>Close</source>
+            <comment>button</comment>
+            <translation>关 闭</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="198" />
+            <source>One day before start</source>
+            <translation>提前1天提醒</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="204" />
+            <source>Remind me tomorrow</source>
+            <translation>明天提醒</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="209" />
+            <source>Remind me later</source>
+            <translation>稍后提醒</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="211" />
+            <source>15 mins later</source>
+            <translation>15分钟后</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="212" />
+            <source>1 hour later</source>
+            <translation>1小时后</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="213" />
+            <source>4 hours later</source>
+            <translation>4小时后</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="214" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="311" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="324" />
+            <source>Tomorrow</source>
+            <translation>明天</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="222" />
+            <source>Schedule Reminder</source>
+            <translation>日程提醒</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="268" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="280" />
+            <source>%1 to %2</source>
+            <translation>%1 至 %2</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="307" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="320" />
+            <source>Today</source>
+            <translation>今天</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavAccountRegistrar</name>
+        <message>
+            <location filename="../src/calendar-service/src/caldav/dcaldavaccountregistrar.cpp" line="60" />
+            <source>Calendar</source>
+            <translation>日历</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavProviderProfile</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="37" />
+            <source>DingTalk</source>
+            <translation>钉钉</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="39" />
+            <source>WeCom</source>
+            <translation>企业微信</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="41" />
+            <source>Tencent Meeting</source>
+            <translation>腾讯会议</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="43" />
+            <source>QQ Mail</source>
+            <translation>QQ邮箱</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="45" />
+            <source>Feishu</source>
+            <translation>飞书</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="48" />
+            <source>Other CalDAV</source>
+            <translation>其他 CalDAV</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavSyncStatus</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server certificate is invalid.</source>
+            <translation>服务器证书无效</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="54" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>用户名或密码错误，请重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="57" />
+            <source>This server does not support CalDAV.</source>
+            <translation>该服务器不支持CalDAV协议</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="61" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>服务器返回的数据无法解析，请确认服务器地址或稍后重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="65" />
+            <source>The server denied access.</source>
+            <translation>服务器拒绝访问</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="68" />
+            <source>The server request timed out.</source>
+            <translation>服务器请求超时</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="72" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>无法连接到服务器，请检查网络连接和服务器地址。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76" />
+            <source>Synchronization failed.</source>
+            <translation>同步失败</translation>
+        </message>
+    </context>
+    <context>
+        <name>DragInfoGraphicsView</name>
+        <message>
+            <source>Edit</source>
+            <translation type="vanished">编辑</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <translation type="vanished">删除</translation>
+        </message>
+        <message>
+            <source>New event</source>
+            <translation type="vanished">新建日程</translation>
+        </message>
+        <message>
+            <source>New Event</source>
+            <translation type="vanished">新建日程</translation>
+        </message>
+    </context>
+    <context>
+        <name>JobTypeListView</name>
+        <message>
+            <source>export</source>
+            <translation type="vanished">导出</translation>
+        </message>
+        <message>
+            <source>import ICS file</source>
+            <translation type="vanished">导入ICS文件</translation>
+        </message>
+        <message>
+            <source>You are deleting an event type.</source>
+            <translation type="vanished">您正在删除日程类型。</translation>
+        </message>
+        <message>
+            <source>All events under this type will be deleted and cannot be recovered.</source>
+            <translation type="vanished">此日程类型下的所有日程都会删除且不可恢复。</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation type="vanished">取 消</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation type="vanished">删 除</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <source>Account settings</source>
+            <translation type="vanished">帐户设置</translation>
+        </message>
+        <message>
+            <source>Account</source>
+            <translation type="vanished">帐户</translation>
+        </message>
+        <message>
+            <source>Select items to be synced</source>
+            <translation type="vanished">设置您的同步项</translation>
+        </message>
+        <message>
+            <source>Events</source>
+            <translation type="vanished">日程</translation>
+        </message>
+        <message>
+            <source>General settings</source>
+            <translation type="vanished">通用设置</translation>
+        </message>
+        <message>
+            <source>Sync interval</source>
+            <translation type="vanished">同步频率</translation>
+        </message>
+        <message>
+            <source>Manage calendar</source>
+            <translation type="vanished">日历管理</translation>
+        </message>
+        <message>
+            <source>Calendar account</source>
+            <translation type="vanished">日历帐户</translation>
+        </message>
+        <message>
+            <source>Event types</source>
+            <translation type="vanished">日程类型</translation>
+        </message>
+        <message>
+            <source>General</source>
+            <translation type="vanished">通用</translation>
+        </message>
+        <message>
+            <source>First day of week</source>
+            <translation type="vanished">每星期开始于</translation>
+        </message>
+        <message>
+            <source>Time</source>
+            <translation type="vanished">时间</translation>
+        </message>
+    </context>
+    <context>
+        <name>Return</name>
+        <message>
+            <source>Today</source>
+            <comment>Return</comment>
+            <translation type="vanished">返回今天</translation>
+        </message>
+    </context>
+    <context>
+        <name>Return Today</name>
+        <message>
+            <source>Today</source>
+            <comment>Return Today</comment>
+            <translation type="vanished">返回今天</translation>
+        </message>
+    </context>
+    <context>
+        <name>ScheduleTypeEditDlg</name>
+        <message>
+            <source>New event type</source>
+            <translation type="vanished">新增日程类型</translation>
+        </message>
+        <message>
+            <source>Edit event type</source>
+            <translation type="vanished">编辑日程类型</translation>
+        </message>
+        <message>
+            <source>Import ICS file</source>
+            <translation type="vanished">导入ICS文件</translation>
+        </message>
+        <message>
+            <source>Name:</source>
+            <translation type="vanished">名称：</translation>
+        </message>
+        <message>
+            <source>Color:</source>
+            <translation type="vanished">颜色：</translation>
+        </message>
+        <message>
+            <source>ICS File:</source>
+            <translation type="vanished">ICS文件：</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation type="vanished">取 消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <comment>button</comment>
+            <translation type="vanished">保 存</translation>
+        </message>
+        <message>
+            <source>The name can not only contain whitespaces</source>
+            <translation type="vanished">名称不能设置为全空格，请修改</translation>
+        </message>
+        <message>
+            <source>Enter a name please</source>
+            <translation type="vanished">名称不能为空</translation>
+        </message>
+    </context>
+    <context>
+        <name>Shortcut</name>
+        <message>
+            <source>Help</source>
+            <translation type="vanished">帮助</translation>
+        </message>
+        <message>
+            <source>Delete event</source>
+            <translation type="vanished">删除日程</translation>
+        </message>
+        <message>
+            <source>Copy</source>
+            <translation type="vanished">复制</translation>
+        </message>
+        <message>
+            <source>Cut</source>
+            <translation type="vanished">剪切</translation>
+        </message>
+        <message>
+            <source>Paste</source>
+            <translation type="vanished">粘贴</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <translation type="vanished">删除</translation>
+        </message>
+        <message>
+            <source>Select all</source>
+            <translation type="vanished">全选</translation>
+        </message>
+    </context>
+    <context>
+        <name>SidebarCalendarWidget</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">年</translation>
+        </message>
+        <message>
+            <source>M</source>
+            <translation type="vanished">月</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimeJumpDialog</name>
+        <message>
+            <source>Go</source>
+            <comment>button</comment>
+            <translation type="vanished">跳 转</translation>
+        </message>
+    </context>
+    <context>
+        <name>UserloginWidget</name>
+        <message>
+            <source>Sign In</source>
+            <comment>button</comment>
+            <translation type="vanished">登 录</translation>
+        </message>
+        <message>
+            <source>Sign Out</source>
+            <comment>button</comment>
+            <translation type="vanished">退出</translation>
+        </message>
+    </context>
+    <context>
+        <name>YearFrame</name>
+        <message>
+            <source>Y</source>
+            <translation type="vanished">年</translation>
+        </message>
+    </context>
+    <context>
+        <name>today</name>
+        <message>
+            <source>Today</source>
+            <comment>Today</comment>
+            <translation type="vanished">今天</translation>
+        </message>
+    </context>
 </TS>

--- a/translations/dde-calendar.ts
+++ b/translations/dde-calendar.ts
@@ -1,1230 +1,1675 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE TS>
 <TS version="2.1" language="en_US">
-<context>
-    <name>AccountItem</name>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="41"/>
-        <source>Sync successful</source>
-        <translation>Sync successful</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="42"/>
-        <source>Network error</source>
-        <translation>Network error</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="43"/>
-        <source>Server exception</source>
-        <translation>Server exception</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="44"/>
-        <source>Storage full</source>
-        <translation>Storage full</translation>
-    </message>
-</context>
-<context>
-    <name>AccountManager</name>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="227"/>
-        <source>Local account</source>
-        <translation>Local account</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="229"/>
-        <source>Event types</source>
-        <translation>Event types</translation>
-    </message>
-</context>
-<context>
-    <name>CColorPickerWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="77"/>
-        <source>Color</source>
-        <translation>Color</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="90"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="92"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>Save</translation>
-    </message>
-</context>
-<context>
-    <name>CDayMonthView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="33"/>
-        <source>Monday</source>
-        <translation>Monday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="34"/>
-        <source>Tuesday</source>
-        <translation>Tuesday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35"/>
-        <source>Wednesday</source>
-        <translation>Wednesday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36"/>
-        <source>Thursday</source>
-        <translation>Thursday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37"/>
-        <source>Friday</source>
-        <translation>Friday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38"/>
-        <source>Saturday</source>
-        <translation>Saturday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39"/>
-        <source>Sunday</source>
-        <translation>Sunday</translation>
-    </message>
-</context>
-<context>
-    <name>CDayWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="112"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="113"/>
-        <source>M</source>
-        <translation>M</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="114"/>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="170"/>
-        <source>Lunar</source>
-        <translation>Lunar</translation>
-    </message>
-</context>
-<context>
-    <name>CGraphicsView</name>
-    <message>
-        <location filename="../calendar-client/src/view/graphicsview.cpp" line="628"/>
-        <source>New Event</source>
-        <translation>New Event</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthScheduleNumItem</name>
-    <message>
-        <location filename="../calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="80"/>
-        <source>%1 more</source>
-        <translation>%1 more</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="50"/>
-        <source>New event</source>
-        <translation>New event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="230"/>
-        <source>New Event</source>
-        <translation>New Event</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-</context>
-<context>
-    <name>CMyScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="284"/>
-        <source>My Event</source>
-        <translation>My Event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="326"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="331"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>Delete</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="332"/>
-        <source>Edit</source>
-        <comment>button</comment>
-        <translation>Edit</translation>
-    </message>
-</context>
-<context>
-    <name>CPushButton</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/cpushbutton.cpp" line="17"/>
-        <source>New event type</source>
-        <translation>New event type</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleDlg</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="46"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="625"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="921"/>
-        <source>New Event</source>
-        <translation>New Event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="60"/>
-        <source>Edit Event</source>
-        <translation>Edit Event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="270"/>
-        <source>End time must be greater than start time</source>
-        <translation>End time must be greater than start time</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="271"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="506"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="535"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1133"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1168"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1422"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1426"/>
-        <source>Never</source>
-        <translation>Never</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="507"/>
-        <source>At time of event</source>
-        <translation>At time of event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="508"/>
-        <source>15 minutes before</source>
-        <translation>15 minutes before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="509"/>
-        <source>30 minutes before</source>
-        <translation>30 minutes before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="510"/>
-        <source>1 hour before</source>
-        <translation>1 hour before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="511"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="537"/>
-        <source>1 day before</source>
-        <translation>1 day before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="512"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="538"/>
-        <source>2 days before</source>
-        <translation>2 days before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="513"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="539"/>
-        <source>1 week before</source>
-        <translation>1 week before</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="536"/>
-        <source>On start day (9:00 AM)</source>
-        <translation>On start day (9:00 AM)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="583"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="791"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1189"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1190"/>
-        <source>time(s)</source>
-        <translation>time(s)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="598"/>
-        <source>Enter a name please</source>
-        <translation>Enter a name please</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="693"/>
-        <source>The name can not only contain whitespaces</source>
-        <translation>The name can not only contain whitespaces</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="749"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="871"/>
-        <source>Type:</source>
-        <translation>Type:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="754"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="906"/>
-        <source>Description:</source>
-        <translation>Description:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="759"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="943"/>
-        <source>All Day:</source>
-        <translation>All Day:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="764"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1009"/>
-        <source>Starts:</source>
-        <translation>Starts:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="769"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1050"/>
-        <source>Ends:</source>
-        <translation>Ends:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="774"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1090"/>
-        <source>Remind Me:</source>
-        <translation>Remind Me:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="779"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1122"/>
-        <source>Repeat:</source>
-        <translation>Repeat:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="784"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1156"/>
-        <source>End Repeat:</source>
-        <translation>End Repeat:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="840"/>
-        <source>Calendar account:</source>
-        <translation>Calendar account:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="841"/>
-        <source>Calendar account</source>
-        <translation>Calendar account</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="868"/>
-        <source>Type</source>
-        <translation>Type</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="910"/>
-        <source>Description</source>
-        <translation>Description</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="940"/>
-        <source>All Day</source>
-        <translation>All Day</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="964"/>
-        <source>Time:</source>
-        <translation>Time:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="965"/>
-        <source>Time</source>
-        <translation>Time</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="972"/>
-        <source>Solar</source>
-        <translation>Solar</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="973"/>
-        <source>Lunar</source>
-        <translation>Lunar</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1006"/>
-        <source>Starts</source>
-        <translation>Starts</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1047"/>
-        <source>Ends</source>
-        <translation>Ends</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1092"/>
-        <source>Remind Me</source>
-        <translation>Remind Me</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1119"/>
-        <source>Repeat</source>
-        <translation>Repeat</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1134"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1427"/>
-        <source>Daily</source>
-        <translation>Daily</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1135"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1428"/>
-        <source>Weekdays</source>
-        <translation>Weekdays</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1136"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1429"/>
-        <source>Weekly</source>
-        <translation>Weekly</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1137"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1423"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1430"/>
-        <source>Monthly</source>
-        <translation>Monthly</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1138"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1424"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1431"/>
-        <source>Yearly</source>
-        <translation>Yearly</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1158"/>
-        <source>End Repeat</source>
-        <translation>End Repeat</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1169"/>
-        <source>After</source>
-        <translation>After</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1170"/>
-        <source>On</source>
-        <translation>On</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1240"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1241"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>Save</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleOperation</name>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74"/>
-        <source>All occurrences of a repeating event must have the same all-day status.</source>
-        <translation>All occurrences of a repeating event must have the same all-day status.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="95"/>
-        <source>Do you want to change all occurrences?</source>
-        <translation>Do you want to change all occurrences?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="96"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="129"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="151"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="174"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="259"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="292"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="97"/>
-        <source>Change All</source>
-        <translation>Change All</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94"/>
-        <source>You are changing the repeating rule of this event.</source>
-        <translation>You are changing the repeating rule of this event.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="149"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="172"/>
-        <source>You are deleting an event.</source>
-        <translation>You are deleting an event.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128"/>
-        <source>Are you sure you want to delete this event?</source>
-        <translation>Are you sure you want to delete this event?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>Delete</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150"/>
-        <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
-        <translation>Do you want to delete all occurrences of this event, or only the selected occurrence?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152"/>
-        <source>Delete All</source>
-        <translation>Delete All</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="176"/>
-        <source>Delete Only This Event</source>
-        <translation>Delete Only This Event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173"/>
-        <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
-        <translation>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175"/>
-        <source>Delete All Future Events</source>
-        <translation>Delete All Future Events</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="288"/>
-        <source>You are changing a repeating event.</source>
-        <translation>You are changing a repeating event.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257"/>
-        <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
-        <translation>Do you want to change only this occurrence of the event, or all occurrences?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260"/>
-        <source>All</source>
-        <translation>All</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="294"/>
-        <source>Only This Event</source>
-        <translation>Only This Event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290"/>
-        <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
-        <translation>Do you want to change only this occurrence of the event, or this and all future occurrences?</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293"/>
-        <source>All Future Events</source>
-        <translation>All Future Events</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416"/>
-        <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
-        <translation>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OK</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchDateItem</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>M</source>
-        <translation>M</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchItem</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="42"/>
-        <source>Edit</source>
-        <translation>Edit</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="43"/>
-        <source>Delete</source>
-        <translation>Delete</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="267"/>
-        <source>All Day</source>
-        <translation>All Day</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="648"/>
-        <source>No search results</source>
-        <translation>No search results</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/scheduleview.cpp" line="316"/>
-        <source>ALL DAY</source>
-        <translation>ALL DAY</translation>
-    </message>
-</context>
-<context>
-    <name>CSettingDialog</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="345"/>
-        <source>Sunday</source>
-        <translation>Sunday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="346"/>
-        <source>Monday</source>
-        <translation>Monday</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="347"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="366"/>
-        <source>Use System Setting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="364"/>
-        <source>24-hour clock</source>
-        <translation>24-hour clock</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="365"/>
-        <source>12-hour clock</source>
-        <translation>12-hour clock</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="389"/>
-        <source>import ICS file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="403"/>
-        <source>Manual</source>
-        <translation>Manual</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="404"/>
-        <source>15 mins</source>
-        <translation>15 mins</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="405"/>
-        <source>30 mins</source>
-        <translation>30 mins</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="406"/>
-        <source>1 hour</source>
-        <translation>1 hour</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="407"/>
-        <source>24 hours</source>
-        <translation>24 hours</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="418"/>
-        <source>Sync Now</source>
-        <translation>Sync Now</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="585"/>
-        <source>Last sync</source>
-        <translation>Last sync</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="779"/>
-        <source>Please go to the &lt;a href='/'&gt;Control Center&lt;/a&gt; to change system settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CTimeEdit</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="71"/>
-        <source>(%1 mins)</source>
-        <translation>(%1 mins)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="73"/>
-        <source>(%1 hour)</source>
-        <translation>(%1 hour)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="75"/>
-        <source>(%1 hours)</source>
-        <translation>(%1 hours)</translation>
-    </message>
-</context>
-<context>
-    <name>CTitleWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="30"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="42"/>
-        <source>M</source>
-        <translation>M</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="50"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="58"/>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="92"/>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="93"/>
-        <source>Search events and festivals</source>
-        <translation>Search events and festivals</translation>
-    </message>
-</context>
-<context>
-    <name>CWeekWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="90"/>
-        <source>Week</source>
-        <translation>Week</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="280"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-</context>
-<context>
-    <name>CYearScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="268"/>
-        <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="271"/>
-        <source>All Day</source>
-        <translation>All Day</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="288"/>
-        <source>No event</source>
-        <translation>No event</translation>
-    </message>
-</context>
-<context>
-    <name>CYearWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="615"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-</context>
-<context>
-    <name>CalendarWindow</name>
-    <message>
-        <location filename="../calendar-client/src/main.cpp" line="66"/>
-        <source>Calendar</source>
-        <translation>Calendar</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/main.cpp" line="69"/>
-        <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
-        <translation>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </translation>
-    </message>
-</context>
-<context>
-    <name>Calendarmainwindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="89"/>
-        <source>Calendar</source>
-        <translation>Calendar</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="372"/>
-        <source>Manage</source>
-        <translation>Manage</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="379"/>
-        <source>Privacy Policy</source>
-        <translation>Privacy Policy</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="962"/>
-        <source>Syncing...</source>
-        <translation>Syncing...</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="973"/>
-        <source>Sync successful</source>
-        <translation>Sync successful</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="982"/>
-        <source>Sync failed, please try later</source>
-        <translation>Sync failed, please try later</translation>
-    </message>
-</context>
-<context>
-    <name>CenterWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="174"/>
-        <source>All Day</source>
-        <translation>All Day</translation>
-    </message>
-</context>
-<context>
-    <name>DAccountDataBase</name>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1155"/>
-        <source>Work</source>
-        <translation>Work</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1157"/>
-        <source>Life</source>
-        <translation>Life</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1159"/>
-        <source>Other</source>
-        <translation>Other</translation>
-    </message>
-</context>
-<context>
-    <name>DAlarmManager</name>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="187"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="196"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="201"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="212"/>
-        <source>Close</source>
-        <comment>button</comment>
-        <translation>Close</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="191"/>
-        <source>One day before start</source>
-        <translation>One day before start</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="197"/>
-        <source>Remind me tomorrow</source>
-        <translation>Remind me tomorrow</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="202"/>
-        <source>Remind me later</source>
-        <translation>Remind me later</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="204"/>
-        <source>15 mins later</source>
-        <translation>15 mins later</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="205"/>
-        <source>1 hour later</source>
-        <translation>1 hour later</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="206"/>
-        <source>4 hours later</source>
-        <translation>4 hours later</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="207"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="300"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="313"/>
-        <source>Tomorrow</source>
-        <translation>Tomorrow</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="215"/>
-        <source>Schedule Reminder</source>
-        <translation>Schedule Reminder</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="258"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="270"/>
-        <source>%1 to %2</source>
-        <translation>%1 to %2</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="296"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="309"/>
-        <source>Today</source>
-        <translation>Today</translation>
-    </message>
-</context>
-<context>
-    <name>DragInfoGraphicsView</name>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="48"/>
-        <source>Edit</source>
-        <translation>Edit</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="49"/>
-        <source>Delete</source>
-        <translation>Delete</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="50"/>
-        <source>New event</source>
-        <translation>New event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="759"/>
-        <source>New Event</source>
-        <translation>New Event</translation>
-    </message>
-</context>
-<context>
-    <name>JobTypeListView</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="144"/>
-        <source>export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="219"/>
-        <source>import ICS file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="450"/>
-        <source>You are deleting an event type.</source>
-        <translation>You are deleting an event type.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="451"/>
-        <source>All events under this type will be deleted and cannot be recovered.</source>
-        <translation>All events under this type will be deleted and cannot be recovered.</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="452"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="453"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>Delete</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="96"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="127"/>
-        <source>Manage calendar</source>
-        <translation>Manage calendar</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="112"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="131"/>
-        <source>Event types</source>
-        <translation>Event types</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="38"/>
-        <source>Account settings</source>
-        <translation>Account settings</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="42"/>
-        <source>Account</source>
-        <translation>Account</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="53"/>
-        <source>Select items to be synced</source>
-        <translation>Select items to be synced</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="56"/>
-        <source>Events</source>
-        <translation>Events</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="63"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="146"/>
-        <source>General settings</source>
-        <translation>General settings</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="74"/>
-        <source>Sync interval</source>
-        <translation>Sync interval</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="104"/>
-        <source>Calendar account</source>
-        <translation>Calendar account</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="150"/>
-        <source>General</source>
-        <translation>General</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="152"/>
-        <source>First day of week</source>
-        <translation>First day of week</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="153"/>
-        <source>Time</source>
-        <translation>Time</translation>
-    </message>
-</context>
-<context>
-    <name>Return</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="611"/>
-        <source>Today</source>
-        <comment>Return</comment>
-        <translation>Today</translation>
-    </message>
-</context>
-<context>
-    <name>Return Today</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="339"/>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="95"/>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="277"/>
-        <source>Today</source>
-        <comment>Return Today</comment>
-        <translation>Today</translation>
-    </message>
-</context>
-<context>
-    <name>ScheduleTypeEditDlg</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22"/>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="48"/>
-        <source>New event type</source>
-        <translation>New event type</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="32"/>
-        <source>Edit event type</source>
-        <translation>Edit event type</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="43"/>
-        <source>Import ICS file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="151"/>
-        <source>Name:</source>
-        <translation>Name:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="152"/>
-        <source>Color:</source>
-        <translation>Color:</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="156"/>
-        <source>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt; File:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="167"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="168"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>Save</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="219"/>
-        <source>The name can not only contain whitespaces</source>
-        <translation>The name can not only contain whitespaces</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="256"/>
-        <source>Enter a name please</source>
-        <translation>Enter a name please</translation>
-    </message>
-</context>
-<context>
-    <name>Shortcut</name>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="16"/>
-        <source>Help</source>
-        <translation>Help</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="17"/>
-        <source>Delete event</source>
-        <translation>Delete event</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="20"/>
-        <source>Copy</source>
-        <translation>Copy</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="21"/>
-        <source>Cut</source>
-        <translation>Cut</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="22"/>
-        <source>Paste</source>
-        <translation>Paste</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="25"/>
-        <source>Delete</source>
-        <translation>Delete</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="26"/>
-        <source>Select all</source>
-        <translation>Select all</translation>
-    </message>
-</context>
-<context>
-    <name>SidebarCalendarWidget</name>
-    <message>
-        <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
-        <source>M</source>
-        <translation>M</translation>
-    </message>
-</context>
-<context>
-    <name>TimeJumpDialog</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/timejumpdialog.cpp" line="29"/>
-        <source>Go</source>
-        <comment>button</comment>
-        <translation>Go</translation>
-    </message>
-</context>
-<context>
-    <name>UserloginWidget</name>
-    <message>
-        <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="48"/>
-        <source>Sign In</source>
-        <comment>button</comment>
-        <translation>Sign In</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="49"/>
-        <source>Sign Out</source>
-        <comment>button</comment>
-        <translation>Sign Out</translation>
-    </message>
-</context>
-<context>
-    <name>YearFrame</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="928"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-</context>
-<context>
-    <name>today</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="188"/>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="337"/>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="93"/>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="230"/>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="57"/>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="275"/>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="261"/>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="609"/>
-        <source>Today</source>
-        <comment>Today</comment>
-        <translation>Today</translation>
-    </message>
-</context>
+    <context>
+        <name>AccountItem</name>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="50" />
+            <source>Sync successful</source>
+            <translation>Sync successful</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="54" />
+            <source>Network error</source>
+            <translation>Network error</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="58" />
+            <source>Server exception</source>
+            <translation>Server exception</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="62" />
+            <source>Storage full</source>
+            <translation>Storage full</translation>
+        </message>
+    </context>
+    <context>
+        <name>AccountManager</name>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="180" />
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="491" />
+            <source>Local account</source>
+            <translation>Local account</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="180" />
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="494" />
+            <source>Event types</source>
+            <translation>Event types</translation>
+        </message>
+    </context>
+    <context>
+        <name>CColorPickerWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="83" />
+            <source>Color</source>
+            <translation>Color</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="96" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>Cancel</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="98" />
+            <source>Save</source>
+            <comment>button</comment>
+            <translation>Save</translation>
+        </message>
+    </context>
+    <context>
+        <name>CDayMonthView</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35" />
+            <source>Monday</source>
+            <translation>Monday</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36" />
+            <source>Tuesday</source>
+            <translation>Tuesday</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37" />
+            <source>Wednesday</source>
+            <translation>Wednesday</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38" />
+            <source>Thursday</source>
+            <translation>Thursday</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39" />
+            <source>Friday</source>
+            <translation>Friday</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="40" />
+            <source>Saturday</source>
+            <translation>Saturday</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="41" />
+            <source>Sunday</source>
+            <translation>Sunday</translation>
+        </message>
+    </context>
+    <context>
+        <name>CDayWindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="128" />
+            <source>Y</source>
+            <translation>Y</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="129" />
+            <source>M</source>
+            <translation>M</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="130" />
+            <source>D</source>
+            <translation>D</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="196" />
+            <source>Lunar</source>
+            <translation>Lunar</translation>
+        </message>
+    </context>
+    <context>
+        <name>CGraphicsView</name>
+        <message>
+            <location filename="../src/calendar-client/src/view/graphicsview.cpp" line="686" />
+            <source>New Event</source>
+            <translation>New Event</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthScheduleNumItem</name>
+        <message>
+            <location filename="../src/calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="88" />
+            <source>%1 more</source>
+            <translation>%1 more</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthView</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthview.cpp" line="52" />
+            <source>New event</source>
+            <translation>New event</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthview.cpp" line="240" />
+            <source>New Event</source>
+            <translation>New Event</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthWindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="103" />
+            <source>Y</source>
+            <translation>Y</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMyScheduleView</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="193" />
+            <source>Calendar Source</source>
+            <translation>Calendar Source</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="363" />
+            <source>My Event</source>
+            <translation>My Event</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="424" />
+            <source>OK</source>
+            <comment>button</comment>
+            <translation>OK</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="429" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>Delete</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="430" />
+            <source>Edit</source>
+            <comment>button</comment>
+            <translation>Edit</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="118" />
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="177" />
+            <source>Local calendar</source>
+            <translation>Local calendar</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="120" />
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="179" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="131" />
+            <source>Source: %1</source>
+            <translation>Source: %1</translation>
+        </message>
+    </context>
+    <context>
+        <name>CPushButton</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/cpushbutton.cpp" line="19" />
+            <source>New event type</source>
+            <translation>New event type</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleDlg</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="48" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="700" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1014" />
+            <source>New Event</source>
+            <translation>New Event</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="62" />
+            <source>Edit Event</source>
+            <translation>Edit Event</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="298" />
+            <source>End time must be greater than start time</source>
+            <translation>End time must be greater than start time</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="299" />
+            <source>OK</source>
+            <comment>button</comment>
+            <translation>OK</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="559" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="596" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1226" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1261" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1591" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1596" />
+            <source>Never</source>
+            <translation>Never</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="560" />
+            <source>At time of event</source>
+            <translation>At time of event</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="561" />
+            <source>15 minutes before</source>
+            <translation>15 minutes before</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="562" />
+            <source>30 minutes before</source>
+            <translation>30 minutes before</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="563" />
+            <source>1 hour before</source>
+            <translation>1 hour before</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="564" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="598" />
+            <source>1 day before</source>
+            <translation>1 day before</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="565" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="599" />
+            <source>2 days before</source>
+            <translation>2 days before</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="566" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="600" />
+            <source>1 week before</source>
+            <translation>1 week before</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="597" />
+            <source>On start day (9:00 AM)</source>
+            <translation>On start day (9:00 AM)</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="652" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="883" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1282" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1283" />
+            <source>time(s)</source>
+            <translation>time(s)</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="670" />
+            <source>Enter a name please</source>
+            <translation>Enter a name please</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="779" />
+            <source>The name can not only contain whitespaces</source>
+            <translation>The name can not only contain whitespaces</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="841" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="964" />
+            <source>Type:</source>
+            <translation>Type:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="846" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="999" />
+            <source>Description:</source>
+            <translation>Description:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="851" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1036" />
+            <source>All Day:</source>
+            <translation>All Day:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="856" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1102" />
+            <source>Starts:</source>
+            <translation>Starts:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="861" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1143" />
+            <source>Ends:</source>
+            <translation>Ends:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="866" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1183" />
+            <source>Remind Me:</source>
+            <translation>Remind Me:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="871" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1215" />
+            <source>Repeat:</source>
+            <translation>Repeat:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="876" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1249" />
+            <source>End Repeat:</source>
+            <translation>End Repeat:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="934" />
+            <source>Calendar account:</source>
+            <translation>Calendar account:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="935" />
+            <source>Calendar account</source>
+            <translation>Calendar account</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="961" />
+            <source>Type</source>
+            <translation>Type</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1003" />
+            <source>Description</source>
+            <translation>Description</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1033" />
+            <source>All Day</source>
+            <translation>All Day</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1057" />
+            <source>Time:</source>
+            <translation>Time:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1058" />
+            <source>Time</source>
+            <translation>Time</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1065" />
+            <source>Solar</source>
+            <translation>Solar</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1066" />
+            <source>Lunar</source>
+            <translation>Lunar</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1099" />
+            <source>Starts</source>
+            <translation>Starts</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1140" />
+            <source>Ends</source>
+            <translation>Ends</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1185" />
+            <source>Remind Me</source>
+            <translation>Remind Me</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1212" />
+            <source>Repeat</source>
+            <translation>Repeat</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1227" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1597" />
+            <source>Daily</source>
+            <translation>Daily</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1228" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1598" />
+            <source>Weekdays</source>
+            <translation>Weekdays</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1229" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1599" />
+            <source>Weekly</source>
+            <translation>Weekly</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1230" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1592" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1600" />
+            <source>Monthly</source>
+            <translation>Monthly</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1231" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1593" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1601" />
+            <source>Yearly</source>
+            <translation>Yearly</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1251" />
+            <source>End Repeat</source>
+            <translation>End Repeat</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1262" />
+            <source>After</source>
+            <translation>After</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1263" />
+            <source>On</source>
+            <translation>On</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1333" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>Cancel</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1334" />
+            <source>Save</source>
+            <comment>button</comment>
+            <translation>Save</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1407" />
+            <source>Local calendar</source>
+            <translation>Local calendar</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1409" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleOperation</name>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74" />
+            <source>All occurrences of a repeating event must have the same all-day status.</source>
+            <translation>All occurrences of a repeating event must have the same all-day status.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="95" />
+            <source>Do you want to change all occurrences?</source>
+            <translation>Do you want to change all occurrences?</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="96" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="129" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="151" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="174" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="259" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="292" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>Cancel</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="97" />
+            <source>Change All</source>
+            <translation>Change All</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94" />
+            <source>You are changing the repeating rule of this event.</source>
+            <translation>You are changing the repeating rule of this event.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="149" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="172" />
+            <source>You are deleting an event.</source>
+            <translation>You are deleting an event.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128" />
+            <source>Are you sure you want to delete this event?</source>
+            <translation>Are you sure you want to delete this event?</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>Delete</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150" />
+            <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
+            <translation>Do you want to delete all occurrences of this event, or only the selected occurrence?</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152" />
+            <source>Delete All</source>
+            <translation>Delete All</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="176" />
+            <source>Delete Only This Event</source>
+            <translation>Delete Only This Event</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173" />
+            <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
+            <translation>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175" />
+            <source>Delete All Future Events</source>
+            <translation>Delete All Future Events</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="288" />
+            <source>You are changing a repeating event.</source>
+            <translation>You are changing a repeating event.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257" />
+            <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
+            <translation>Do you want to change only this occurrence of the event, or all occurrences?</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260" />
+            <source>All</source>
+            <translation>All</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="294" />
+            <source>Only This Event</source>
+            <translation>Only This Event</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290" />
+            <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
+            <translation>Do you want to change only this occurrence of the event, or this and all future occurrences?</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293" />
+            <source>All Future Events</source>
+            <translation>All Future Events</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416" />
+            <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
+            <translation>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417" />
+            <source>OK</source>
+            <comment>button</comment>
+            <translation>OK</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchDateItem</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
+            <source>Y</source>
+            <translation>Y</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
+            <source>M</source>
+            <translation>M</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
+            <source>D</source>
+            <translation>D</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchItem</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="44" />
+            <source>Edit</source>
+            <translation>Edit</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="45" />
+            <source>Delete</source>
+            <translation>Delete</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="287" />
+            <source>All Day</source>
+            <translation>All Day</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchView</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="698" />
+            <source>No search results</source>
+            <translation>No search results</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleView</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleview.cpp" line="344" />
+            <source>ALL DAY</source>
+            <translation>ALL DAY</translation>
+        </message>
+    </context>
+    <context>
+        <name>CSettingDialog</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="455" />
+            <source>Sunday</source>
+            <translation>Sunday</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="456" />
+            <source>Monday</source>
+            <translation>Monday</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="457" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="476" />
+            <source>Use System Setting</source>
+            <translation>Use System Setting</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="474" />
+            <source>24-hour clock</source>
+            <translation>24-hour clock</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="475" />
+            <source>12-hour clock</source>
+            <translation>12-hour clock</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="214" />
+            <source>More</source>
+            <translation>More</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="246" />
+            <source>Third-party accounts</source>
+            <translation>Third-party accounts</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="255" />
+            <source>Add</source>
+            <translation>Add</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="304" />
+            <source>Sync items</source>
+            <translation>Sync items</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="305" />
+            <source>Sync interval</source>
+            <translation>Sync interval</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="497" />
+            <source>Add schedule</source>
+            <translation>Add schedule</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="498" />
+            <source>Import ICS file</source>
+            <translation>Import ICS file</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="499" />
+            <source>Import events from an ICS file</source>
+            <translation>Import events from an ICS file</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="514" />
+            <source>Manual</source>
+            <translation>Manual</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="515" />
+            <source>15 mins</source>
+            <translation>15 mins</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="516" />
+            <source>30 mins</source>
+            <translation>30 mins</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="517" />
+            <source>1 hour</source>
+            <translation>1 hour</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="518" />
+            <source>24 hours</source>
+            <translation>24 hours</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="538" />
+            <source>Sync Now</source>
+            <translation>Sync Now</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="681" />
+            <source>Remove Calendar Account</source>
+            <translation>Remove Calendar Account</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="689" />
+            <source>Are you sure you want to remove the account "%1"?</source>
+            <translation>Are you sure you want to remove the account "%1"?</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="693" />
+            <source>Also remove synced events from this calendar</source>
+            <translation>Also remove synced events from this calendar</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="698" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>Cancel</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="699" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>Delete</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="818" />
+            <source>Last sync time</source>
+            <translation>Last sync time</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="819" />
+            <source>Last sync time (%1)</source>
+            <translation>Last sync time (%1)</translation>
+        </message>
+        <message>
+            <source>Last sync: %1</source>
+            <translation type="vanished">Last sync: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="908" />
+            <source>Local account</source>
+            <translation>Local account</translation>
+        </message>
+        <message>
+            <source>Last sync</source>
+            <translation type="vanished">Last sync</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="1049" />
+            <source>Please go to the &lt;a href='/'&gt;Control Center&lt;/a&gt; to change system settings</source>
+            <translation>Please go to the &lt;a href='/'&gt;Control Center&lt;/a&gt; to change system settings</translation>
+        </message>
+    </context>
+    <context>
+        <name>CTimeEdit</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="79" />
+            <source>(%1 mins)</source>
+            <translation>(%1 mins)</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="81" />
+            <source>(%1 hour)</source>
+            <translation>(%1 hour)</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="83" />
+            <source>(%1 hours)</source>
+            <translation>(%1 hours)</translation>
+        </message>
+    </context>
+    <context>
+        <name>CTitleWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="32" />
+            <source>Y</source>
+            <translation>Y</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="44" />
+            <source>M</source>
+            <translation>M</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="52" />
+            <source>W</source>
+            <translation>W</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="60" />
+            <source>D</source>
+            <translation>D</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="94" />
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="95" />
+            <source>Search events and festivals</source>
+            <translation>Search events and festivals</translation>
+        </message>
+    </context>
+    <context>
+        <name>CWeekWindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="92" />
+            <source>Week</source>
+            <translation>Week</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="286" />
+            <source>Y</source>
+            <translation>Y</translation>
+        </message>
+    </context>
+    <context>
+        <name>CYearScheduleView</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="314" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="317" />
+            <source>All Day</source>
+            <translation>All Day</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="335" />
+            <source>No event</source>
+            <translation>No event</translation>
+        </message>
+    </context>
+    <context>
+        <name>CYearWindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="669" />
+            <source>Y</source>
+            <translation>Y</translation>
+        </message>
+    </context>
+    <context>
+        <name>CalDavAccountDialog</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="65" />
+            <source>:</source>
+            <translation>:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="75" />
+            <source>Add Calendar Account</source>
+            <translation>Add Calendar Account</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="98" />
+            <source>Select account type</source>
+            <translation>Select account type</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="109" />
+            <source>Automatically filled after selecting account type</source>
+            <translation>Automatically filled after selecting account type</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="110" />
+            <source>Enter username or email</source>
+            <translation>Enter username or email</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="111" />
+            <source>Enter password</source>
+            <translation>Enter password</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="118" />
+            <source>Account Type</source>
+            <translation>Account Type</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="119" />
+            <source>Server Address</source>
+            <translation>Server Address</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="120" />
+            <source>Username</source>
+            <translation>Username</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="121" />
+            <source>Password</source>
+            <translation>Password</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="132" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>Cancel</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="133" />
+            <source>Sign In</source>
+            <comment>button</comment>
+            <translation>Sign In</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="224" />
+            <source>Edit Account</source>
+            <translation>Edit Account</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="225" />
+            <source>Save</source>
+            <comment>button</comment>
+            <translation>Save</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="232" />
+            <source>Leave empty to keep the current password</source>
+            <translation>Leave empty to keep the current password</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="510" />
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="558" />
+            <source>Please enter a valid server address.</source>
+            <translation>Please enter a valid server address.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="561" />
+            <source>Please enter the correct username.</source>
+            <translation>Please enter the correct username.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="562" />
+            <source>Please enter the correct password.</source>
+            <translation>Please enter the correct password.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="571" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>Incorrect username or password. Please try again.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="573" />
+            <source>This server does not support CalDAV.</source>
+            <translation>This server does not support CalDAV.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="575" />
+            <source>The server rejected your login request. Please check your account permissions.</source>
+            <translation>The server rejected your login request. Please check your account permissions.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="577" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>Unable to parse the data returned by the server. Please verify the server address or try again later.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="579" />
+            <source>The server certificate is invalid.</source>
+            <translation>The server certificate is invalid.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="583" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>Unable to connect to the server. Please check your network connection and server address.</translation>
+        </message>
+    </context>
+    <context>
+        <name>CalDavAccountListWidget</name>
+        <message>
+            <source>Last sync: %1</source>
+            <translation type="vanished">Last sync: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="69" />
+            <source>Last sync time</source>
+            <translation>Last sync time</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="74" />
+            <source>Last sync time (%1)</source>
+            <translation>Last sync time (%1)</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="151" />
+            <source>No third-party accounts added</source>
+            <translation>No third-party accounts added</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="157" />
+            <source>Add</source>
+            <translation>Add</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="210" />
+            <source>Pending synchronization</source>
+            <translation>Pending synchronization</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="210" />
+            <source>Delete</source>
+            <translation>Delete</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="242" />
+            <source>Sync conflict</source>
+            <translation>Sync conflict</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="243" />
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="304" />
+            <source>A synchronization conflict was detected. The server version will replace the local changes.</source>
+            <translation>A synchronization conflict was detected. The server version will replace the local changes.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="252" />
+            <source>Sync Failed: %1</source>
+            <translation>Sync Failed: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="255" />
+            <source>Deleting...</source>
+            <translation>Deleting...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="255" />
+            <source>Syncing...</source>
+            <translation>Syncing...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="267" />
+            <source>Sync Now</source>
+            <translation>Sync Now</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="302" />
+            <source>Calendar synchronization conflict</source>
+            <translation>Calendar synchronization conflict</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="308" />
+            <source>Use server version</source>
+            <translation>Use server version</translation>
+        </message>
+    </context>
+    <context>
+        <name>CalendarWindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/main.cpp" line="69" />
+            <source>Calendar</source>
+            <translation>Calendar</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/main.cpp" line="72" />
+            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
+            <translation>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </translation>
+        </message>
+    </context>
+    <context>
+        <name>Calendarmainwindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="90" />
+            <source>Calendar</source>
+            <translation>Calendar</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="433" />
+            <source>Manage</source>
+            <translation>Manage</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="440" />
+            <source>Privacy Policy</source>
+            <translation>Privacy Policy</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1209" />
+            <source>Syncing...</source>
+            <translation>Syncing...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1220" />
+            <source>Sync successful</source>
+            <translation>Sync successful</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1229" />
+            <source>Sync failed, please try later</source>
+            <translation>Sync failed, please try later</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1266" />
+            <source>%1 does not allow creating events. Please check account permissions.</source>
+            <translation>%1 does not allow creating events. Please check account permissions.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1269" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>Unable to connect to the server. Please check your network connection and server address.</translation>
+        </message>
+    </context>
+    <context>
+        <name>CenterWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="239" />
+            <source>All Day</source>
+            <translation>All Day</translation>
+        </message>
+    </context>
+    <context>
+        <name>DAccountDataBase</name>
+        <message>
+            <source>Work</source>
+            <translation type="vanished">Work</translation>
+        </message>
+        <message>
+            <source>Life</source>
+            <translation type="vanished">Life</translation>
+        </message>
+        <message>
+            <source>Other</source>
+            <translation type="vanished">Other</translation>
+        </message>
+    </context>
+    <context>
+        <name>DAlarmManager</name>
+        <message>
+            <source>Close</source>
+            <comment>button</comment>
+            <translation type="vanished">Close</translation>
+        </message>
+        <message>
+            <source>One day before start</source>
+            <translation type="vanished">One day before start</translation>
+        </message>
+        <message>
+            <source>Remind me tomorrow</source>
+            <translation type="vanished">Remind me tomorrow</translation>
+        </message>
+        <message>
+            <source>Remind me later</source>
+            <translation type="vanished">Remind me later</translation>
+        </message>
+        <message>
+            <source>15 mins later</source>
+            <translation type="vanished">15 mins later</translation>
+        </message>
+        <message>
+            <source>1 hour later</source>
+            <translation type="vanished">1 hour later</translation>
+        </message>
+        <message>
+            <source>4 hours later</source>
+            <translation type="vanished">4 hours later</translation>
+        </message>
+        <message>
+            <source>Tomorrow</source>
+            <translation type="vanished">Tomorrow</translation>
+        </message>
+        <message>
+            <source>Schedule Reminder</source>
+            <translation type="vanished">Schedule Reminder</translation>
+        </message>
+        <message>
+            <source>%1 to %2</source>
+            <translation type="vanished">%1 to %2</translation>
+        </message>
+        <message>
+            <source>Today</source>
+            <translation type="vanished">Today</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavProviderProfile</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="37" />
+            <source>DingTalk</source>
+            <translation>DingTalk</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="39" />
+            <source>WeCom</source>
+            <translation>WeCom</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="41" />
+            <source>Tencent Meeting</source>
+            <translation>Tencent Meeting</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="43" />
+            <source>QQ Mail</source>
+            <translation>QQ Mail</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="45" />
+            <source>Feishu</source>
+            <translation>Feishu</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="48" />
+            <source>Other CalDAV</source>
+            <translation>Other CalDAV</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavSyncStatus</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="61" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>Unable to parse the data returned by the server. Please verify the server address or try again later.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server certificate is invalid.</source>
+            <translation>The server certificate is invalid.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="54" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>Incorrect username or password. Please try again.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="57" />
+            <source>This server does not support CalDAV.</source>
+            <translation>This server does not support CalDAV.</translation>
+        </message>
+        <message>
+            <source>The server rejected your login request. Please check your account permissions.</source>
+            <translation type="vanished">The server rejected your login request. Please check your account permissions.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="65" />
+            <source>The server denied access.</source>
+            <translation>The server denied access.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="68" />
+            <source>The server request timed out.</source>
+            <translation>The server request timed out.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="72" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>Unable to connect to the server. Please check your network connection and server address.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76" />
+            <source>Synchronization failed.</source>
+            <translation>Synchronization failed.</translation>
+        </message>
+    </context>
+    <context>
+        <name>DragInfoGraphicsView</name>
+        <message>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="49" />
+            <source>Edit</source>
+            <translation>Edit</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="50" />
+            <source>Delete</source>
+            <translation>Delete</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="51" />
+            <source>New event</source>
+            <translation>New event</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="844" />
+            <source>New Event</source>
+            <translation>New Event</translation>
+        </message>
+    </context>
+    <context>
+        <name>JobTypeListView</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="213" />
+            <source>Edit</source>
+            <translation>Edit</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="216" />
+            <source>Delete</source>
+            <translation>Delete</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="219" />
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="233" />
+            <source>Export</source>
+            <translation>Export</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="308" />
+            <source>import ICS file</source>
+            <translation>import ICS file</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="308" />
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="417" />
+            <source>ICS files (*.ics)</source>
+            <translation>ICS files (*.ics)</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="416" />
+            <source>Export ICS file</source>
+            <translation>Export ICS file</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="565" />
+            <source>You are deleting an event type.</source>
+            <translation>You are deleting an event type.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="566" />
+            <source>All events under this type will be deleted and cannot be recovered.</source>
+            <translation>All events under this type will be deleted and cannot be recovered.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="567" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>Cancel</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="568" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>Delete</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="67" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="98" />
+            <source>Manage calendar</source>
+            <translation>Manage calendar</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="83" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="102" />
+            <source>Event types</source>
+            <translation>Event types</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="50" />
+            <source>Account settings</source>
+            <translation>Account settings</translation>
+        </message>
+        <message>
+            <source>Account</source>
+            <translation type="vanished">Account</translation>
+        </message>
+        <message>
+            <source>Select items to be synced</source>
+            <translation type="vanished">Select items to be synced</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="559" />
+            <source>Events</source>
+            <translation>Events</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="117" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="561" />
+            <source>General settings</source>
+            <translation>General settings</translation>
+        </message>
+        <message>
+            <source>Sync interval</source>
+            <translation type="vanished">Sync interval</translation>
+        </message>
+        <message>
+            <source>Calendar account</source>
+            <translation type="vanished">Calendar account</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="54" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="59" />
+            <source>Third-party accounts</source>
+            <translation>Third-party accounts</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="75" />
+            <source>Associated account</source>
+            <translation>Associated account</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="121" />
+            <source>General</source>
+            <translation>General</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="123" />
+            <source>First day of week</source>
+            <translation>First day of week</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="124" />
+            <source>Time</source>
+            <translation>Time</translation>
+        </message>
+    </context>
+    <context>
+        <name>Return</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="665" />
+            <source>Today</source>
+            <comment>Return</comment>
+            <translation>Today</translation>
+        </message>
+    </context>
+    <context>
+        <name>Return Today</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="353" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="100" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="283" />
+            <source>Today</source>
+            <comment>Return Today</comment>
+            <translation>Today</translation>
+        </message>
+    </context>
+    <context>
+        <name>ScheduleTypeEditDlg</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22" />
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="50" />
+            <source>New event type</source>
+            <translation>New event type</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="33" />
+            <source>Edit event type</source>
+            <translation>Edit event type</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="45" />
+            <source>Import ICS file</source>
+            <translation>Import ICS file</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="158" />
+            <source>Name:</source>
+            <translation>Name:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="159" />
+            <source>Color:</source>
+            <translation>Color:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="164" />
+            <source>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt; File:</source>
+            <translation>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt; File:</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="175" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>Cancel</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="176" />
+            <source>Save</source>
+            <comment>button</comment>
+            <translation>Save</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="232" />
+            <source>The name can not only contain whitespaces</source>
+            <translation>The name can not only contain whitespaces</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="275" />
+            <source>Enter a name please</source>
+            <translation>Enter a name please</translation>
+        </message>
+    </context>
+    <context>
+        <name>Shortcut</name>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="18" />
+            <source>Help</source>
+            <translation>Help</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="19" />
+            <source>Delete event</source>
+            <translation>Delete event</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="22" />
+            <source>Copy</source>
+            <translation>Copy</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="23" />
+            <source>Cut</source>
+            <translation>Cut</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="24" />
+            <source>Paste</source>
+            <translation>Paste</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="27" />
+            <source>Delete</source>
+            <translation>Delete</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="28" />
+            <source>Select all</source>
+            <translation>Select all</translation>
+        </message>
+    </context>
+    <context>
+        <name>SidebarAccountItemWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="335" />
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="345" />
+            <source>Sync</source>
+            <translation>Sync</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="344" />
+            <source>Deleting...</source>
+            <translation>Deleting...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="345" />
+            <source>Syncing...</source>
+            <translation>Syncing...</translation>
+        </message>
+    </context>
+    <context>
+        <name>SidebarCalendarWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="135" />
+            <source>Y</source>
+            <translation>Y</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="135" />
+            <source>M</source>
+            <translation>M</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimeJumpDialog</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/timejumpdialog.cpp" line="32" />
+            <source>Go</source>
+            <comment>button</comment>
+            <translation>Go</translation>
+        </message>
+    </context>
+    <context>
+        <name>UserloginWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="105" />
+            <source>Sign In</source>
+            <comment>button</comment>
+            <translation>Sign In</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="106" />
+            <source>Sign Out</source>
+            <comment>button</comment>
+            <translation>Sign Out</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="203" />
+            <source>Not signed in</source>
+            <translation>Not signed in</translation>
+        </message>
+    </context>
+    <context>
+        <name>YearFrame</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="1020" />
+            <source>Y</source>
+            <translation>Y</translation>
+        </message>
+    </context>
+    <context>
+        <name>today</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="200" />
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="351" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="261" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="59" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="281" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="288" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="663" />
+            <source>Today</source>
+            <comment>Today</comment>
+            <translation>Today</translation>
+        </message>
+    </context>
 </TS>

--- a/translations/dde-calendar_zh_CN.ts
+++ b/translations/dde-calendar_zh_CN.ts
@@ -1,1230 +1,1592 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
-<context>
-    <name>AccountItem</name>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="41"/>
-        <source>Sync successful</source>
-        <translation>同步成功</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="42"/>
-        <source>Network error</source>
-        <translation>网络异常</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="43"/>
-        <source>Server exception</source>
-        <translation>服务器异常</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="44"/>
-        <source>Storage full</source>
-        <translation>存储已满</translation>
-    </message>
-</context>
-<context>
-    <name>AccountManager</name>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="227"/>
-        <source>Local account</source>
-        <translation>本地帐户</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="229"/>
-        <source>Event types</source>
-        <translation>日程类型</translation>
-    </message>
-</context>
-<context>
-    <name>CColorPickerWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="77"/>
-        <source>Color</source>
-        <translation>颜色</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="90"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="92"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>保 存</translation>
-    </message>
-</context>
-<context>
-    <name>CDayMonthView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="33"/>
-        <source>Monday</source>
-        <translation>星期一</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="34"/>
-        <source>Tuesday</source>
-        <translation>星期二</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35"/>
-        <source>Wednesday</source>
-        <translation>星期三</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36"/>
-        <source>Thursday</source>
-        <translation>星期四</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37"/>
-        <source>Friday</source>
-        <translation>星期五</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38"/>
-        <source>Saturday</source>
-        <translation>星期六</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39"/>
-        <source>Sunday</source>
-        <translation>星期日</translation>
-    </message>
-</context>
-<context>
-    <name>CDayWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="112"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="113"/>
-        <source>M</source>
-        <translation>月</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="114"/>
-        <source>D</source>
-        <translation>日</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="170"/>
-        <source>Lunar</source>
-        <translation>农历</translation>
-    </message>
-</context>
-<context>
-    <name>CGraphicsView</name>
-    <message>
-        <location filename="../calendar-client/src/view/graphicsview.cpp" line="628"/>
-        <source>New Event</source>
-        <translation>新建日程</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthScheduleNumItem</name>
-    <message>
-        <location filename="../calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="80"/>
-        <source>%1 more</source>
-        <translation>还有%1项</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="50"/>
-        <source>New event</source>
-        <translation>新建日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="230"/>
-        <source>New Event</source>
-        <translation>新建日程</translation>
-    </message>
-</context>
-<context>
-    <name>CMonthWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-</context>
-<context>
-    <name>CMyScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="284"/>
-        <source>My Event</source>
-        <translation>我的日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="326"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>确 定</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="331"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>删 除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="332"/>
-        <source>Edit</source>
-        <comment>button</comment>
-        <translation>编 辑</translation>
-    </message>
-</context>
-<context>
-    <name>CPushButton</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/cpushbutton.cpp" line="17"/>
-        <source>New event type</source>
-        <translation>新增日程类型</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleDlg</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="46"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="625"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="921"/>
-        <source>New Event</source>
-        <translation>新建日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="60"/>
-        <source>Edit Event</source>
-        <translation>编辑日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="270"/>
-        <source>End time must be greater than start time</source>
-        <translation>结束时间需晚于开始时间</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="271"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>确 定</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="506"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="535"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1133"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1168"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1422"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1426"/>
-        <source>Never</source>
-        <translation>从不</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="507"/>
-        <source>At time of event</source>
-        <translation>日程开始时</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="508"/>
-        <source>15 minutes before</source>
-        <translation>15分钟前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="509"/>
-        <source>30 minutes before</source>
-        <translation>30分钟前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="510"/>
-        <source>1 hour before</source>
-        <translation>1小时前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="511"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="537"/>
-        <source>1 day before</source>
-        <translation>1天前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="512"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="538"/>
-        <source>2 days before</source>
-        <translation>2天前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="513"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="539"/>
-        <source>1 week before</source>
-        <translation>1周前</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="536"/>
-        <source>On start day (9:00 AM)</source>
-        <translation>日程发生当天（上午9点）</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="583"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="791"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1189"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1190"/>
-        <source>time(s)</source>
-        <translation>次后</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="598"/>
-        <source>Enter a name please</source>
-        <translation>名称不能为空</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="693"/>
-        <source>The name can not only contain whitespaces</source>
-        <translation>名称不能设置为全空格，请修改</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="749"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="871"/>
-        <source>Type:</source>
-        <translation>类型：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="754"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="906"/>
-        <source>Description:</source>
-        <translation>内容：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="759"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="943"/>
-        <source>All Day:</source>
-        <translation>全天：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="764"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1009"/>
-        <source>Starts:</source>
-        <translation>开始时间：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="769"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1050"/>
-        <source>Ends:</source>
-        <translation>结束时间：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="774"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1090"/>
-        <source>Remind Me:</source>
-        <translation>提醒：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="779"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1122"/>
-        <source>Repeat:</source>
-        <translation>重复：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="784"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1156"/>
-        <source>End Repeat:</source>
-        <translation>结束重复：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="840"/>
-        <source>Calendar account:</source>
-        <translation>日历帐户：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="841"/>
-        <source>Calendar account</source>
-        <translation>日历帐户</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="868"/>
-        <source>Type</source>
-        <translation>类型</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="910"/>
-        <source>Description</source>
-        <translation>内容</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="940"/>
-        <source>All Day</source>
-        <translation>全天</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="964"/>
-        <source>Time:</source>
-        <translation>时间：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="965"/>
-        <source>Time</source>
-        <translation>时间</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="972"/>
-        <source>Solar</source>
-        <translation>公历</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="973"/>
-        <source>Lunar</source>
-        <translation>农历</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1006"/>
-        <source>Starts</source>
-        <translation>开始时间</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1047"/>
-        <source>Ends</source>
-        <translation>结束时间</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1092"/>
-        <source>Remind Me</source>
-        <translation>提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1119"/>
-        <source>Repeat</source>
-        <translation>重复</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1134"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1427"/>
-        <source>Daily</source>
-        <translation>每天</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1135"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1428"/>
-        <source>Weekdays</source>
-        <translation>工作日</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1136"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1429"/>
-        <source>Weekly</source>
-        <translation>每周</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1137"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1423"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1430"/>
-        <source>Monthly</source>
-        <translation>每月</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1138"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1424"/>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1431"/>
-        <source>Yearly</source>
-        <translation>每年</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1158"/>
-        <source>End Repeat</source>
-        <translation>结束重复</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1169"/>
-        <source>After</source>
-        <translation>于</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1170"/>
-        <source>On</source>
-        <translation>于日期</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1240"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1241"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>保 存</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleOperation</name>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74"/>
-        <source>All occurrences of a repeating event must have the same all-day status.</source>
-        <translation>重复日程的所有重复必须具有相同的全天状态。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="95"/>
-        <source>Do you want to change all occurrences?</source>
-        <translation>您要更改所有重复吗？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="96"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="129"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="151"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="174"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="259"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="292"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="97"/>
-        <source>Change All</source>
-        <translation>全部更改</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94"/>
-        <source>You are changing the repeating rule of this event.</source>
-        <translation>您正在更改日程的重复规则。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="149"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="172"/>
-        <source>You are deleting an event.</source>
-        <translation>您正在删除日程。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128"/>
-        <source>Are you sure you want to delete this event?</source>
-        <translation>您确定要删除此日程吗？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>删 除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150"/>
-        <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
-        <translation>您要删除此日程的所有重复，还是只删除所选重复？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152"/>
-        <source>Delete All</source>
-        <translation>全部删除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="176"/>
-        <source>Delete Only This Event</source>
-        <translation>仅删除此日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173"/>
-        <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
-        <translation>您要删除此日程的这个重复和所有将来重复，还是只删除所选重复？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175"/>
-        <source>Delete All Future Events</source>
-        <translation>删除所有将来日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="288"/>
-        <source>You are changing a repeating event.</source>
-        <translation>您正在更改重复日程。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257"/>
-        <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
-        <translation>您要更改此日程的仅这一个重复，还是更改它的所有重复？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260"/>
-        <source>All</source>
-        <translation>全部日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261"/>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="294"/>
-        <source>Only This Event</source>
-        <translation>仅此日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290"/>
-        <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
-        <translation>您要更改此日程的这个重复和所有将来重复，还是只更改所选重复？</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293"/>
-        <source>All Future Events</source>
-        <translation>所有将来日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416"/>
-        <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
-        <translation>您选择的是闰月，将按照农历规则提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>确 定</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchDateItem</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>M</source>
-        <translation>月</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
-        <source>D</source>
-        <translation>日</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchItem</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="42"/>
-        <source>Edit</source>
-        <translation>编辑</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="43"/>
-        <source>Delete</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="267"/>
-        <source>All Day</source>
-        <translation>全天</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleSearchView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="648"/>
-        <source>No search results</source>
-        <translation>无搜索结果</translation>
-    </message>
-</context>
-<context>
-    <name>CScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/scheduleview.cpp" line="316"/>
-        <source>ALL DAY</source>
-        <translation>全天</translation>
-    </message>
-</context>
-<context>
-    <name>CSettingDialog</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="345"/>
-        <source>Sunday</source>
-        <translation>周日</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="346"/>
-        <source>Monday</source>
-        <translation>周一</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="347"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="366"/>
-        <source>Use System Setting</source>
-        <translation>跟随系统</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="364"/>
-        <source>24-hour clock</source>
-        <translation>24小时制</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="365"/>
-        <source>12-hour clock</source>
-        <translation>12小时制</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="389"/>
-        <source>import ICS file</source>
-        <translation>导入ICS文件</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="403"/>
-        <source>Manual</source>
-        <translation>手动</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="404"/>
-        <source>15 mins</source>
-        <translation>每15分钟</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="405"/>
-        <source>30 mins</source>
-        <translation>每30分钟</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="406"/>
-        <source>1 hour</source>
-        <translation>每1小时</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="407"/>
-        <source>24 hours</source>
-        <translation>每24小时</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="418"/>
-        <source>Sync Now</source>
-        <translation>立即同步</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="585"/>
-        <source>Last sync</source>
-        <translation>最近同步时间</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="779"/>
-        <source>Please go to the &lt;a href='/'&gt;Control Center&lt;/a&gt; to change system settings</source>
-        <translation>请到&lt;a href='/'&gt;控制中心&lt;/a&gt;更改系统设置</translation>
-    </message>
-</context>
-<context>
-    <name>CTimeEdit</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="71"/>
-        <source>(%1 mins)</source>
-        <translation>(%1分钟)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="73"/>
-        <source>(%1 hour)</source>
-        <translation>(%1小时)</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="75"/>
-        <source>(%1 hours)</source>
-        <translation>(%1小时)</translation>
-    </message>
-</context>
-<context>
-    <name>CTitleWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="30"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="42"/>
-        <source>M</source>
-        <translation>月</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="50"/>
-        <source>W</source>
-        <translation>周</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="58"/>
-        <source>D</source>
-        <translation>日</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="92"/>
-        <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="93"/>
-        <source>Search events and festivals</source>
-        <translation>搜索日程/节日</translation>
-    </message>
-</context>
-<context>
-    <name>CWeekWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="90"/>
-        <source>Week</source>
-        <translation>周</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="280"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-</context>
-<context>
-    <name>CYearScheduleView</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="268"/>
-        <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="271"/>
-        <source>All Day</source>
-        <translation>全天</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="288"/>
-        <source>No event</source>
-        <translation>无日程</translation>
-    </message>
-</context>
-<context>
-    <name>CYearWindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="615"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-</context>
-<context>
-    <name>CalendarWindow</name>
-    <message>
-        <location filename="../calendar-client/src/main.cpp" line="66"/>
-        <source>Calendar</source>
-        <translation>日历</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/main.cpp" line="69"/>
-        <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
-        <translation>日历是一款查看日期、管理日程的小工具。</translation>
-    </message>
-</context>
-<context>
-    <name>Calendarmainwindow</name>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="89"/>
-        <source>Calendar</source>
-        <translation>日历</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="372"/>
-        <source>Manage</source>
-        <translation>管理</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="379"/>
-        <source>Privacy Policy</source>
-        <translation>隐私政策</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="962"/>
-        <source>Syncing...</source>
-        <translation>正在同步...</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="973"/>
-        <source>Sync successful</source>
-        <translation>同步成功</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="982"/>
-        <source>Sync failed, please try later</source>
-        <translation>同步失败，请稍后再试</translation>
-    </message>
-</context>
-<context>
-    <name>CenterWidget</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="174"/>
-        <source>All Day</source>
-        <translation>全天</translation>
-    </message>
-</context>
-<context>
-    <name>DAccountDataBase</name>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1155"/>
-        <source>Work</source>
-        <translation>工作</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1157"/>
-        <source>Life</source>
-        <translation>生活</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1159"/>
-        <source>Other</source>
-        <translation>其他</translation>
-    </message>
-</context>
-<context>
-    <name>DAlarmManager</name>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="187"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="196"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="201"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="212"/>
-        <source>Close</source>
-        <comment>button</comment>
-        <translation>关 闭</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="191"/>
-        <source>One day before start</source>
-        <translation>提前1天提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="197"/>
-        <source>Remind me tomorrow</source>
-        <translation>明天提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="202"/>
-        <source>Remind me later</source>
-        <translation>稍后提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="204"/>
-        <source>15 mins later</source>
-        <translation>15分钟后</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="205"/>
-        <source>1 hour later</source>
-        <translation>1小时后</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="206"/>
-        <source>4 hours later</source>
-        <translation>4小时后</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="207"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="300"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="313"/>
-        <source>Tomorrow</source>
-        <translation>明天</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="215"/>
-        <source>Schedule Reminder</source>
-        <translation>日程提醒</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="258"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="270"/>
-        <source>%1 to %2</source>
-        <translation>%1 至 %2</translation>
-    </message>
-    <message>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="296"/>
-        <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="309"/>
-        <source>Today</source>
-        <translation>今天</translation>
-    </message>
-</context>
-<context>
-    <name>DragInfoGraphicsView</name>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="48"/>
-        <source>Edit</source>
-        <translation>编辑</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="49"/>
-        <source>Delete</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="50"/>
-        <source>New event</source>
-        <translation>新建日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="759"/>
-        <source>New Event</source>
-        <translation>新建日程</translation>
-    </message>
-</context>
-<context>
-    <name>JobTypeListView</name>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="144"/>
-        <source>export</source>
-        <translation>导出</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="219"/>
-        <source>import ICS file</source>
-        <translation>导入ICS文件</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="450"/>
-        <source>You are deleting an event type.</source>
-        <translation>您正在删除日程类型。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="451"/>
-        <source>All events under this type will be deleted and cannot be recovered.</source>
-        <translation>此日程类型下的所有日程都会删除且不可恢复。</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="452"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="453"/>
-        <source>Delete</source>
-        <comment>button</comment>
-        <translation>删 除</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="96"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="127"/>
-        <source>Manage calendar</source>
-        <translation>日历管理</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="112"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="131"/>
-        <source>Event types</source>
-        <translation>日程类型</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="38"/>
-        <source>Account settings</source>
-        <translation>帐户设置</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="42"/>
-        <source>Account</source>
-        <translation>帐户</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="53"/>
-        <source>Select items to be synced</source>
-        <translation>设置您的同步项</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="56"/>
-        <source>Events</source>
-        <translation>日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="63"/>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="146"/>
-        <source>General settings</source>
-        <translation>通用设置</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="74"/>
-        <source>Sync interval</source>
-        <translation>同步频率</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="104"/>
-        <source>Calendar account</source>
-        <translation>日历帐户</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="150"/>
-        <source>General</source>
-        <translation>通用</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="152"/>
-        <source>First day of week</source>
-        <translation>每星期开始于</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="153"/>
-        <source>Time</source>
-        <translation>时间</translation>
-    </message>
-</context>
-<context>
-    <name>Return</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="611"/>
-        <source>Today</source>
-        <comment>Return</comment>
-        <translation>返回今天</translation>
-    </message>
-</context>
-<context>
-    <name>Return Today</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="339"/>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="95"/>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="277"/>
-        <source>Today</source>
-        <comment>Return Today</comment>
-        <translation>返回今天</translation>
-    </message>
-</context>
-<context>
-    <name>ScheduleTypeEditDlg</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22"/>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="48"/>
-        <source>New event type</source>
-        <translation>新增日程类型</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="32"/>
-        <source>Edit event type</source>
-        <translation>编辑日程类型</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="43"/>
-        <source>Import ICS file</source>
-        <translation>导入ICS文件</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="151"/>
-        <source>Name:</source>
-        <translation>名称：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="152"/>
-        <source>Color:</source>
-        <translation>颜色：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="156"/>
-        <source>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt; File:</source>
-        <translation>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt;文件：</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="167"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="168"/>
-        <source>Save</source>
-        <comment>button</comment>
-        <translation>保 存</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="219"/>
-        <source>The name can not only contain whitespaces</source>
-        <translation>名称不能设置为全空格，请修改</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="256"/>
-        <source>Enter a name please</source>
-        <translation>名称不能为空</translation>
-    </message>
-</context>
-<context>
-    <name>Shortcut</name>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="16"/>
-        <source>Help</source>
-        <translation>帮助</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="17"/>
-        <source>Delete event</source>
-        <translation>删除日程</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="20"/>
-        <source>Copy</source>
-        <translation>复制</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="21"/>
-        <source>Cut</source>
-        <translation>剪切</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="22"/>
-        <source>Paste</source>
-        <translation>粘贴</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="25"/>
-        <source>Delete</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/shortcut.cpp" line="26"/>
-        <source>Select all</source>
-        <translation>全选</translation>
-    </message>
-</context>
-<context>
-    <name>SidebarCalendarWidget</name>
-    <message>
-        <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
-        <source>M</source>
-        <translation>月</translation>
-    </message>
-</context>
-<context>
-    <name>TimeJumpDialog</name>
-    <message>
-        <location filename="../calendar-client/src/dialog/timejumpdialog.cpp" line="29"/>
-        <source>Go</source>
-        <comment>button</comment>
-        <translation>跳 转</translation>
-    </message>
-</context>
-<context>
-    <name>UserloginWidget</name>
-    <message>
-        <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="48"/>
-        <source>Sign In</source>
-        <comment>button</comment>
-        <translation>登 录</translation>
-    </message>
-    <message>
-        <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="49"/>
-        <source>Sign Out</source>
-        <comment>button</comment>
-        <translation>退出登录</translation>
-    </message>
-</context>
-<context>
-    <name>YearFrame</name>
-    <message>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="928"/>
-        <source>Y</source>
-        <translation>年</translation>
-    </message>
-</context>
-<context>
-    <name>today</name>
-    <message>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="188"/>
-        <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="337"/>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="93"/>
-        <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="230"/>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="57"/>
-        <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="275"/>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="261"/>
-        <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="609"/>
-        <source>Today</source>
-        <comment>Today</comment>
-        <translation>今天</translation>
-    </message>
-</context>
+    <context>
+        <name>AccountItem</name>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="50" />
+            <source>Sync successful</source>
+            <translation>同步成功</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="54" />
+            <source>Network error</source>
+            <translation>网络异常</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="58" />
+            <source>Server exception</source>
+            <translation>服务器异常</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="62" />
+            <source>Storage full</source>
+            <translation>存储已满</translation>
+        </message>
+    </context>
+    <context>
+        <name>AccountManager</name>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="180" />
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="491" />
+            <source>Local account</source>
+            <translation>本地账户</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="180" />
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="494" />
+            <source>Event types</source>
+            <translation>日程类型</translation>
+        </message>
+    </context>
+    <context>
+        <name>CColorPickerWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="83" />
+            <source>Color</source>
+            <translation>颜色</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="96" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>取 消</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="98" />
+            <source>Save</source>
+            <comment>button</comment>
+            <translation>保 存</translation>
+        </message>
+    </context>
+    <context>
+        <name>CDayMonthView</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35" />
+            <source>Monday</source>
+            <translation>星期一</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36" />
+            <source>Tuesday</source>
+            <translation>星期二</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37" />
+            <source>Wednesday</source>
+            <translation>星期三</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38" />
+            <source>Thursday</source>
+            <translation>星期四</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39" />
+            <source>Friday</source>
+            <translation>星期五</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="40" />
+            <source>Saturday</source>
+            <translation>星期六</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="41" />
+            <source>Sunday</source>
+            <translation>星期日</translation>
+        </message>
+    </context>
+    <context>
+        <name>CDayWindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="128" />
+            <source>Y</source>
+            <translation>年</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="129" />
+            <source>M</source>
+            <translation>月</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="130" />
+            <source>D</source>
+            <translation>日</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="196" />
+            <source>Lunar</source>
+            <translation>农历</translation>
+        </message>
+    </context>
+    <context>
+        <name>CGraphicsView</name>
+        <message>
+            <location filename="../src/calendar-client/src/view/graphicsview.cpp" line="686" />
+            <source>New Event</source>
+            <translation>新建日程</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthScheduleNumItem</name>
+        <message>
+            <location filename="../src/calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="88" />
+            <source>%1 more</source>
+            <translation>还有%1项</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthView</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthview.cpp" line="52" />
+            <source>New event</source>
+            <translation>新建日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthview.cpp" line="240" />
+            <source>New Event</source>
+            <translation>新建日程</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMonthWindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="103" />
+            <source>Y</source>
+            <translation>年</translation>
+        </message>
+    </context>
+    <context>
+        <name>CMyScheduleView</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="363" />
+            <source>My Event</source>
+            <translation>我的日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="424" />
+            <source>OK</source>
+            <comment>button</comment>
+            <translation>确 定</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="429" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>删 除</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="430" />
+            <source>Edit</source>
+            <comment>button</comment>
+            <translation>编 辑</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="131" />
+            <source>Source: %1</source>
+            <translation>来源: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="118" />
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="177" />
+            <source>Local calendar</source>
+            <translation>本地日历</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="120" />
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="179" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="193" />
+            <source>Calendar Source</source>
+            <translation>日历来源</translation>
+        </message>
+    </context>
+    <context>
+        <name>CPushButton</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/cpushbutton.cpp" line="19" />
+            <source>New event type</source>
+            <translation>新增日程类型</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleDlg</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="48" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="700" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1014" />
+            <source>New Event</source>
+            <translation>新建日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="62" />
+            <source>Edit Event</source>
+            <translation>编辑日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="298" />
+            <source>End time must be greater than start time</source>
+            <translation>结束时间需晚于开始时间</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="299" />
+            <source>OK</source>
+            <comment>button</comment>
+            <translation>确 定</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="559" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="596" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1226" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1261" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1591" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1596" />
+            <source>Never</source>
+            <translation>从不</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="560" />
+            <source>At time of event</source>
+            <translation>日程开始时</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="561" />
+            <source>15 minutes before</source>
+            <translation>15分钟前</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="562" />
+            <source>30 minutes before</source>
+            <translation>30分钟前</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="563" />
+            <source>1 hour before</source>
+            <translation>1小时前</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="564" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="598" />
+            <source>1 day before</source>
+            <translation>1天前</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="565" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="599" />
+            <source>2 days before</source>
+            <translation>2天前</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="566" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="600" />
+            <source>1 week before</source>
+            <translation>1周前</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="597" />
+            <source>On start day (9:00 AM)</source>
+            <translation>日程发生当天（上午9点）</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="652" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="883" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1282" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1283" />
+            <source>time(s)</source>
+            <translation>次后</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="670" />
+            <source>Enter a name please</source>
+            <translation>名称不能为空</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="779" />
+            <source>The name can not only contain whitespaces</source>
+            <translation>名称不能设置为全空格，请修改</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="841" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="964" />
+            <source>Type:</source>
+            <translation>类型：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="846" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="999" />
+            <source>Description:</source>
+            <translation>描述：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="851" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1036" />
+            <source>All Day:</source>
+            <translation>全天：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="856" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1102" />
+            <source>Starts:</source>
+            <translation>开始时间：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="861" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1143" />
+            <source>Ends:</source>
+            <translation>结束时间：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="866" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1183" />
+            <source>Remind Me:</source>
+            <translation>提醒：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="871" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1215" />
+            <source>Repeat:</source>
+            <translation>重复：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="876" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1249" />
+            <source>End Repeat:</source>
+            <translation>结束重复：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="934" />
+            <source>Calendar account:</source>
+            <translation>日历账户：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="935" />
+            <source>Calendar account</source>
+            <translation>日历账户</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="961" />
+            <source>Type</source>
+            <translation>类型</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1003" />
+            <source>Description</source>
+            <translation>描述</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1033" />
+            <source>All Day</source>
+            <translation>全天</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1057" />
+            <source>Time:</source>
+            <translation>时间：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1058" />
+            <source>Time</source>
+            <translation>时间</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1065" />
+            <source>Solar</source>
+            <translation>公历</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1066" />
+            <source>Lunar</source>
+            <translation>农历</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1099" />
+            <source>Starts</source>
+            <translation>开始时间</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1140" />
+            <source>Ends</source>
+            <translation>结束时间</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1185" />
+            <source>Remind Me</source>
+            <translation>提醒</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1212" />
+            <source>Repeat</source>
+            <translation>重复</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1227" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1597" />
+            <source>Daily</source>
+            <translation>每天</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1228" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1598" />
+            <source>Weekdays</source>
+            <translation>工作日</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1229" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1599" />
+            <source>Weekly</source>
+            <translation>每周</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1230" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1592" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1600" />
+            <source>Monthly</source>
+            <translation>每月</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1231" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1593" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1601" />
+            <source>Yearly</source>
+            <translation>每年</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1251" />
+            <source>End Repeat</source>
+            <translation>结束重复</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1262" />
+            <source>After</source>
+            <translation>于</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1263" />
+            <source>On</source>
+            <translation>于日期</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1333" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>取 消</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1334" />
+            <source>Save</source>
+            <comment>button</comment>
+            <translation>保 存</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1407" />
+            <source>Local calendar</source>
+            <translation>本地日历</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1409" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleOperation</name>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74" />
+            <source>All occurrences of a repeating event must have the same all-day status.</source>
+            <translation>重复日程的所有重复必须具有相同的全天状态。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="95" />
+            <source>Do you want to change all occurrences?</source>
+            <translation>您要更改所有重复吗？</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="96" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="129" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="151" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="174" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="259" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="292" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>取 消</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="97" />
+            <source>Change All</source>
+            <translation>全部更改</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94" />
+            <source>You are changing the repeating rule of this event.</source>
+            <translation>您正在更改日程的重复规则。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="149" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="172" />
+            <source>You are deleting an event.</source>
+            <translation>您正在删除日程。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128" />
+            <source>Are you sure you want to delete this event?</source>
+            <translation>您确定要删除此日程吗？</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>删 除</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150" />
+            <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
+            <translation>您要删除此日程的所有重复，还是只删除所选重复？</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152" />
+            <source>Delete All</source>
+            <translation>全部删除</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="176" />
+            <source>Delete Only This Event</source>
+            <translation>仅删除此日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173" />
+            <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
+            <translation>您要删除此日程的这个重复和所有将来重复，还是只删除所选重复？</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175" />
+            <source>Delete All Future Events</source>
+            <translation>删除所有将来日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="288" />
+            <source>You are changing a repeating event.</source>
+            <translation>您正在更改重复日程。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257" />
+            <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
+            <translation>您要更改此日程的仅这一个重复，还是更改它的所有重复？</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260" />
+            <source>All</source>
+            <translation>全部日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="294" />
+            <source>Only This Event</source>
+            <translation>仅此日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290" />
+            <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
+            <translation>您要更改此日程的这个重复和所有将来重复，还是只更改所选重复？</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293" />
+            <source>All Future Events</source>
+            <translation>所有将来日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416" />
+            <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
+            <translation>您选择的是闰月，将按照农历规则提醒</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417" />
+            <source>OK</source>
+            <comment>button</comment>
+            <translation>确 定</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchDateItem</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
+            <source>Y</source>
+            <translation>年</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
+            <source>M</source>
+            <translation>月</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
+            <source>D</source>
+            <translation>日</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchItem</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="44" />
+            <source>Edit</source>
+            <translation>编辑</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="45" />
+            <source>Delete</source>
+            <translation>删除</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="287" />
+            <source>All Day</source>
+            <translation>全天</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleSearchView</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="698" />
+            <source>No search results</source>
+            <translation>无搜索结果</translation>
+        </message>
+    </context>
+    <context>
+        <name>CScheduleView</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleview.cpp" line="344" />
+            <source>ALL DAY</source>
+            <translation>全天</translation>
+        </message>
+    </context>
+    <context>
+        <name>CSettingDialog</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="455" />
+            <source>Sunday</source>
+            <translation>周日</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="456" />
+            <source>Monday</source>
+            <translation>周一</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="457" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="476" />
+            <source>Use System Setting</source>
+            <translation>跟随系统</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="474" />
+            <source>24-hour clock</source>
+            <translation>24小时制</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="475" />
+            <source>12-hour clock</source>
+            <translation>12小时制</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="514" />
+            <source>Manual</source>
+            <translation>手动</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="515" />
+            <source>15 mins</source>
+            <translation>每15分钟</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="516" />
+            <source>30 mins</source>
+            <translation>每30分钟</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="517" />
+            <source>1 hour</source>
+            <translation>每1小时</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="518" />
+            <source>24 hours</source>
+            <translation>每24小时</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="538" />
+            <source>Sync Now</source>
+            <translation>立即同步</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="214" />
+            <source>More</source>
+            <translation>更多</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="497" />
+            <source>Add schedule</source>
+            <translation>添加日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="498" />
+            <source>Import ICS file</source>
+            <translation>导入ICS文件</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="818" />
+            <source>Last sync time</source>
+            <translation>最近同步时间</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="819" />
+            <source>Last sync time (%1)</source>
+            <translation>最近同步时间（%1）</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="1049" />
+            <source>Please go to the &lt;a href='/'&gt;Control Center&lt;/a&gt; to change system settings</source>
+            <translation>请到&lt;a href='/'&gt;控制中心&lt;/a&gt;更改系统设置</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="681" />
+            <source>Remove Calendar Account</source>
+            <translation>删除日历账户</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="689" />
+            <source>Are you sure you want to remove the account "%1"?</source>
+            <translation>您确定要删除账户"%1"吗？</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="693" />
+            <source>Also remove synced events from this calendar</source>
+            <translation>同时删除已同步到本地的日程数据</translation>
+        </message>
+        <message>
+            <source>Last sync: %1</source>
+            <translation type="vanished">上次同步：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="246" />
+            <source>Third-party accounts</source>
+            <translation>第三方账户</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="304" />
+            <source>Sync items</source>
+            <translation>同步项</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="908" />
+            <source>Local account</source>
+            <translation>本地账户</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="305" />
+            <source>Sync interval</source>
+            <translation>同步频率</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="255" />
+            <source>Add</source>
+            <translation>添加</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="499" />
+            <source>Import events from an ICS file</source>
+            <translation>从 ICS 文件导入日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="698" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="699" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>删除</translation>
+        </message>
+    </context>
+    <context>
+        <name>CTimeEdit</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="79" />
+            <source>(%1 mins)</source>
+            <translation>(%1分钟)</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="81" />
+            <source>(%1 hour)</source>
+            <translation>(%1小时)</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="83" />
+            <source>(%1 hours)</source>
+            <translation>(%1小时)</translation>
+        </message>
+    </context>
+    <context>
+        <name>CTitleWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="32" />
+            <source>Y</source>
+            <translation>年</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="44" />
+            <source>M</source>
+            <translation>月</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="52" />
+            <source>W</source>
+            <translation>周</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="60" />
+            <source>D</source>
+            <translation>日</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="94" />
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="95" />
+            <source>Search events and festivals</source>
+            <translation>搜索日程/节日</translation>
+        </message>
+    </context>
+    <context>
+        <name>CWeekWindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="92" />
+            <source>Week</source>
+            <translation>周</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="286" />
+            <source>Y</source>
+            <translation>年</translation>
+        </message>
+    </context>
+    <context>
+        <name>CYearScheduleView</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="314" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="317" />
+            <source>All Day</source>
+            <translation>全天</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="335" />
+            <source>No event</source>
+            <translation>无日程</translation>
+        </message>
+    </context>
+    <context>
+        <name>CYearWindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="669" />
+            <source>Y</source>
+            <translation>年</translation>
+        </message>
+    </context>
+    <context>
+        <name>CalDavAccountDialog</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="75" />
+            <source>Add Calendar Account</source>
+            <translation>添加日历账户</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="65" />
+            <source>:</source>
+            <translation>：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="118" />
+            <source>Account Type</source>
+            <translation>账户类型</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="119" />
+            <source>Server Address</source>
+            <translation>服务器地址</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="109" />
+            <source>Automatically filled after selecting account type</source>
+            <translation>选择账户类型后自动填充</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="120" />
+            <source>Username</source>
+            <translation>用户名</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="110" />
+            <source>Enter username or email</source>
+            <translation>输入用户名或邮箱</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="121" />
+            <source>Password</source>
+            <translation>密码</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="111" />
+            <source>Enter password</source>
+            <translation>输入密码</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="133" />
+            <source>Sign In</source>
+            <comment>button</comment>
+            <translation>登录</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="224" />
+            <source>Edit Account</source>
+            <translation>编辑账户</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="510" />
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="558" />
+            <source>Please enter a valid server address.</source>
+            <translation>请输入有效的服务器地址</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="561" />
+            <source>Please enter the correct username.</source>
+            <translation>请输入正确用户名</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="562" />
+            <source>Please enter the correct password.</source>
+            <translation>请输入正确密码</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="583" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>无法连接到服务器，请检查网络连接和服务器地址。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="571" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>用户名或密码错误，请重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="573" />
+            <source>This server does not support CalDAV.</source>
+            <translation>该服务器不支持CalDAV协议</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="579" />
+            <source>The server certificate is invalid.</source>
+            <translation>服务器证书无效</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="575" />
+            <source>The server rejected your login request. Please check your account permissions.</source>
+            <translation>服务器拒绝了登录请求，请检查账户是否有访问权限</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="577" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>服务器返回的数据无法解析，请确认服务器地址或稍后重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="98" />
+            <source>Select account type</source>
+            <translation>选择账户类型</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="132" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="225" />
+            <source>Save</source>
+            <comment>button</comment>
+            <translation>保存</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="232" />
+            <source>Leave empty to keep the current password</source>
+            <translation>留空以保留当前密码</translation>
+        </message>
+    </context>
+    <context>
+        <name>CalDavAccountListWidget</name>
+        <message>
+            <source>Last sync: %1</source>
+            <translation type="vanished">上次同步：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="255" />
+            <source>Syncing...</source>
+            <translation>同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="255" />
+            <source>Deleting...</source>
+            <translation>删除同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="252" />
+            <source>Sync Failed: %1</source>
+            <translation>同步失败：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="69" />
+            <source>Last sync time</source>
+            <translation>最近同步时间</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="74" />
+            <source>Last sync time (%1)</source>
+            <translation>最近同步时间（%1）</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="242" />
+            <source>Sync conflict</source>
+            <translation>同步冲突</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="302" />
+            <source>Calendar synchronization conflict</source>
+            <translation>日程同步冲突</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="243" />
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="304" />
+            <source>A synchronization conflict was detected. The server version will replace the local changes.</source>
+            <translation>检测到日程同步冲突，服务器版本将覆盖本地修改。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="308" />
+            <source>Use server version</source>
+            <translation>使用服务器版本</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="267" />
+            <source>Sync Now</source>
+            <translation>立即同步</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="210" />
+            <source>Pending synchronization</source>
+            <translation>有待完成的同步任务</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="151" />
+            <source>No third-party accounts added</source>
+            <translation>未添加第三方账户</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="157" />
+            <source>Add</source>
+            <translation>添加</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="210" />
+            <source>Delete</source>
+            <translation>删除</translation>
+        </message>
+    </context>
+    <context>
+        <name>CalendarWindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/main.cpp" line="69" />
+            <source>Calendar</source>
+            <translation>日历</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/main.cpp" line="72" />
+            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
+            <translation>日历是一款查看日期、管理日程的小工具。</translation>
+        </message>
+    </context>
+    <context>
+        <name>Calendarmainwindow</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="90" />
+            <source>Calendar</source>
+            <translation>日历</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="433" />
+            <source>Manage</source>
+            <translation>管理</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="440" />
+            <source>Privacy Policy</source>
+            <translation>隐私政策</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1209" />
+            <source>Syncing...</source>
+            <translation>同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1220" />
+            <source>Sync successful</source>
+            <translation>同步成功</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1229" />
+            <source>Sync failed, please try later</source>
+            <translation>同步失败，请稍后再试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1266" />
+            <source>%1 does not allow creating events. Please check account permissions.</source>
+            <translation>%1不允许创建日程，请检查账户权限。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1269" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>无法连接到服务器，请检查网络连接和服务器地址。</translation>
+        </message>
+    </context>
+    <context>
+        <name>CenterWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="239" />
+            <source>All Day</source>
+            <translation>全天</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavProviderProfile</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="37" />
+            <source>DingTalk</source>
+            <translation>钉钉</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="39" />
+            <source>WeCom</source>
+            <translation>企业微信</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="41" />
+            <source>Tencent Meeting</source>
+            <translation>腾讯会议</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="43" />
+            <source>QQ Mail</source>
+            <translation>QQ邮箱</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="45" />
+            <source>Feishu</source>
+            <translation>飞书</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="48" />
+            <source>Other CalDAV</source>
+            <translation>其他 CalDAV</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavSyncStatus</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="61" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>服务器返回的数据无法解析，请确认服务器地址或稍后重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server certificate is invalid.</source>
+            <translation>服务器证书无效</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="54" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>用户名或密码错误，请重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="57" />
+            <source>This server does not support CalDAV.</source>
+            <translation>该服务器不支持CalDAV协议</translation>
+        </message>
+        <message>
+            <source>The server rejected your login request. Please check your account permissions.</source>
+            <translation type="vanished">服务器拒绝了登录请求，请检查账号是否有访问权限</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="65" />
+            <source>The server denied access.</source>
+            <translation>服务器拒绝访问</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="68" />
+            <source>The server request timed out.</source>
+            <translation>服务器请求超时</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="72" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>无法连接到服务器，请检查网络连接和服务器地址。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76" />
+            <source>Synchronization failed.</source>
+            <translation>同步失败</translation>
+        </message>
+    </context>
+    <context>
+        <name>DragInfoGraphicsView</name>
+        <message>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="49" />
+            <source>Edit</source>
+            <translation>编辑</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="50" />
+            <source>Delete</source>
+            <translation>删除</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="51" />
+            <source>New event</source>
+            <translation>新建日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="844" />
+            <source>New Event</source>
+            <translation>新建日程</translation>
+        </message>
+    </context>
+    <context>
+        <name>JobTypeListView</name>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="308" />
+            <source>import ICS file</source>
+            <translation>导入ICS文件</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="565" />
+            <source>You are deleting an event type.</source>
+            <translation>您正在删除日程类型。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="566" />
+            <source>All events under this type will be deleted and cannot be recovered.</source>
+            <translation>此日程类型下的所有日程都会删除且不可恢复。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="567" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>取 消</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="568" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>删 除</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="213" />
+            <source>Edit</source>
+            <translation>编辑</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="219" />
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="233" />
+            <source>Export</source>
+            <translation>导出</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="308" />
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="417" />
+            <source>ICS files (*.ics)</source>
+            <translation>ICS 文件（*.ics）</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="416" />
+            <source>Export ICS file</source>
+            <translation>导出 ICS 文件</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="216" />
+            <source>Delete</source>
+            <translation>删除</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="67" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="98" />
+            <source>Manage calendar</source>
+            <translation>日历管理</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="83" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="102" />
+            <source>Event types</source>
+            <translation>日程类型</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="50" />
+            <source>Account settings</source>
+            <translation>账户设置</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="559" />
+            <source>Events</source>
+            <translation>日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="117" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="561" />
+            <source>General settings</source>
+            <translation>通用设置</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="75" />
+            <source>Associated account</source>
+            <translation>关联账户</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="121" />
+            <source>General</source>
+            <translation>通用</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="123" />
+            <source>First day of week</source>
+            <translation>每星期开始于</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="124" />
+            <source>Time</source>
+            <translation>时间</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="59" />
+            <source>Third-party accounts</source>
+            <translation>第三方账户</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="54" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
+        </message>
+    </context>
+    <context>
+        <name>Return</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="665" />
+            <source>Today</source>
+            <comment>Return</comment>
+            <translation>返回今天</translation>
+        </message>
+    </context>
+    <context>
+        <name>Return Today</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="353" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="100" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="283" />
+            <source>Today</source>
+            <comment>Return Today</comment>
+            <translation>返回今天</translation>
+        </message>
+    </context>
+    <context>
+        <name>ScheduleTypeEditDlg</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22" />
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="50" />
+            <source>New event type</source>
+            <translation>新增日程类型</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="33" />
+            <source>Edit event type</source>
+            <translation>编辑日程类型</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="45" />
+            <source>Import ICS file</source>
+            <translation>导入ICS文件</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="158" />
+            <source>Name:</source>
+            <translation>名称：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="159" />
+            <source>Color:</source>
+            <translation>颜色：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="164" />
+            <source>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt; File:</source>
+            <translation>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt;文件：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="175" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>取 消</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="176" />
+            <source>Save</source>
+            <comment>button</comment>
+            <translation>保 存</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="232" />
+            <source>The name can not only contain whitespaces</source>
+            <translation>名称不能设置为全空格，请修改</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="275" />
+            <source>Enter a name please</source>
+            <translation>名称不能为空</translation>
+        </message>
+    </context>
+    <context>
+        <name>Shortcut</name>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="18" />
+            <source>Help</source>
+            <translation>帮助</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="19" />
+            <source>Delete event</source>
+            <translation>删除日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="22" />
+            <source>Copy</source>
+            <translation>复制</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="23" />
+            <source>Cut</source>
+            <translation>剪切</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="24" />
+            <source>Paste</source>
+            <translation>粘贴</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="27" />
+            <source>Delete</source>
+            <translation>删除</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="28" />
+            <source>Select all</source>
+            <translation>全选</translation>
+        </message>
+    </context>
+    <context>
+        <name>SidebarAccountItemWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="344" />
+            <source>Deleting...</source>
+            <translation>删除同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="345" />
+            <source>Syncing...</source>
+            <translation>同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="335" />
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="345" />
+            <source>Sync</source>
+            <translation>同步</translation>
+        </message>
+    </context>
+    <context>
+        <name>SidebarCalendarWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="135" />
+            <source>Y</source>
+            <translation>年</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="135" />
+            <source>M</source>
+            <translation>月</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimeJumpDialog</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/timejumpdialog.cpp" line="32" />
+            <source>Go</source>
+            <comment>button</comment>
+            <translation>跳 转</translation>
+        </message>
+    </context>
+    <context>
+        <name>UserloginWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="105" />
+            <source>Sign In</source>
+            <comment>button</comment>
+            <translation>登录</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="106" />
+            <source>Sign Out</source>
+            <comment>button</comment>
+            <translation>退出</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="203" />
+            <source>Not signed in</source>
+            <translation>未登录</translation>
+        </message>
+    </context>
+    <context>
+        <name>YearFrame</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="1020" />
+            <source>Y</source>
+            <translation>年</translation>
+        </message>
+    </context>
+    <context>
+        <name>today</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="200" />
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="351" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="261" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="59" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="281" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="288" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="663" />
+            <source>Today</source>
+            <comment>Today</comment>
+            <translation>今天</translation>
+        </message>
+    </context>
 </TS>


### PR DESCRIPTION
Add translations for CalDAV account management, synchronization, provider names, and error messages.

增加 CalDAV 账户管理、同步、厂商名称和错误提示翻译。

Log: 完善 CalDAV 功能翻译
PMS: TASK-393989
Influence: 完善日历账户、同步状态和异常提示的中英文显示。