### PR TITLE
feat(caldav): improve sync status and toast feedback

### DIFF
--- a/src/calendar-client/assets/builtin/icons/dde_calendar_sync_failed_32px.svg
+++ b/src/calendar-client/assets/builtin/icons/dde_calendar_sync_failed_32px.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32px" height="32px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>calendar sync failed</title>
+    <defs>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#FF674A" offset="0%"></stop>
+            <stop stop-color="#EC5783" offset="100%"></stop>
+        </linearGradient>
+        <path d="M9.99071429,0 C15.5186566,0 20,4.4782507 20,10 C20,15.5217493 15.5186566,20 9.99071429,20 C4.47205964,20 0,15.521755 0,10 C0,4.47824507 4.47205964,0 9.99071429,0 Z" id="path-2"></path>
+        <filter x="-27.5%" y="-17.5%" width="155.0%" height="155.0%" filterUnits="objectBoundingBox" id="filter-3">
+            <feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="1.5" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 1   0 0 0 0 0.443137255   0 0 0 0 0.443137255  0 0 0 0.3 0" type="matrix" in="shadowBlurOuter1"></feColorMatrix>
+        </filter>
+    </defs>
+    <g id="warning" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="warning" transform="translate(2.000000, 2.000000) scale(1.4)">
+            <g id="Shape">
+                <use fill="black" fill-opacity="1" filter="url(#filter-3)" xlink:href="#path-2"></use>
+                <use fill="url(#linearGradient-1)" fill-rule="evenodd" xlink:href="#path-2"></use>
+            </g>
+            <path d="M9,5 L11,5 L11,11 L9,11 L9,5 Z M9,13 L11,13 L11,15 L9,15 L9,13 Z" id="Combined-Shape" fill="#FFFFFF" fill-rule="nonzero" opacity="0.900000036"></path>
+        </g>
+    </g>
+</svg>

--- a/src/calendar-client/assets/builtin/icons/dde_calendar_sync_success_32px.svg
+++ b/src/calendar-client/assets/builtin/icons/dde_calendar_sync_success_32px.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32px" height="32px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>calendar sync success</title>
+    <defs>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#55C600" offset="0%"></stop>
+            <stop stop-color="#00C3B6" offset="100%"></stop>
+        </linearGradient>
+        <circle id="path-2" cx="10" cy="10" r="10"></circle>
+        <filter x="-27.5%" y="-17.5%" width="155.0%" height="155.0%" filterUnits="objectBoundingBox" id="filter-3">
+            <feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="1.5" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0.835294118   0 0 0 0 0.270588235  0 0 0 0.3 0" type="matrix" in="shadowBlurOuter1"></feColorMatrix>
+        </filter>
+    </defs>
+    <g id="ok" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="ok" transform="translate(2.000000, 2.000000) scale(1.4)">
+            <g id="Oval-127">
+                <use fill="black" fill-opacity="1" filter="url(#filter-3)" xlink:href="#path-2"></use>
+                <use fill="url(#linearGradient-1)" fill-rule="evenodd" xlink:href="#path-2"></use>
+            </g>
+            <polyline id="Path-1766" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" points="5.23632962 10.0435227 8.86867992 14.4222887 16.2792863 5.66475667"></polyline>
+        </g>
+    </g>
+</svg>

--- a/src/calendar-client/assets/resources.qrc
+++ b/src/calendar-client/assets/resources.qrc
@@ -61,6 +61,8 @@
         <file>builtin/icons/dde_calendar_fail_200px.png</file>
         <file>builtin/icons/dde_calendar_ji_32px.svg</file>
         <file>builtin/icons/dde_calendar_spinner_32px.svg</file>
+        <file>builtin/icons/dde_calendar_sync_success_32px.svg</file>
+        <file>builtin/icons/dde_calendar_sync_failed_32px.svg</file>
         <file>builtin/icons/dde_calendar_success_200px.png</file>
         <file>builtin/icons/dde_calendar_sync_schedule_32px.svg</file>
         <file>builtin/icons/dde_calendar_sync_setting_32px.svg</file>

--- a/src/calendar-client/src/dataManage/accountmanager.cpp
+++ b/src/calendar-client/src/dataManage/accountmanager.cpp
@@ -503,13 +503,22 @@ void AccountManager::slotGetAccountListFinish(DAccount::List accountList)
         } else if (account->accountType() == DAccount::Account_UnionID && !isCommunityEdition()) {
             qCDebug(ClientLogger) << "Processing UnionID account:" << account->accountName();
             hasUnionAccount = true;
+            bool unionAccountChanged = false;
             if (!m_unionAccountItem) {
                 qCDebug(ClientLogger) << "Creating new union account item";
                 m_unionAccountItem.reset(new AccountItem(account, this));
-            } else if (m_unionAccountItem && m_unionAccountItem->getAccount()->accountID() != account->accountID()) {
+                unionAccountChanged = true;
+            } else if (m_unionAccountItem->getAccount()->accountID() != account->accountID()) {
                 qCDebug(ClientLogger) << "Union account ID changed, creating new union account item";
                 emit m_unionAccountItem->signalLogout(m_unionAccountItem->getAccount()->accountType());
                 m_unionAccountItem.reset(new AccountItem(account, this));
+                unionAccountChanged = true;
+            }
+            if (unionAccountChanged) {
+                connect(m_unionAccountItem.data(), &AccountItem::signalSyncStateChange,
+                        this, [this](DAccount::AccountSyncState state) {
+                    emit signalSyncNum(static_cast<int>(state));
+                });
             }
         } else if (account->accountType() == DAccount::Account_CalDav) {
             currentCalDavAccountIDs.append(account->accountID());

--- a/src/calendar-client/src/dialog/caldavaccountlistwidget.cpp
+++ b/src/calendar-client/src/dialog/caldavaccountlistwidget.cpp
@@ -13,6 +13,8 @@
 #include <QCoreApplication>
 #include <QIcon>
 #include <DLabel>
+#include <DPalette>
+#include <DFontSizeManager>
 #include <QHBoxLayout>
 #include <QPalette>
 #include <QTimer>
@@ -38,22 +40,32 @@ QString accountTitle(const DAccount::Ptr &account, const DCalDavAccountStatus &s
     return title;
 }
 
-QString syncTimeText(const DCalDavAccountStatus &status)
+QString syncTimeLabel()
+{
+    return QCoreApplication::translate("CalDavAccountListWidget", "Last sync time");
+}
+
+QString syncTimeValue(const DCalDavAccountStatus &status)
 {
     if (!status.lastSuccessfulSync.isValid()) {
-        return QCoreApplication::translate("CalDavAccountListWidget", "Last sync time");
+        return {};
     }
 
     const QString time = status.lastSuccessfulSync.toLocalTime().toString(
         QStringLiteral("yyyy/MM/dd HH:mm"));
-    return QCoreApplication::translate("CalDavAccountListWidget", "Last sync time (%1)").arg(time);
+    return QStringLiteral("(%1)").arg(time);
 }
 
-QIcon syncStatusIcon(bool failed)
+QIcon syncResultIcon(bool failed)
 {
     return QIcon(failed
-        ? QStringLiteral(":/icons/deepin/builtin/icons/dde_calendar_warning_light_32px.svg")
-        : QStringLiteral(":/icons/deepin/builtin/icons/dde_calendar_spinner_32px.svg"));
+        ? QStringLiteral(":/icons/deepin/builtin/icons/dde_calendar_sync_failed_32px.svg")
+        : QStringLiteral(":/icons/deepin/builtin/icons/dde_calendar_sync_success_32px.svg"));
+}
+
+QIcon syncRunningIcon()
+{
+    return QIcon(QStringLiteral(":/icons/deepin/builtin/icons/dde_calendar_spinner_32px.svg"));
 }
 
 
@@ -205,36 +217,59 @@ void CalDavAccountListWidget::rebuildCards()
 
         // The last successful sync time remains visible while a sync operation
         // is running or has failed. The current state is shown alongside it.
-        Dtk::Widget::DLabel *timeLabel = new Dtk::Widget::DLabel(syncTimeText(status), statusRow);
+        const bool showResultIcon = status.syncStatus == DCalDavSyncStatus::Succeeded
+            || status.conflictCount > 0 || failed;
+        QWidget *timeWidget = new QWidget(statusRow);
+        QHBoxLayout *timeLayout = new QHBoxLayout(timeWidget);
+        timeLayout->setContentsMargins(0, 0, 0, 0);
+        timeLayout->setSpacing(6);
+
+        Dtk::Widget::DLabel *timeLabel = new Dtk::Widget::DLabel(syncTimeLabel(), timeWidget);
         timeLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-        statusLayout->addWidget(timeLabel);
+        timeLayout->addWidget(timeLabel);
+
+        if (showResultIcon) {
+            Dtk::Widget::DLabel *resultIconLabel = new Dtk::Widget::DLabel(timeWidget);
+            resultIconLabel->setFixedSize(16, 16);
+            resultIconLabel->setPixmap(syncResultIcon(status.conflictCount > 0 || failed).pixmap(16, 16));
+            timeLayout->addWidget(resultIconLabel);
+        } else if (running || pendingDelete) {
+            Dtk::Widget::DLabel *stateIconLabel = new Dtk::Widget::DLabel(timeWidget);
+            stateIconLabel->setFixedSize(16, 16);
+            stateIconLabel->setPixmap(syncRunningIcon().pixmap(16, 16));
+            timeLayout->addWidget(stateIconLabel);
+        }
+
+        const QString timeValue = syncTimeValue(status);
+        if (!timeValue.isEmpty()) {
+            Dtk::Widget::DLabel *timeValueLabel = new Dtk::Widget::DLabel(timeValue, timeWidget);
+            Dtk::Widget::DFontSizeManager::instance()->bind(timeValueLabel,
+                                                             Dtk::Widget::DFontSizeManager::T8);
+            timeValueLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+            timeLayout->addWidget(timeValueLabel);
+        }
+        statusLayout->addWidget(timeWidget);
 
         if (status.conflictCount > 0) {
-            Dtk::Widget::DLabel *stateIconLabel = new Dtk::Widget::DLabel(statusRow);
-            stateIconLabel->setFixedSize(16, 16);
-            stateIconLabel->setPixmap(syncStatusIcon(true).pixmap(16, 16));
-            statusLayout->addWidget(stateIconLabel);
             Dtk::Widget::DLabel *stateLabel = new Dtk::Widget::DLabel(tr("Sync conflict"), statusRow);
             stateLabel->setToolTip(tr("A synchronization conflict was detected. The server version will replace the local changes."));
             statusLayout->addWidget(stateLabel);
         } else if (running || pendingDelete || failed) {
-            Dtk::Widget::DLabel *stateIconLabel = new Dtk::Widget::DLabel(statusRow);
-            stateIconLabel->setFixedSize(16, 16);
-            stateIconLabel->setPixmap(syncStatusIcon(failed).pixmap(16, 16));
-            statusLayout->addWidget(stateIconLabel);
-
             const QString stateText = failed
                 ? tr("Sync Failed: %1").arg(
                       DCalDavSyncStatus::localizedFailureReason(
                     static_cast<DCalDavErrorCode>(status.failureCode)))
                 : (pendingDelete ? tr("Deleting...") : tr("Syncing..."));
             Dtk::Widget::DLabel *stateLabel = new Dtk::Widget::DLabel(stateText, statusRow);
+            stateLabel->setForegroundRole(Dtk::Gui::DPalette::TextTips);
+            Dtk::Widget::DFontSizeManager::instance()->bind(stateLabel,
+                                                             Dtk::Widget::DFontSizeManager::T8);
             stateLabel->setToolTip(failed
                 ? DCalDavSyncStatus::localizedFailureReason(
                     static_cast<DCalDavErrorCode>(status.failureCode))
                 : QString());
-            stateLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
             stateLabel->setElideMode(Qt::ElideRight);
+            stateLabel->setMinimumWidth(0);
             stateLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
             statusLayout->addWidget(stateLabel);
         }

--- a/src/calendar-client/src/dialog/settingdialog.cpp
+++ b/src/calendar-client/src/dialog/settingdialog.cpp
@@ -23,6 +23,7 @@
 #include <QMenu>
 #include <QPushButton>
 #include <QVBoxLayout>
+#include <QTimer>
 
 #include <DBackgroundGroup>
 #include <DComboBox>
@@ -31,6 +32,8 @@
 #include <DSettingsOption>
 #include <DSettingsWidgetFactory>
 #include <DIcon>
+#include <DPalette>
+#include <DFontSizeManager>
 #include <DToolButton>
 
 #include <qglobal.h>
@@ -406,6 +409,9 @@ void CSettingDialog::initConnect()
     //TODO:更新union帐户的的同步频率
     connect(m_syncFreqComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &CSettingDialog::slotSetUosSyncFreq);
     connect(m_syncBtn, &QPushButton::clicked, this, &CSettingDialog::slotUosManualSync);
+    m_syncTimeoutTimer = new QTimer(this);
+    m_syncTimeoutTimer->setSingleShot(true);
+    connect(m_syncTimeoutTimer, &QTimer::timeout, this, &CSettingDialog::slotSyncTimeout);
     connect(m_ptrNetworkState, &DOANetWorkDBus::sign_NetWorkChange, this, &CSettingDialog::slotNetworkStateChange);
     qCDebug(ClientLogger) << "Settings dialog connections initialized";
 }
@@ -554,10 +560,19 @@ void CSettingDialog::initManualSyncButton()
     m_syncBtn->setText(tr("Sync Now"));
 
     m_syncTimeLabel = new QLabel;
+    m_syncTimeValueLabel = new DLabel;
+    m_syncTimeValueLabel->setForegroundRole(Dtk::Gui::DPalette::TextTips);
+    DFontSizeManager::instance()->bind(m_syncTimeValueLabel, DFontSizeManager::T8);
+    m_syncStatusIconLabel = new QLabel;
+    m_syncStatusIconLabel->setFixedSize(16, 16);
+    m_syncStatusIconLabel->hide();
 
     QHBoxLayout *layout = new QHBoxLayout(m_manualSyncWidget);
     layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(6);
     layout->addWidget(m_syncTimeLabel);
+    layout->addWidget(m_syncStatusIconLabel);
+    layout->addWidget(m_syncTimeValueLabel);
     layout->addStretch();
     layout->addWidget(m_syncBtn);
 
@@ -612,7 +627,10 @@ void CSettingDialog::slotAccountUpdate()
     //判断账户是否为登录状态，并建立连接
     if (gUosAccountItem) {
         slotLastSyncTimeUpdate(gUosAccountItem->getDtLastUpdate());
-        connect(gUosAccountItem.get(), &AccountItem::signalDtLastUpdate, this, &CSettingDialog::slotLastSyncTimeUpdate);
+        connect(gUosAccountItem.get(), &AccountItem::signalDtLastUpdate,
+                this, &CSettingDialog::slotLastSyncTimeUpdate, Qt::UniqueConnection);
+        connect(gUosAccountItem.get(), &AccountItem::signalSyncStateChange,
+                this, &CSettingDialog::slotSyncStateChange, Qt::UniqueConnection);
     }
 }
 
@@ -770,6 +788,16 @@ void CSettingDialog::slotUosManualSync()
         return;
     }
     qCDebug(ClientLogger) << "Manual sync requested for account:" << gUosAccountItem->getAccount()->accountID();
+    if (m_syncTimeValueLabel && m_syncStatusIconLabel) {
+        m_syncTimeValueLabel->setText(tr("Syncing..."));
+        m_syncStatusIconLabel->setPixmap(QIcon(QStringLiteral(
+            ":/icons/deepin/builtin/icons/dde_calendar_spinner_32px.svg"))
+            .pixmap(16, 16));
+        m_syncStatusIconLabel->show();
+    }
+    if (m_syncTimeoutTimer) {
+        m_syncTimeoutTimer->start(10000);
+    }
     gAccountManager->downloadByAccountID(gUosAccountItem->getAccount()->accountID());
 }
 
@@ -823,9 +851,13 @@ void CSettingDialog::slotSyncAccountStateUpdate(bool status)
     }
 }
 
-void CSettingDialog::slotLastSyncTimeUpdate(const QString &datetime)
+void CSettingDialog::updateSyncStatusDisplay(const QString &datetime,
+                                              DAccount::AccountSyncState state)
 {
-    qCDebug(ClientLogger) << "Last sync time updated:" << datetime;
+    if (!m_syncTimeLabel || !m_syncTimeValueLabel || !m_syncStatusIconLabel || !gUosAccountItem) {
+        return;
+    }
+
     QString dtstr;
     if (gCalendarManager->getTimeShowType()) {
         dtstr = dtFromString(datetime).toString("yyyy/MM/dd ap hh:mm");
@@ -833,11 +865,56 @@ void CSettingDialog::slotLastSyncTimeUpdate(const QString &datetime)
         dtstr = dtFromString(datetime).toString("yyyy/MM/dd hh:mm");
     }
 
-    if (m_syncTimeLabel && gUosAccountItem) {
-        m_syncTimeLabel->setText(dtstr.isEmpty()
-            ? tr("Last sync time")
-            : tr("Last sync time (%1)").arg(dtstr));
+    m_syncTimeLabel->setText(tr("Last sync time"));
+    const bool failed = state != DAccount::Sync_Normal;
+    if (!failed && dtstr.isEmpty()) {
+        m_syncTimeValueLabel->clear();
+        m_syncStatusIconLabel->hide();
+        return;
     }
+
+    if (failed) {
+        m_syncTimeValueLabel->setText(
+            QCoreApplication::translate("DCalDavSyncStatus", "Sync Failed"));
+    } else {
+        m_syncTimeValueLabel->setText(QStringLiteral("(%1)").arg(dtstr));
+    }
+    m_syncStatusIconLabel->setPixmap(QIcon(failed
+        ? QStringLiteral(":/icons/deepin/builtin/icons/dde_calendar_sync_failed_32px.svg")
+        : QStringLiteral(":/icons/deepin/builtin/icons/dde_calendar_sync_success_32px.svg"))
+        .pixmap(16, 16));
+    m_syncStatusIconLabel->show();
+}
+
+void CSettingDialog::slotLastSyncTimeUpdate(const QString &datetime)
+{
+    qCDebug(ClientLogger) << "Last sync time updated:" << datetime;
+    const DAccount::AccountSyncState state = gUosAccountItem
+        ? gUosAccountItem->getAccount()->syncState()
+        : DAccount::Sync_ServerException;
+    updateSyncStatusDisplay(datetime, state);
+}
+
+void CSettingDialog::slotSyncStateChange(DAccount::AccountSyncState state)
+{
+    if (m_syncTimeoutTimer) {
+        m_syncTimeoutTimer->stop();
+    }
+    if (!m_syncStatusIconLabel || !m_syncTimeValueLabel || !gUosAccountItem) {
+        return;
+    }
+
+    updateSyncStatusDisplay(gUosAccountItem->getDtLastUpdate(), state);
+}
+
+void CSettingDialog::slotSyncTimeout()
+{
+    qCWarning(ClientLogger) << "UOS account sync timed out";
+    if (!gUosAccountItem) {
+        return;
+    }
+
+    updateSyncStatusDisplay(gUosAccountItem->getDtLastUpdate(), DAccount::Sync_NetworkAnomaly);
 }
 
 void CSettingDialog::slotAccountStateChange()

--- a/src/calendar-client/src/dialog/settingdialog.h
+++ b/src/calendar-client/src/dialog/settingdialog.h
@@ -12,6 +12,7 @@
 #include <DSettingsDialog>
 #include <DIconButton>
 #include <DCommandLinkButton>
+#include <DLabel>
 
 DWIDGET_USE_NAMESPACE
 
@@ -19,6 +20,7 @@ class QAction;
 class QCheckBox;
 class QPushButton;
 class UserloginWidget;
+class QTimer;
 
 class CSettingDialog : public DSettingsDialog
 {
@@ -60,6 +62,8 @@ public slots:
     void slotSyncTagButtonUpdate();
     //点击同步项时，更新uos账户状态
     void slotSyncAccountStateUpdate(bool);
+    void slotSyncStateChange(DAccount::AccountSyncState state);
+    void slotSyncTimeout();
 
 private:
     void initFirstDayofWeekWidget();
@@ -78,6 +82,7 @@ private:
     void updateCalDavAddButtonVisibility();
 
     void setTypeEnable(int index);
+    void updateSyncStatusDisplay(const QString &datetime, DAccount::AccountSyncState state);
 private:
     void initWidget();
     void initConnect();
@@ -116,10 +121,13 @@ private:
 
     //手动同步按钮和同步时间显示
     QLabel *m_syncTimeLabel = nullptr;
+    DLabel *m_syncTimeValueLabel = nullptr;
+    QLabel *m_syncStatusIconLabel = nullptr;
     QPushButton *m_syncBtn = nullptr;
     QWidget *m_manualSyncWidget = nullptr;
     QWidget *m_uosSyncItemsWidget = nullptr;
     DOANetWorkDBus *m_ptrNetworkState;
+    QTimer *m_syncTimeoutTimer = nullptr;
     QCheckBox *m_radiobuttonAccountCalendar = nullptr;
     QCheckBox *m_radiobuttonAccountSetting = nullptr;
     ControlCenterProxy *m_controlCenterProxy;

--- a/src/calendar-client/src/widget/calendarmainwindow.cpp
+++ b/src/calendar-client/src/widget/calendarmainwindow.cpp
@@ -545,9 +545,10 @@ void Calendarmainwindow::initConnection()
     connect(m_titleWidget, &CTitleWidget::signalSidebarStatusChange, this, &Calendarmainwindow::slotSidebarStatusChange);
     //signalAccountUpdate
     connect(gAccountManager, &AccountManager::signalSyncNum, this, &Calendarmainwindow::slotShowSyncToast);
-    connect(gAccountManager, &AccountManager::signalAccountUpdate, this, &Calendarmainwindow::slotAccountUpdate);
     connect(gAccountManager, &AccountManager::signalCalDavScheduleCreateFailed, this,
             &Calendarmainwindow::slotCalDavScheduleCreateFailed);
+    connect(gAccountManager, &AccountManager::signalCalDavAccountStatusChanged, this,
+            &Calendarmainwindow::slotCalDavAccountStatusChanged);
 }
 
 void Calendarmainwindow::initData()
@@ -1151,11 +1152,10 @@ void Calendarmainwindow::slotapplicationStateChanged(Qt::ApplicationState state)
 void Calendarmainwindow::slotOpenSettingDialog()
 {
     qCDebug(ClientLogger) << "Calendarmainwindow::slotOpenSettingDialog";
-    m_dsdSetting = new CSettingDialog(this);
+    CSettingDialog settingDialog(this);
+    m_dsdSetting = &settingDialog;
     //内容定位到顶端
-    m_dsdSetting->exec();
-    //使用完后释放
-    delete m_dsdSetting;
+    settingDialog.exec();
     m_dsdSetting = nullptr;
     gCalendarManager->updateData();
 }
@@ -1184,10 +1184,11 @@ void Calendarmainwindow::slotShowPrivacy()
     QDesktopServices::openUrl(url);
 }
 
-void Calendarmainwindow::removeSyncToast()
+void Calendarmainwindow::removeSyncToast(QWidget *parent)
 {
     qCDebug(ClientLogger) << "Calendarmainwindow::removeSyncToast";
-    QWidget *content = this->window()->findChild<QWidget *>("_d_message_manager_content", Qt::FindDirectChildrenOnly);
+    QWidget *messageParent = parent ? parent : this->window();
+    QWidget *content = messageParent->findChild<QWidget *>("_d_message_manager_content", Qt::FindDirectChildrenOnly);
     if (nullptr == content) return;
     for (DFloatingMessage *message : content->findChildren<DFloatingMessage *>(QString(), Qt::FindDirectChildrenOnly)) {
         content->layout()->removeWidget(message);
@@ -1196,43 +1197,91 @@ void Calendarmainwindow::removeSyncToast()
     }
 }
 
+void Calendarmainwindow::removeAllSyncToasts()
+{
+    removeSyncToast();
+    if (m_dsdSetting) {
+        removeSyncToast(m_dsdSetting);
+    }
+}
+
+QWidget *Calendarmainwindow::syncToastParent() const
+{
+    return m_dsdSetting ? m_dsdSetting.data() : this->window();
+}
+
 void Calendarmainwindow::slotShowSyncToast(int syncNum)
 {
     qCDebug(ClientLogger) << "Showing sync toast" << "sync number:" << syncNum;
     //-1:正在刷新 0:正常 1:网络异常 2:服务器异常 3：存储已经满
-    static int preSyncNum = -2;
-    if (preSyncNum != syncNum && syncNum == -1) {
-        preSyncNum = -1;
-        //同步中
-        qCDebug(ClientLogger) << "Showing 'Syncing...' toast";
+    if (syncNum == -1) {
+        // The settings dialog shows the running state in the account row.
+        // Only show the running toast in the main window when the dialog is closed.
+        if (m_dsdSetting) {
+            removeAllSyncToasts();
+            return;
+        }
+        qCDebug(ClientLogger) << "Showing 'Syncing...' toast in the main window";
         removeSyncToast();
-        DMessageManager::instance()->sendMessage(this->window(), QIcon::fromTheme(":/icons/deepin/builtin/icons/dde_calendar_spinner_32px.svg"), tr("Syncing..."));
+        DMessageManager::instance()->sendMessage(
+            this->window(),
+            QIcon(QStringLiteral(":/icons/deepin/builtin/icons/dde_calendar_spinner_32px.svg")),
+            tr("Syncing..."));
         return;
     }
-    //
-    if (preSyncNum == -1 && syncNum != -1) {
-        preSyncNum = -2;
-        switch (syncNum) {
-        case 0: {
-            qCDebug(ClientLogger) << "Sync completed successfully";
-            //同步成功
-            removeSyncToast();
-            DMessageManager::instance()->sendMessage(this->window(), QIcon::fromTheme(":/icons/deepin/builtin/icons/dde_calendar_success_200px.png"), tr("Sync successful"));
-            break;
-        }
-        case 1:
-        case 2:
-        case 3: {
-            qCWarning(ClientLogger) << "Sync failed with error code:" << syncNum;
-            //同步失败
-            removeSyncToast();
-            DMessageManager::instance()->sendMessage(this->window(), QIcon::fromTheme(":/icons/deepin/builtin/icons/dde_calendar_fail_200px.png"), tr("Sync failed, please try later"));
-            break;
-        }
-        default:
-            break;
-        }
+
+    QWidget *messageParent = syncToastParent();
+
+    switch (syncNum) {
+    case 0:
+        qCDebug(ClientLogger) << "Sync completed successfully";
+        removeAllSyncToasts();
+        DMessageManager::instance()->sendMessage(
+            messageParent,
+            QIcon(QStringLiteral(":/icons/deepin/builtin/icons/dde_calendar_success_200px.png")),
+            tr("Sync successful"));
+        break;
+    case 1:
+    case 2:
+    case 3:
+        qCWarning(ClientLogger) << "Sync failed with error code:" << syncNum;
+        removeAllSyncToasts();
+        DMessageManager::instance()->sendMessage(
+            messageParent,
+            QIcon(QStringLiteral(":/icons/deepin/builtin/icons/dde_calendar_sync_failed_32px.svg")),
+            tr("Sync failed, please try later"));
+        break;
+    default:
+        break;
     }
+}
+
+void Calendarmainwindow::slotCalDavAccountStatusChanged(const QString &accountID)
+{
+    const DCalDavAccountStatus status = gAccountManager->getCalDavAccountStatus(accountID);
+    if (status.syncStatus == DCalDavSyncStatus::Succeeded) {
+        slotShowSyncToast(0);
+        return;
+    }
+
+    const bool failed = status.syncStatus == DCalDavSyncStatus::Failed
+        || status.syncStatus == DCalDavSyncStatus::AuthenticationRequired
+        || status.syncStatus == DCalDavSyncStatus::PermissionDenied
+        || status.syncStatus == DCalDavSyncStatus::RetryScheduled;
+    if (!failed) {
+        return;
+    }
+
+    const QString failureReason = !status.failureReason.isEmpty()
+        ? status.failureReason
+        : DCalDavSyncStatus::localizedFailureReason(
+              static_cast<DCalDavErrorCode>(status.failureCode));
+    QWidget *messageParent = syncToastParent();
+    removeAllSyncToasts();
+    DMessageManager::instance()->sendMessage(
+        messageParent,
+        QIcon(QStringLiteral(":/icons/deepin/builtin/icons/dde_calendar_sync_failed_32px.svg")),
+        failureReason);
 }
 
 void Calendarmainwindow::slotCalDavScheduleCreateFailed(const QString &accountID,
@@ -1274,16 +1323,7 @@ void Calendarmainwindow::slotCalDavScheduleCreateFailed(const QString &accountID
     message->setIcon(QIcon::fromTheme(QStringLiteral("dialog-error")));
     message->setMessage(toastText);
     message->setDuration(2000);
-    DMessageManager::instance()->sendMessage(window(), message);
-}
-
-void Calendarmainwindow::slotAccountUpdate()
-{
-    qCDebug(ClientLogger) << "Updating account information";
-    AccountItem::Ptr uidAccount = gUosAccountItem;
-    if (!uidAccount.isNull()) {
-        connect(uidAccount.get(), &AccountItem::signalSyncStateChange, this, &Calendarmainwindow::slotShowSyncToast);
-    }
+    DMessageManager::instance()->sendMessage(syncToastParent(), message);
 }
 
 void Calendarmainwindow::paintEvent(QPaintEvent *event)

--- a/src/calendar-client/src/widget/calendarmainwindow.h
+++ b/src/calendar-client/src/widget/calendarmainwindow.h
@@ -26,6 +26,7 @@
 #include <QObject>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QPointer>
 
 DWIDGET_USE_NAMESPACE
 class CYearWindow;
@@ -73,7 +74,9 @@ private:
     CDayWindow* ensureDayWindow();
     //重置界面大小
     void resizeView();
-    void removeSyncToast();
+    void removeSyncToast(QWidget *parent = nullptr);
+    void removeAllSyncToasts();
+    QWidget *syncToastParent() const;
 protected:
     void resizeEvent(QResizeEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -117,8 +120,8 @@ private slots:
 
     //显示同步提示
     void slotShowSyncToast(int syncNum);
+    void slotCalDavAccountStatusChanged(const QString &accountID);
 
-    void slotAccountUpdate();
     void slotCalDavScheduleCreateFailed(const QString &accountID, int createFailure);
 
 private:
@@ -142,7 +145,7 @@ private:
     QPropertyAnimation *m_animation = nullptr;
     QTimer *m_currentDateUpdateTimer = nullptr;
     DIconButton *m_newScheduleBtn {nullptr}; //全局的新建日程按钮
-    CSettingDialog *m_dsdSetting {nullptr};
+    QPointer<CSettingDialog> m_dsdSetting;
     JobTypeListView *m_jobTypeListView {nullptr};
     //日历打开默认显示视图
     int m_defaultIndex;

--- a/translations/dde-calendar.ts
+++ b/translations/dde-calendar.ts
@@ -809,9 +809,9 @@
             <translation>Last sync time</translation>
         </message>
         <message>
-            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="819" />
-            <source>Last sync time (%1)</source>
-            <translation>Last sync time (%1)</translation>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="794" />
+            <source>Syncing...</source>
+            <translation>Syncing...</translation>
         </message>
         <message>
             <source>Last sync: %1</source>
@@ -1051,11 +1051,6 @@
             <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="69" />
             <source>Last sync time</source>
             <translation>Last sync time</translation>
-        </message>
-        <message>
-            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="74" />
-            <source>Last sync time (%1)</source>
-            <translation>Last sync time (%1)</translation>
         </message>
         <message>
             <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="151" />
@@ -1324,6 +1319,11 @@
             <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76" />
             <source>Synchronization failed.</source>
             <translation>Synchronization failed.</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="855" />
+            <source>Sync Failed</source>
+            <translation>Sync Failed</translation>
         </message>
     </context>
     <context>

--- a/translations/dde-calendar_zh_CN.ts
+++ b/translations/dde-calendar_zh_CN.ts
@@ -757,9 +757,9 @@
             <translation>最近同步时间</translation>
         </message>
         <message>
-            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="819" />
-            <source>Last sync time (%1)</source>
-            <translation>最近同步时间（%1）</translation>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="794" />
+            <source>Syncing...</source>
+            <translation>同步中...</translation>
         </message>
         <message>
             <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="1049" />
@@ -1064,11 +1064,6 @@
             <translation>最近同步时间</translation>
         </message>
         <message>
-            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="74" />
-            <source>Last sync time (%1)</source>
-            <translation>最近同步时间（%1）</translation>
-        </message>
-        <message>
             <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="242" />
             <source>Sync conflict</source>
             <translation>同步冲突</translation>
@@ -1256,6 +1251,11 @@
         <message>
             <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76" />
             <source>Synchronization failed.</source>
+            <translation>同步失败</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="855" />
+            <source>Sync Failed</source>
             <translation>同步失败</translation>
         </message>
     </context>


### PR DESCRIPTION
Show sync states in account settings and route result to the active window. Display specific CalDAV failure reasons in result notifications.

在账户设置中显示同步状态，并将结果提示发送到当前窗口。
在同步失败提示中显示 CalDAV 的具体失败原因。

Log: 完善账户同步状态和结果提示
PMS: TASK-393989
Influence: 优化UOS ID和第三方CalDAV账户的同步状态及结果提示，
提升同步成功和失败信息的可见性。

## Summary by Sourcery

Improve account synchronization visibility and deliver contextual, reason-specific feedback in the active application window.

New Features:
- Display synchronization status, result icons, timestamps, and failure states for UOS ID and third-party CalDAV accounts in account settings.
- Show CalDAV-specific failure reasons in synchronization notifications.

Bug Fixes:
- Route synchronization notifications to the currently active window, including the settings dialog when it is open.
- Handle manual synchronization timeouts by presenting a network anomaly status.

Enhancements:
- Improve synchronization toast lifecycle and account status updates for running, successful, failed, and conflicting sync operations.