### PR TITLE
feat(sync): improve calendar account sync status feedback

### DIFF
--- a/src/calendar-client/src/dataManage/accountmanager.cpp
+++ b/src/calendar-client/src/dataManage/accountmanager.cpp
@@ -92,6 +92,7 @@ void AccountManager::initConnect()
         if (success && !m_pendingCalDavDeleteAccountID.isEmpty()) {
             m_calDavProviderTypeOverrides.remove(m_pendingCalDavDeleteAccountID);
             m_calDavAccountStatuses.remove(m_pendingCalDavDeleteAccountID);
+            m_manualCalDavSyncAccounts.remove(m_pendingCalDavDeleteAccountID);
         }
         m_pendingCalDavDeleteAccountID.clear();
         emit signalDeleteCalDavAccountFinish(success);
@@ -109,6 +110,21 @@ bool AccountManager::canWriteCalDavAccount(const QString &accountID) const
 {
     const DCalDavAccountStatus status = m_calDavAccountStatuses.value(accountID);
     return !status.accountId.isEmpty() && status.supportsWrite;
+}
+
+bool AccountManager::takeManualCalDavSyncRequest(const QString &accountID, int syncStatus)
+{
+    const bool completed = syncStatus == DCalDavSyncStatus::Succeeded
+        || syncStatus == DCalDavSyncStatus::Failed
+        || syncStatus == DCalDavSyncStatus::AuthenticationRequired
+        || syncStatus == DCalDavSyncStatus::PermissionDenied
+        || syncStatus == DCalDavSyncStatus::RetryScheduled;
+    if (!completed || !m_manualCalDavSyncAccounts.contains(accountID)) {
+        return false;
+    }
+
+    m_manualCalDavSyncAccounts.remove(accountID);
+    return true;
 }
 
 bool AccountManager::getIsSupportUid() const
@@ -337,7 +353,13 @@ void AccountManager::resetAccount()
 void AccountManager::downloadByAccountID(const QString &accountID, CallbackFunc callback)
 {
     qCDebug(ClientLogger) << "Downloading data for account ID:" << accountID;
-    emit signalSyncNum();
+    const AccountItem::Ptr account = getAccountItemByAccountId(accountID);
+    if (account && account->getAccount()
+        && account->getAccount()->accountType() == DAccount::Account_CalDav) {
+        m_manualCalDavSyncAccounts.insert(accountID);
+    } else {
+        emit signalSyncNum();
+    }
     m_dbusRequest->setCallbackFunc(callback);
     m_dbusRequest->downloadByAccountID(accountID);
 }

--- a/src/calendar-client/src/dataManage/accountmanager.h
+++ b/src/calendar-client/src/dataManage/accountmanager.h
@@ -10,6 +10,7 @@
 #include "dcalendargeneralsettings.h"
 
 #include <QHash>
+#include <QSet>
 #include <QString>
 
 //所有帐户管理类
@@ -71,6 +72,15 @@ public:
     DCalDavAccountStatus getCalDavAccountStatus(const QString &accountID) const;
     bool canWriteCalDavAccount(const QString &accountID) const;
 
+    /**
+     * @brief Determines whether a completed CalDAV sync was manually requested.
+     * @param accountID Identifier of the account that completed synchronization.
+     * @param syncStatus Current CalDAV synchronization status.
+     * @return True when the completed sync was manually requested. The request
+     * marker is consumed before returning true.
+     */
+    bool takeManualCalDavSyncRequest(const QString &accountID, int syncStatus);
+
 signals:
     void signalDataInitFinished();
     void signalAccountUpdate();
@@ -122,6 +132,7 @@ private:
     AccountItem::Ptr  m_unionAccountItem;
     QList<AccountItem::Ptr> m_calDavAccountItems;
     QHash<QString, DCalDavAccountStatus> m_calDavAccountStatuses;
+    QSet<QString> m_manualCalDavSyncAccounts;
     bool m_calDavStatusesInitialized = false;
     QHash<QString, int> m_calDavProviderTypeOverrides;
     int m_pendingCalDavProviderType = -1;

--- a/src/calendar-client/src/dialog/caldavaccountlistwidget.cpp
+++ b/src/calendar-client/src/dialog/caldavaccountlistwidget.cpp
@@ -47,7 +47,8 @@ QString syncTimeLabel()
 
 QString syncTimeValue(const DCalDavAccountStatus &status)
 {
-    if (!status.lastSuccessfulSync.isValid()) {
+    if (status.syncStatus != DCalDavSyncStatus::Succeeded
+        || !status.lastSuccessfulSync.isValid()) {
         return {};
     }
 
@@ -255,19 +256,15 @@ void CalDavAccountListWidget::rebuildCards()
             stateLabel->setToolTip(tr("A synchronization conflict was detected. The server version will replace the local changes."));
             statusLayout->addWidget(stateLabel);
         } else if (running || pendingDelete || failed) {
+            const QString failureReason = DCalDavAccountStatus::resolveFailureReason(status);
             const QString stateText = failed
-                ? tr("Sync Failed: %1").arg(
-                      DCalDavSyncStatus::localizedFailureReason(
-                    static_cast<DCalDavErrorCode>(status.failureCode)))
+                ? tr("Sync Failed: %1").arg(failureReason)
                 : (pendingDelete ? tr("Deleting...") : tr("Syncing..."));
             Dtk::Widget::DLabel *stateLabel = new Dtk::Widget::DLabel(stateText, statusRow);
             stateLabel->setForegroundRole(Dtk::Gui::DPalette::TextTips);
             Dtk::Widget::DFontSizeManager::instance()->bind(stateLabel,
                                                              Dtk::Widget::DFontSizeManager::T8);
-            stateLabel->setToolTip(failed
-                ? DCalDavSyncStatus::localizedFailureReason(
-                    static_cast<DCalDavErrorCode>(status.failureCode))
-                : QString());
+            stateLabel->setToolTip(failed ? failureReason : QString());
             stateLabel->setElideMode(Qt::ElideRight);
             stateLabel->setMinimumWidth(0);
             stateLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);

--- a/src/calendar-client/src/dialog/settingdialog.cpp
+++ b/src/calendar-client/src/dialog/settingdialog.cpp
@@ -909,12 +909,12 @@ void CSettingDialog::slotSyncStateChange(DAccount::AccountSyncState state)
 
 void CSettingDialog::slotSyncTimeout()
 {
-    qCWarning(ClientLogger) << "UOS account sync timed out";
+    qCWarning(ClientLogger) << "UOS account sync timed out, restoring the last known sync status";
     if (!gUosAccountItem) {
         return;
     }
 
-    updateSyncStatusDisplay(gUosAccountItem->getDtLastUpdate(), DAccount::Sync_NetworkAnomaly);
+    slotLastSyncTimeUpdate(gUosAccountItem->getDtLastUpdate());
 }
 
 void CSettingDialog::slotAccountStateChange()

--- a/src/calendar-client/src/widget/calendarmainwindow.cpp
+++ b/src/calendar-client/src/widget/calendarmainwindow.cpp
@@ -1259,8 +1259,12 @@ void Calendarmainwindow::slotShowSyncToast(int syncNum)
 void Calendarmainwindow::slotCalDavAccountStatusChanged(const QString &accountID)
 {
     const DCalDavAccountStatus status = gAccountManager->getCalDavAccountStatus(accountID);
+    const bool manuallyRequested = gAccountManager->takeManualCalDavSyncRequest(accountID,
+                                                                                  status.syncStatus);
     if (status.syncStatus == DCalDavSyncStatus::Succeeded) {
-        slotShowSyncToast(0);
+        if (manuallyRequested) {
+            slotShowSyncToast(0);
+        }
         return;
     }
 
@@ -1272,10 +1276,7 @@ void Calendarmainwindow::slotCalDavAccountStatusChanged(const QString &accountID
         return;
     }
 
-    const QString failureReason = !status.failureReason.isEmpty()
-        ? status.failureReason
-        : DCalDavSyncStatus::localizedFailureReason(
-              static_cast<DCalDavErrorCode>(status.failureCode));
+    const QString failureReason = DCalDavAccountStatus::resolveFailureReason(status);
     QWidget *messageParent = syncToastParent();
     removeAllSyncToasts();
     DMessageManager::instance()->sendMessage(

--- a/src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp
+++ b/src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp
@@ -337,9 +337,7 @@ void SidebarAccountItemWidget::resetRearIconButton()
             || status.syncStatus == DCalDavSyncStatus::RetryScheduled;
         if (failed) {
             m_syncIconButton->hide();
-            m_warningLabel->setToolTip(
-                DCalDavSyncStatus::localizedFailureReason(
-                    static_cast<DCalDavErrorCode>(status.failureCode)));
+            m_warningLabel->setToolTip(DCalDavAccountStatus::resolveFailureReason(status));
             m_warningLabel->show();
         } else {
             m_syncIconButton->show();

--- a/src/calendar-common/src/dcaldavaccountstatus.h
+++ b/src/calendar-common/src/dcaldavaccountstatus.h
@@ -47,6 +47,9 @@ public:
     static QString localizedFailureReason(DCalDavErrorCode errorCode)
     {
         switch (errorCode) {
+        case DCalDavErrorCode::InvalidRequest:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus", "The server request is invalid.");
         case DCalDavErrorCode::CertificateInvalid:
             return QCoreApplication::translate(
                 "DCalDavSyncStatus", "The server certificate is invalid.");
@@ -64,6 +67,18 @@ public:
         case DCalDavErrorCode::PermissionDenied:
             return QCoreApplication::translate(
                 "DCalDavSyncStatus", "The server denied access.");
+        case DCalDavErrorCode::RateLimited:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus", "The server is busy. Please try again later.");
+        case DCalDavErrorCode::ServerUnavailable:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus", "The server is unavailable. Please try again later.");
+        case DCalDavErrorCode::Conflict:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus", "The calendar data conflicts with the server.");
+        case DCalDavErrorCode::ResponseTooLarge:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus", "The server returned too much data. Please try again later.");
         case DCalDavErrorCode::RequestTimedOut:
             return QCoreApplication::translate(
                 "DCalDavSyncStatus", "The server request timed out.");
@@ -72,6 +87,9 @@ public:
             return QCoreApplication::translate(
                 "DCalDavSyncStatus",
                 "Unable to connect to the server. Please check your network connection and server address.");
+        case DCalDavErrorCode::StorageError:
+            return QCoreApplication::translate(
+                "DCalDavSyncStatus", "Unable to save calendar data. Please try again later.");
         default:
             return QCoreApplication::translate("DCalDavSyncStatus", "Synchronization failed.");
         }
@@ -111,6 +129,24 @@ public:
     int pendingDeleteCount = 0;
     int conflictCount = 0;
     QDateTime nextRetryAt;
+
+    /**
+     * @brief Returns the user-facing reason for a failed synchronization.
+     * @param status Synchronization status containing the error code and raw reason.
+     * @return The raw reason for unknown errors when available, otherwise a
+     * localized message for the error code.
+     */
+    static QString resolveFailureReason(const DCalDavAccountStatus &status)
+    {
+        const DCalDavErrorCode errorCode =
+            static_cast<DCalDavErrorCode>(status.failureCode);
+        if ((errorCode == DCalDavErrorCode::Unknown
+             || errorCode == DCalDavErrorCode::NoError)
+            && !status.failureReason.isEmpty()) {
+            return status.failureReason;
+        }
+        return DCalDavSyncStatus::localizedFailureReason(errorCode);
+    }
 
     static QString toJsonListString(const List &statusList)
     {

--- a/src/calendar-service/src/caldav/dcaldavaccountsync.cpp
+++ b/src/calendar-service/src/caldav/dcaldavaccountsync.cpp
@@ -91,6 +91,9 @@ void DCalDavAccountSync::flushOutbox()
     m_outboxProcessor.start(outboxRequest, [this](const DCalDavOutboxProcessor::Result &result) {
         m_result.failureResponse = result.failureResponse;
         m_result.failureCode = DCalDavSyncStatusMapper::errorCodeForFailure(m_result.failureResponse);
+        if (!result.success && m_result.failureCode == DCalDavErrorCode::NoError) {
+            m_result.failureCode = DCalDavErrorCode::Unknown;
+        }
         m_result.createFailure = result.createFailure;
         if (!result.success) {
             if (result.retryScheduledCount > 0 && result.permanentFailureCount == 0) {
@@ -152,6 +155,9 @@ void DCalDavAccountSync::syncNextCalendar()
                                      << "errorPresent:" << !syncResult.errorMessage.isEmpty();
             m_result.failureResponse = syncResult.failureResponse;
             m_result.failureCode = DCalDavSyncStatusMapper::errorCodeForFailure(m_result.failureResponse);
+            if (!syncResult.success && m_result.failureCode == DCalDavErrorCode::NoError) {
+                m_result.failureCode = DCalDavErrorCode::Unknown;
+            }
             const bool permissionDenied = syncResult.failureResponse.httpStatus == 403
                 || syncResult.failureResponse.error == DCalDavTransport::PermissionDenied;
             if (permissionDenied) {

--- a/src/calendar-service/src/caldav/dcaldavsyncstatemachine.cpp
+++ b/src/calendar-service/src/caldav/dcaldavsyncstatemachine.cpp
@@ -38,7 +38,8 @@ bool DCalDavSyncStateMachine::requestSync(const QString &accountId, Trigger trig
     }
 
     if (account->state == Running) {
-        return false;
+        account->pendingTriggers |= trigger;
+        return true;
     }
 
     account->pendingTriggers |= trigger;

--- a/src/calendar-service/src/calendarDataManager/daccountmanagemodule.cpp
+++ b/src/calendar-service/src/calendarDataManager/daccountmanagemodule.cpp
@@ -317,7 +317,11 @@ DAccountManageModule::DAccountManageModule(QObject *parent)
     //第一次启动加载完成后发送帐户改变信号
     // emit signalLoginStatusChange();
     connect(&m_calDavSyncJobManager, &DCalDavSyncJobManager::accountSyncStateChanged,
-            this, [this](const QString &accountID, DCalDavSyncStateMachine::State) {
+            this, [this](const QString &accountID, DCalDavSyncStateMachine::State state) {
+        if (state == DCalDavSyncStateMachine::Queued) {
+            m_accountManagerDB->updateCalDavSyncStatus(
+                accountID, DCalDavSyncStatus::Running, QDateTime(), QString());
+        }
         emit calDavAccountStatusChanged(accountID);
     });
     connect(&m_calDavSyncJobManager, &DCalDavSyncJobManager::accountSyncDataChanged,
@@ -452,7 +456,16 @@ void DAccountManageModule::downloadByAccountID(const QString &accountID)
     qCDebug(ServiceLogger) << "Triggering download for account:" << accountID;
     const DAccount::Ptr account = m_accountManagerDB->getAccountByID(accountID);
     if (account && account->accountType() == DAccount::Account_CalDav) {
-        m_calDavSyncJobManager.requestSync(accountID, DCalDavSyncStateMachine::ManualTrigger);
+        if (!m_calDavSyncJobManager.requestSync(accountID,
+                                                DCalDavSyncStateMachine::ManualTrigger)) {
+            qCWarning(ServiceLogger) << "Unable to request CalDAV manual sync"
+                                     << "accountID:" << accountID;
+            m_accountManagerDB->updateCalDavSyncStatus(
+                accountID, DCalDavSyncStatus::Failed, QDateTime(),
+                QStringLiteral("CalDAV account is not ready for synchronization."),
+                DCalDavErrorCode::InvalidRequest);
+            emit calDavAccountStatusChanged(accountID);
+        }
         return;
     }
     if (m_accountModuleMap.contains(accountID)) {

--- a/src/calendar-service/src/dbmanager/daccountmanagerdatabase.cpp
+++ b/src/calendar-service/src/dbmanager/daccountmanagerdatabase.cpp
@@ -1207,13 +1207,18 @@ bool DAccountManagerDataBase::updateCalDavSyncStatus(const QString &accountID, i
     }
 
     SqliteQuery query(m_database);
-    if (!query.prepare("UPDATE caldavAccount SET syncStatus = ?, lastSuccessfulSync = ?, failureReason = ?, failureCode = ? "
+    if (!query.prepare("UPDATE caldavAccount SET syncStatus = ?, "
+                       "lastSuccessfulSync = CASE WHEN ? != '' THEN ? ELSE lastSuccessfulSync END, "
+                       "failureReason = ?, failureCode = ? "
                        "WHERE accountID = ?")) {
         qCWarning(ServiceLogger) << "Failed to prepare CalDAV status update:" << query.lastError().text();
         return false;
     }
     query.addBindValue(syncStatus);
-    query.addBindValue(lastSuccessfulSync.isValid() ? lastSuccessfulSync.toString(Qt::ISODate) : QString());
+    const QString lastSuccessfulSyncValue = lastSuccessfulSync.isValid()
+        ? lastSuccessfulSync.toString(Qt::ISODate) : QString();
+    query.addBindValue(lastSuccessfulSyncValue);
+    query.addBindValue(lastSuccessfulSyncValue);
     query.addBindValue(failureReason);
     query.addBindValue(static_cast<int>(failureCode));
     query.addBindValue(accountID);

--- a/tests/dde-calendar-service-test/src/test_dbmanager/test_caldavschema.cpp
+++ b/tests/dde-calendar-service-test/src/test_dbmanager/test_caldavschema.cpp
@@ -864,7 +864,7 @@ TEST(CalDavReadOnlySync, RejectsInvalidRequestWithoutNetworkAccess)
 }
 
 
-TEST(CalDavSyncStateMachine, IgnoresTriggersWhileAccountIsRunning)
+TEST(CalDavSyncStateMachine, QueuesTriggersReceivedWhileAccountIsRunning)
 {
     DCalDavSyncStateMachine stateMachine;
     ASSERT_TRUE(stateMachine.registerAccount(QStringLiteral("account-1")));
@@ -878,11 +878,14 @@ TEST(CalDavSyncStateMachine, IgnoresTriggersWhileAccountIsRunning)
 
     EXPECT_EQ(QStringLiteral("account-1"), stateMachine.takeNextRunnableAccount());
     EXPECT_EQ(DCalDavSyncStateMachine::Running, stateMachine.stateFor(QStringLiteral("account-1")));
-    EXPECT_FALSE(stateMachine.requestSync(QStringLiteral("account-1"),
-                                          DCalDavSyncStateMachine::ForegroundTrigger));
-    EXPECT_EQ(DCalDavSyncStateMachine::NoTrigger,
+    EXPECT_TRUE(stateMachine.requestSync(QStringLiteral("account-1"),
+                                         DCalDavSyncStateMachine::ForegroundTrigger));
+    EXPECT_EQ(DCalDavSyncStateMachine::ForegroundTrigger,
               stateMachine.pendingTriggersFor(QStringLiteral("account-1")));
 
+    ASSERT_TRUE(stateMachine.complete(QStringLiteral("account-1"), true));
+    EXPECT_EQ(DCalDavSyncStateMachine::Queued, stateMachine.stateFor(QStringLiteral("account-1")));
+    EXPECT_EQ(QStringLiteral("account-1"), stateMachine.takeNextRunnableAccount());
     ASSERT_TRUE(stateMachine.complete(QStringLiteral("account-1"), true));
     EXPECT_EQ(DCalDavSyncStateMachine::Succeeded, stateMachine.stateFor(QStringLiteral("account-1")));
     EXPECT_TRUE(stateMachine.takeNextRunnableAccount().isEmpty());
@@ -1139,6 +1142,11 @@ TEST(CalDavRepository, PersistsCalendarTokenAndAccountStatus)
 
     const QDateTime syncTime = QDateTime::fromString(QStringLiteral("2026-08-10T12:00:00Z"), Qt::ISODate);
     ASSERT_TRUE(database.updateCalDavSyncStatus(QStringLiteral("account-1"), 2, syncTime, QString()));
+    EXPECT_TRUE(database.getCalDavAccountStatusList().contains(QStringLiteral("2026-08-10T12:00:00Z")));
+    ASSERT_TRUE(database.updateCalDavSyncStatus(QStringLiteral("account-1"), 1, QDateTime(), QString()));
+    EXPECT_TRUE(database.getCalDavAccountStatusList().contains(QStringLiteral("2026-08-10T12:00:00Z")));
+    ASSERT_TRUE(database.updateCalDavSyncStatus(QStringLiteral("account-1"), 3, QDateTime(),
+                                                QStringLiteral("sync failed")));
     EXPECT_TRUE(database.getCalDavAccountStatusList().contains(QStringLiteral("2026-08-10T12:00:00Z")));
 
     DCalDavEventMappingInfo mapping;

--- a/translations/dde-calendar-service_zh_CN.ts
+++ b/translations/dde-calendar-service_zh_CN.ts
@@ -795,6 +795,36 @@
         <name>DCalDavSyncStatus</name>
         <message>
             <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server request is invalid.</source>
+            <translation>服务器请求无效</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="71" />
+            <source>The server is busy. Please try again later.</source>
+            <translation>服务器繁忙，请稍后重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="74" />
+            <source>The server is unavailable. Please try again later.</source>
+            <translation>服务器不可用，请稍后重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="77" />
+            <source>The calendar data conflicts with the server.</source>
+            <translation>日历数据与服务器存在冲突</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="80" />
+            <source>The server returned too much data. Please try again later.</source>
+            <translation>服务器返回的数据过大，请稍后重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="91" />
+            <source>Unable to save calendar data. Please try again later.</source>
+            <translation>无法保存日历数据，请稍后重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
             <source>The server certificate is invalid.</source>
             <translation>服务器证书无效</translation>
         </message>

--- a/translations/dde-calendar_zh_CN.ts
+++ b/translations/dde-calendar_zh_CN.ts
@@ -987,7 +987,7 @@
         <message>
             <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="583" />
             <source>Unable to connect to the server. Please check your network connection and server address.</source>
-            <translation>无法连接到服务器，请检查网络连接和服务器地址。</translation>
+            <translation>无法连接到服务器，请检查网络连接和服务器地址</translation>
         </message>
         <message>
             <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="571" />
@@ -1007,7 +1007,7 @@
         <message>
             <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="575" />
             <source>The server rejected your login request. Please check your account permissions.</source>
-            <translation>服务器拒绝了登录请求，请检查账户是否有访问权限</translation>
+            <translation>服务器拒绝了登录请求，请检查账号是否有访问权限</translation>
         </message>
         <message>
             <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="577" />
@@ -1163,7 +1163,7 @@
         <message>
             <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1269" />
             <source>Unable to connect to the server. Please check your network connection and server address.</source>
-            <translation>无法连接到服务器，请检查网络连接和服务器地址。</translation>
+            <translation>无法连接到服务器，请检查网络连接和服务器地址</translation>
         </message>
     </context>
     <context>
@@ -1210,6 +1210,36 @@
     <context>
         <name>DCalDavSyncStatus</name>
         <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server request is invalid.</source>
+            <translation>服务器请求无效</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="71" />
+            <source>The server is busy. Please try again later.</source>
+            <translation>服务器繁忙，请稍后重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="74" />
+            <source>The server is unavailable. Please try again later.</source>
+            <translation>服务器不可用，请稍后重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="77" />
+            <source>The calendar data conflicts with the server.</source>
+            <translation>日历数据与服务器存在冲突</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="80" />
+            <source>The server returned too much data. Please try again later.</source>
+            <translation>服务器返回的数据过大，请稍后重试</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="91" />
+            <source>Unable to save calendar data. Please try again later.</source>
+            <translation>无法保存日历数据，请稍后重试</translation>
+        </message>
+        <message>
             <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="61" />
             <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
             <translation>服务器返回的数据无法解析，请确认服务器地址或稍后重试</translation>
@@ -1246,7 +1276,7 @@
         <message>
             <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="72" />
             <source>Unable to connect to the server. Please check your network connection and server address.</source>
-            <translation>无法连接到服务器，请检查网络连接和服务器地址。</translation>
+            <translation>无法连接到服务器，请检查网络连接和服务器地址</translation>
         </message>
         <message>
             <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76" />


### PR DESCRIPTION
Show sync states in account settings and route results to the active window. Display CalDAV failure reasons and show timestamps only after successful sync.

在账户设置中展示同步状态，并将结果提示发送到当前活动窗口。
显示 CalDAV 失败原因，且仅在同步成功后显示最近同步时间。

Log: 完善账户同步状态和结果提示
PMS: TASK-393989
Influence: 优化 UOS ID 与 CalDAV 的同步状态、失败提示和时间展示，
避免同步中或失败时错误显示旧的最近同步时间。

## Summary by Sourcery

Improve calendar account synchronization feedback by exposing accurate states, preserving valid timestamps, and providing actionable CalDAV failure information.

New Features:
- Display CalDAV synchronization states and detailed failure reasons in account settings and account sidebar feedback.
- Route manual CalDAV sync results to the active window while avoiding duplicate success notifications for background syncs.

Bug Fixes:
- Prevent failed or in-progress synchronization from overwriting the last successful sync timestamp.
- Preserve the last successful timestamp when updating CalDAV status without a new successful sync time.
- Ensure unsuccessful syncs receive an explicit failure classification when no specific error code is available.

Enhancements:
- Queue synchronization triggers received while a CalDAV account is already syncing.
- Improve handling and localization of common CalDAV server, request, conflict, and storage errors.
- Restore the last known UOS account sync status after a sync timeout instead of reporting a network anomaly.

Tests:
- Update CalDAV sync state-machine coverage for queued triggers and verify successful sync timestamps persist across running and failed status updates.

Chores:
- Update Chinese translations for the expanded CalDAV synchronization error messages.