### PR TITLE
feat(caldav): show organizer and attendees in event preview

### DIFF
--- a/src/calendar-client/src/customWidget/scheduleRemindWidget.cpp
+++ b/src/calendar-client/src/customWidget/scheduleRemindWidget.cpp
@@ -27,13 +27,57 @@ static const int kReminderArrowInset = 10;
 DGUI_USE_NAMESPACE
 
 namespace {
-constexpr int kContentTop = 12;
+constexpr int kContentTop = 4;
+constexpr int kMinTextRectWidth = 165;
+constexpr int kMaxTextRectWidth = 191;
+constexpr int kMinContentWidth = 207;
+constexpr int kContentWidthPadding = 35;
 constexpr int kTimeFrameHeight = 17;
 constexpr int kTimeTitleSpacing = 6;
 constexpr int kTitleFrameHeight = 17;
+constexpr int kTitleDetailSpacing = 9;
+constexpr int kDetailFrameHeight = 22;
+constexpr int kDetailSourceSpacing = 13;
+constexpr int kDetailDividerOffset = 6;
 constexpr int kTitleSourceSpacing = 7;
-constexpr int kSourceFrameHeight = 15;
-constexpr int kContentBottom = 13;
+constexpr int kToolTipTextWidth = 300;
+
+QString userDisplayNamePart(QString value)
+{
+    value = value.trimmed();
+    if (value.startsWith(QLatin1String("mailto:"), Qt::CaseInsensitive)) {
+        value.remove(0, 7);
+    }
+
+    const int parameterStart = value.indexOf(QLatin1Char(';'));
+    if (parameterStart >= 0) {
+        value.truncate(parameterStart);
+    }
+    value = value.trimmed();
+    if (value.size() > 1 && ((value.front() == QLatin1Char('\"') && value.back() == QLatin1Char('\"'))
+                             || (value.front() == QLatin1Char('\'') && value.back() == QLatin1Char('\'')))) {
+        value = value.mid(1, value.size() - 2);
+    }
+
+    return value.section(QLatin1Char('@'), 0, 0);
+}
+
+QString userDisplayName(const QString &name, const QString &email)
+{
+    const QString displayName = userDisplayNamePart(name);
+    return displayName.isEmpty() ? userDisplayNamePart(email) : displayName;
+}
+
+QString personDisplayName(const KCalendarCore::Person &person)
+{
+    return userDisplayName(person.name(), person.email());
+}
+
+QString attendeeDisplayName(const KCalendarCore::Attendee &attendee)
+{
+    return userDisplayName(attendee.name(), attendee.email());
+}
+constexpr int kContentBottom = 0;
 }
 ScheduleRemindWidget::ScheduleRemindWidget(QWidget *parent)
     : DArrowRectangle(DArrowRectangle::ArrowLeft, DArrowRectangle::FloatWidget, parent)
@@ -49,7 +93,7 @@ ScheduleRemindWidget::ScheduleRemindWidget(QWidget *parent)
     setRadiusArrowStyleEnable(true);
     setRadius(DARROWRECT::DRADIUS);
 #endif
-    m_centerWidget->setFixedWidth(207);
+    m_centerWidget->setFixedWidth(kMinContentWidth);
     m_centerWidget->setFixedHeight(57);
     setContent(m_centerWidget);
     this->resizeWithContent();
@@ -137,6 +181,10 @@ void CenterWidget::setData(const DSchedule::Ptr &vScheduleInfo, const CSchedules
     m_ScheduleInfo = vScheduleInfo;
     gdcolor = gcolor;
     textfont.setPixelSize(DDECalendar::FontSizeTwelve);
+    m_organizerLabel = QCoreApplication::translate("CMyScheduleView", "Organizer");
+    m_attendeeLabel = QCoreApplication::translate("CMyScheduleView", "Attendees");
+    m_organizerLines.clear();
+    m_attendeeLines.clear();
     m_sourceText.clear();
 
     const AccountItem::Ptr accountItem =
@@ -198,10 +246,40 @@ void CenterWidget::UpdateTextList()
 {
     qCDebug(ClientLogger) << "CenterWidget::UpdateTextList";
     testList.clear();
-    QFontMetrics metrics(textfont);
+    m_organizerLines.clear();
+    m_attendeeLines.clear();
+
+    sourceFont.setPixelSize(DDECalendar::FontSizeTwelve);
+    const QFontMetrics metrics(textfont);
+    const QFontMetrics sourceMetrics(sourceFont);
+    const QString organizer = personDisplayName(m_ScheduleInfo->organizer());
+    QStringList attendees;
+    for (const KCalendarCore::Attendee &attendee : m_ScheduleInfo->attendees()) {
+        const QString name = attendeeDisplayName(attendee);
+        if (!name.isEmpty()) {
+            attendees.append(name);
+        }
+    }
+    const QString attendeeText = attendees.join(QStringLiteral("、"));
+
+    m_detailLabelWidth = qMax(metrics.horizontalAdvance(m_organizerLabel),
+                              metrics.horizontalAdvance(m_attendeeLabel)) + 6;
+    int contentTextWidth = metrics.horizontalAdvance(m_ScheduleInfo->summary());
+    if (!organizer.isEmpty()) {
+        contentTextWidth = qMax(contentTextWidth,
+                                 m_detailLabelWidth + metrics.horizontalAdvance(organizer));
+    }
+    if (!attendeeText.isEmpty()) {
+        contentTextWidth = qMax(contentTextWidth,
+                                 m_detailLabelWidth + metrics.horizontalAdvance(attendeeText));
+    }
+    contentTextWidth = qMax(contentTextWidth, sourceMetrics.horizontalAdvance(m_sourceText));
+    textRectWidth = qBound(kMinTextRectWidth, contentTextWidth, kMaxTextRectWidth);
+    setFixedWidth(qMax(kMinContentWidth, textRectWidth + kContentWidthPadding));
+
     textwidth = metrics.horizontalAdvance(m_ScheduleInfo->summary());
     textheight = metrics.height();
-    const int  h_count = qCeil(textwidth / textRectWidth);
+    const int h_count = qCeil(textwidth / textRectWidth);
     QString text;
 
     if (h_count < 1) {
@@ -226,23 +304,90 @@ void CenterWidget::UpdateTextList()
                     break;
                 }
                 --i;
-            } else {
-                if (i + 1 == m_ScheduleInfo->summary().count()) {
-                    // qCDebug(ClientLogger) << "Adding final line of text";
-                    testList.append(text);
-                }
+            } else if (i + 1 == m_ScheduleInfo->summary().count()) {
+                testList.append(text);
             }
         }
     }
 
+    const int detailValueWidth = textRectWidth - m_detailLabelWidth;
+    const auto wrapDetailText = [&metrics, detailValueWidth](const QString &detailText) {
+        QStringList lines;
+        QString line;
+        for (const QChar character : detailText) {
+            if (metrics.horizontalAdvance(line + character) > detailValueWidth && !line.isEmpty()) {
+                lines.append(line);
+                line.clear();
+            }
+            line.append(character);
+        }
+        if (!line.isEmpty()) {
+            lines.append(line);
+        }
+
+        constexpr int kMaximumDetailLines = 2;
+        if (lines.count() > kMaximumDetailLines) {
+            const QString remainingText = lines.mid(kMaximumDetailLines - 1).join(QString());
+            lines = lines.mid(0, kMaximumDetailLines - 1);
+            lines.append(metrics.elidedText(remainingText, Qt::ElideRight, detailValueWidth));
+        }
+        return lines;
+    };
+
+    if (!organizer.isEmpty()) {
+        m_organizerLines = wrapDetailText(organizer);
+    }
+    if (!attendeeText.isEmpty()) {
+        m_attendeeLines = wrapDetailText(attendeeText);
+    }
+
     qCDebug(ClientLogger) << "Final text list has" << testList.count() << "lines";
-    sourceFont.setPixelSize(DDECalendar::FontSizeTwelve);
-    const int sourceHeight = m_sourceText.isEmpty() ? 0 : kSourceFrameHeight;
+    const int sourceFrameHeight = sourceMetrics.lineSpacing() + 2;
+    const int detailLineCount = m_organizerLines.count() + m_attendeeLines.count();
+    const bool hasParticipantInfo = detailLineCount > 0;
+    const int detailHeight = detailLineCount * kDetailFrameHeight;
+    const int detailSpacing = hasParticipantInfo ? kTitleDetailSpacing : 0;
+    const int sourceHeight = m_sourceText.isEmpty() ? 0 : sourceFrameHeight;
     const int titleHeight = testList.count() * kTitleFrameHeight;
-    const int sourceSpacing = m_sourceText.isEmpty() ? 0 : kTitleSourceSpacing;
+    const int sourceSpacing = m_sourceText.isEmpty()
+        ? 0 : (hasParticipantInfo ? kDetailSourceSpacing : kTitleSourceSpacing);
     const int contentHeight = kContentTop + kTimeFrameHeight + kTimeTitleSpacing + titleHeight
-        + sourceSpacing + sourceHeight + kContentBottom;
+        + detailSpacing + detailHeight + sourceSpacing + sourceHeight + kContentBottom;
     this->setFixedHeight(contentHeight);
+
+    QStringList toolTipLines;
+    const auto appendToolTipText = [&metrics, &toolTipLines](const QString &toolTipText) {
+        QString line;
+        for (const QChar character : toolTipText) {
+            if (character == QLatin1Char('\n')) {
+                toolTipLines.append(line);
+                line.clear();
+            } else if (metrics.horizontalAdvance(line + character) > kToolTipTextWidth && !line.isEmpty()) {
+                toolTipLines.append(line);
+                line = character;
+            } else {
+                line.append(character);
+            }
+        }
+        if (!line.isEmpty()) {
+            toolTipLines.append(line);
+        }
+    };
+
+    if (testList.join(QString()) != m_ScheduleInfo->summary()) {
+        appendToolTipText(m_ScheduleInfo->summary());
+    }
+    if (!m_organizerLines.isEmpty() && m_organizerLines.join(QString()) != organizer) {
+        appendToolTipText(m_organizerLabel + QStringLiteral(": ") + organizer);
+    }
+    if (!m_attendeeLines.isEmpty() && m_attendeeLines.join(QString()) != attendeeText) {
+        appendToolTipText(m_attendeeLabel + QStringLiteral(": ") + attendeeText);
+    }
+    if (!m_sourceText.isEmpty()
+        && sourceMetrics.elidedText(m_sourceText, Qt::ElideRight, textRectWidth) != m_sourceText) {
+        appendToolTipText(m_sourceText);
+    }
+    setToolTip(toolTipLines.join(QLatin1Char('\n')));
 }
 
 void CenterWidget::paintEvent(QPaintEvent *e)
@@ -275,7 +420,7 @@ void CenterWidget::paintEvent(QPaintEvent *e)
 
     const int titleY = kContentTop + timeheight + kTimeTitleSpacing;
     painter.drawText(QRect(x + 13, kContentTop, timewidth, kTimeFrameHeight),
-                     Qt::AlignLeft | Qt::AlignTop, timestr);
+                     Qt::AlignLeft | Qt::AlignVCenter, timestr);
     painter.setRenderHints(QPainter::Antialiasing);
     painter.setPen(Qt::NoPen);
     painter.setBrush(QBrush(gdcolor.orginalColor));
@@ -288,15 +433,49 @@ void CenterWidget::paintEvent(QPaintEvent *e)
     for (int i = 0; i < testList.count(); i++) {
         painter.drawText(
             QRect(x, titleY + i * kTitleFrameHeight, textRectWidth, kTitleFrameHeight),
-            Qt::AlignLeft, testList.at(i));
+            Qt::AlignLeft | Qt::AlignVCenter, testList.at(i));
     }
 
+    int detailY = titleY + testList.count() * kTitleFrameHeight;
+    if (!m_organizerLines.isEmpty() || !m_attendeeLines.isEmpty()) {
+        detailY += kTitleDetailSpacing;
+    }
+
+    const auto drawDetails = [&painter, this, x, &detailY](const QString &label,
+                                                             const QStringList &lines) {
+        if (lines.isEmpty()) {
+            return;
+        }
+        painter.drawText(QRect(x, detailY, m_detailLabelWidth, kDetailFrameHeight),
+                         Qt::AlignLeft | Qt::AlignVCenter, label);
+        for (const QString &line : lines) {
+            painter.drawText(QRect(x + m_detailLabelWidth, detailY,
+                                   textRectWidth - m_detailLabelWidth, kDetailFrameHeight),
+                             Qt::AlignLeft | Qt::AlignVCenter, line);
+            detailY += kDetailFrameHeight;
+        }
+    };
+    drawDetails(m_organizerLabel, m_organizerLines);
+    drawDetails(m_attendeeLabel, m_attendeeLines);
+
+    const bool hasParticipantInfo = !m_organizerLines.isEmpty() || !m_attendeeLines.isEmpty();
     if (!m_sourceText.isEmpty()) {
+        const int sourceSpacing = hasParticipantInfo ? kDetailSourceSpacing : kTitleSourceSpacing;
+        if (hasParticipantInfo) {
+            QColor dividerColor = timeColor;
+            dividerColor.setAlphaF(0.15);
+            painter.setPen(dividerColor);
+            const int dividerY = detailY + kDetailDividerOffset;
+            painter.drawLine(x, dividerY, x + textRectWidth, dividerY);
+        }
+
         painter.setFont(sourceFont);
         painter.setPen(timeColor);
-        const int sourceY = titleY + testList.count() * kTitleFrameHeight + kTitleSourceSpacing;
+        const int sourceY = detailY + sourceSpacing;
         const QFontMetrics sourceMetrics(sourceFont);
-        painter.drawText(QRect(x, sourceY, textRectWidth, kSourceFrameHeight),
-                         Qt::AlignLeft, sourceMetrics.elidedText(m_sourceText, Qt::ElideRight, textRectWidth));
+        const int sourceFrameHeight = sourceMetrics.lineSpacing() + 2;
+        painter.drawText(QRect(x, sourceY, textRectWidth, sourceFrameHeight),
+                         Qt::AlignLeft | Qt::AlignVCenter,
+                         sourceMetrics.elidedText(m_sourceText, Qt::ElideRight, textRectWidth));
     }
 }

--- a/src/calendar-client/src/customWidget/scheduleRemindWidget.h
+++ b/src/calendar-client/src/customWidget/scheduleRemindWidget.h
@@ -55,12 +55,17 @@ protected:
     void paintEvent(QPaintEvent *e) override;
 private:
     QStringList testList;
+    QStringList m_organizerLines;
+    QStringList m_attendeeLines;
+    QString m_organizerLabel;
+    QString m_attendeeLabel;
     QString m_sourceText;
     QFont textfont;
     QFont sourceFont;
     int textwidth;
     int textheight;
-    const int textRectWidth = 165;
+    int m_detailLabelWidth = 0;
+    int textRectWidth = 165;
     DSchedule::Ptr m_ScheduleInfo;
     CSchedulesColor gdcolor;
     QColor textColor;

--- a/translations/dde-calendar.ts
+++ b/translations/dde-calendar.ts
@@ -204,6 +204,16 @@
             <source>Source: %1</source>
             <translation>Source: %1</translation>
         </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="152" />
+            <source>Organizer</source>
+            <translation>Organizer</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="153" />
+            <source>Attendees</source>
+            <translation>Attendees</translation>
+        </message>
     </context>
     <context>
         <name>CPushButton</name>

--- a/translations/dde-calendar_zh_CN.ts
+++ b/translations/dde-calendar_zh_CN.ts
@@ -188,6 +188,16 @@
             <translation>来源: %1</translation>
         </message>
         <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="152" />
+            <source>Organizer</source>
+            <translation>发起人</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="153" />
+            <source>Attendees</source>
+            <translation>参会人</translation>
+        </message>
+        <message>
             <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="118" />
             <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="177" />
             <source>Local calendar</source>


### PR DESCRIPTION
Display organizer and attendee names in the event preview popup. Clean attendee metadata, wrap long names, and provide full tooltips.

在日程预览浮层中显示发起人和参会人姓名。
清理参会人元数据，支持长名单换行并提供完整提示。

Log: 完善日程预览中的发起人和参会人显示
PMS: TASK-393989
Influence: 完善 CalDAV 日程人员信息展示，优化长文本、分隔线和浮层布局。

## Summary by Sourcery

Improve the CalDAV event preview with clearer organizer and attendee information and a more flexible layout for long content.

New Features:
- Show organizer and attendee names in the calendar event preview.

Bug Fixes:
- Clean attendee metadata so displayed participant names are readable and consistent.

Enhancements:
- Adapt the preview layout for long event titles and participant lists with wrapping, truncation, dividers, and complete tooltips.