### PR TITLE
fix(caldav): defer account discovery until client opens

### DIFF
--- a/src/calendar-client/src/dataManage/accountmanager.cpp
+++ b/src/calendar-client/src/dataManage/accountmanager.cpp
@@ -13,7 +13,6 @@ AccountManager::AccountManager(QObject *parent)
 {
     qCDebug(ClientLogger) << "Creating AccountManager";
     initConnect();
-    m_dbusRequest->clientIsShow(true);
     m_dbusRequest->getCalDavAccountStatusList();
 
     if (isCommunityEdition()) {
@@ -34,6 +33,12 @@ void AccountManager::initConnect()
     connect(m_dbusRequest, &DbusAccountManagerRequest::signalGetIsSupportUidFinish, this, &AccountManager::slotGetIsSupportUidFinish);
     connect(m_dbusRequest, &DbusAccountManagerRequest::signalGetCalDavAccountStatusListFinish,
             this, &AccountManager::slotGetCalDavAccountStatusListFinish);
+    connect(m_dbusRequest, &DbusAccountManagerRequest::signalCalDavAccountStatusRefreshRequested,
+            this, [this](const QString &accountID) {
+        if (!m_calDavStatusesInitialized && !accountID.isEmpty()) {
+            m_pendingCalDavStatusChanges.insert(accountID);
+        }
+    });
     connect(m_dbusRequest, &DbusAccountManagerRequest::signalValidateCalDavAccountStart,
             this, [this](const QString &requestID) {
         qCDebug(ClientLogger) << "Forwarding CalDAV validation start"
@@ -156,10 +161,18 @@ void AccountManager::slotGetCalDavAccountStatusListFinish(DCalDavAccountStatus::
     m_calDavStatusesInitialized = true;
     if (!shouldNotifyChanges) {
         // The initial snapshot is intentionally not exposed as a status-change
-        // event, otherwise persisted failures could trigger stale toasts. The
-        // settings page still needs a separate notification to refresh actions
-        // that depend on supportsWrite.
+        // event, otherwise persisted failures could trigger stale toasts. A
+        // status-change signal received before this snapshot, however, belongs
+        // to a live service event and must not be swallowed by initialization.
+        const QSet<QString> pendingStatusChanges = m_pendingCalDavStatusChanges;
+        m_pendingCalDavStatusChanges.clear();
         emit signalCalDavAccountStatusReady();
+        for (const QString &accountID : pendingStatusChanges) {
+            if (updatedStatuses.contains(accountID)) {
+                emit signalCalDavAccountStatusChanged(accountID);
+            }
+        }
+        maybeNotifyClientIsShow();
         return;
     }
 
@@ -183,6 +196,18 @@ void AccountManager::slotGetCalDavAccountStatusListFinish(DCalDavAccountStatus::
         }
     }
     emit signalCalDavAccountStatusReady();
+    maybeNotifyClientIsShow();
+}
+
+void AccountManager::maybeNotifyClientIsShow()
+{
+    if (!m_clientShowRequested || m_clientShowNotified || !m_calDavStatusesInitialized) {
+        return;
+    }
+
+    qCDebug(ClientLogger) << "Notifying account service that calendar is shown";
+    m_clientShowNotified = true;
+    m_dbusRequest->clientIsShow(true);
 }
 
 void AccountManager::slotGetIsSupportUidFinish(bool supported)
@@ -344,6 +369,12 @@ void AccountManager::resetAccount()
     m_dbusRequest->getCalendarGeneralSettings();
 }
 
+void AccountManager::notifyClientIsShow()
+{
+    m_clientShowRequested = true;
+    maybeNotifyClientIsShow();
+}
+
 /**
  * @brief AccountManager::downloadByAccountID
  * 根据帐户ID下拉数据
@@ -358,6 +389,10 @@ void AccountManager::downloadByAccountID(const QString &accountID, CallbackFunc 
         && account->getAccount()->accountType() == DAccount::Account_CalDav) {
         m_manualCalDavSyncAccounts.insert(accountID);
     } else {
+        if (account && account->getAccount()
+            && account->getAccount()->accountType() == DAccount::Account_UnionID) {
+            m_manualUnionSyncAccounts.insert(accountID);
+        }
         emit signalSyncNum();
     }
     m_dbusRequest->setCallbackFunc(callback);
@@ -533,12 +568,21 @@ void AccountManager::slotGetAccountListFinish(DAccount::List accountList)
             } else if (m_unionAccountItem->getAccount()->accountID() != account->accountID()) {
                 qCDebug(ClientLogger) << "Union account ID changed, creating new union account item";
                 emit m_unionAccountItem->signalLogout(m_unionAccountItem->getAccount()->accountType());
+                m_manualUnionSyncAccounts.remove(m_unionAccountItem->getAccount()->accountID());
                 m_unionAccountItem.reset(new AccountItem(account, this));
                 unionAccountChanged = true;
             }
             if (unionAccountChanged) {
+                const QString unionAccountID = m_unionAccountItem->getAccount()->accountID();
                 connect(m_unionAccountItem.data(), &AccountItem::signalSyncStateChange,
-                        this, [this](DAccount::AccountSyncState state) {
+                        this, [this, unionAccountID](DAccount::AccountSyncState state) {
+                    // Automatic syncs stay silent on success, while failures
+                    // always notify. Manual sync results also notify.
+                    const bool manuallyRequested =
+                        m_manualUnionSyncAccounts.remove(unionAccountID) > 0;
+                    if (state == DAccount::Sync_Normal && !manuallyRequested) {
+                        return;
+                    }
                     emit signalSyncNum(static_cast<int>(state));
                 });
             }
@@ -566,6 +610,7 @@ void AccountManager::slotGetAccountListFinish(DAccount::List accountList)
     if (!hasUnionAccount && m_unionAccountItem) {
         qCDebug(ClientLogger) << "No union account in list but union account item exists, clearing it";
         emit m_unionAccountItem->signalLogout(m_unionAccountItem->getAccount()->accountType());
+        m_manualUnionSyncAccounts.clear();
         m_unionAccountItem.reset(nullptr);
     }
 

--- a/src/calendar-client/src/dataManage/accountmanager.h
+++ b/src/calendar-client/src/dataManage/accountmanager.h
@@ -33,6 +33,9 @@ public:
     //重新获取帐户信息
     void resetAccount();
 
+    //通知服务端客户端已显示，触发启动后的同步
+    void notifyClientIsShow();
+
     //根据帐户ID下拉数据
     void downloadByAccountID(const QString &accountID, CallbackFunc callback = nullptr);
     //更新网络帐户数据
@@ -125,6 +128,7 @@ protected:
 
 private:
     void initConnect();
+    void maybeNotifyClientIsShow();
 
 private:
     static AccountManager *m_accountManager;
@@ -133,7 +137,11 @@ private:
     QList<AccountItem::Ptr> m_calDavAccountItems;
     QHash<QString, DCalDavAccountStatus> m_calDavAccountStatuses;
     QSet<QString> m_manualCalDavSyncAccounts;
+    QSet<QString> m_manualUnionSyncAccounts;
+    QSet<QString> m_pendingCalDavStatusChanges;
     bool m_calDavStatusesInitialized = false;
+    bool m_clientShowRequested = false;
+    bool m_clientShowNotified = false;
     QHash<QString, int> m_calDavProviderTypeOverrides;
     int m_pendingCalDavProviderType = -1;
     QString m_pendingCalDavDeleteAccountID;

--- a/src/calendar-client/src/dbus/dbusaccountmanagerrequest.cpp
+++ b/src/calendar-client/src/dbus/dbusaccountmanagerrequest.cpp
@@ -415,6 +415,8 @@ void DbusAccountManagerRequest::slotDbusCall(const QDBusMessage &msg)
         qCDebug(ClientLogger) << "Account update signal received, refreshing account list";
         getAccountList();
     } else if (msg.member() == "calDavAccountStatusChanged") {
+        emit signalCalDavAccountStatusRefreshRequested(
+            msg.arguments().value(0).toString());
         getCalDavAccountStatusList();
     } else if (msg.member() == "calDavAccountValidationFinished") {
         const QString requestID = msg.arguments().value(0).toString();

--- a/src/calendar-client/src/dbus/dbusaccountmanagerrequest.h
+++ b/src/calendar-client/src/dbus/dbusaccountmanagerrequest.h
@@ -74,6 +74,7 @@ signals:
     //获取是否支持UID完成信号
     void signalGetIsSupportUidFinish(bool supported);
     void signalGetCalDavAccountStatusListFinish(DCalDavAccountStatus::List statusList);
+    void signalCalDavAccountStatusRefreshRequested(const QString &accountID);
     void signalGetCalDavAccountConfigFinish(const QString &config);
     void signalValidateCalDavAccountForUpdateStart(const QString &requestID);
     void signalValidateCalDavAccountStart(const QString &requestID);

--- a/src/calendar-client/src/widget/calendarmainwindow.cpp
+++ b/src/calendar-client/src/widget/calendarmainwindow.cpp
@@ -1335,3 +1335,17 @@ void Calendarmainwindow::paintEvent(QPaintEvent *event)
         QTimer::singleShot(0, this, &Calendarmainwindow::startDeferredViewDataInit);
     }
 }
+
+void Calendarmainwindow::showEvent(QShowEvent *event)
+{
+    DMainWindow::showEvent(event);
+    if (m_clientShowSyncScheduled) {
+        return;
+    }
+
+    m_clientShowSyncScheduled = true;
+    // Let the first UI/data work settle before starting network synchronization.
+    constexpr int kStartupSyncDelayMs = 500;
+    QTimer::singleShot(kStartupSyncDelayMs, gAccountManager,
+                       &AccountManager::notifyClientIsShow);
+}

--- a/src/calendar-client/src/widget/calendarmainwindow.h
+++ b/src/calendar-client/src/widget/calendarmainwindow.h
@@ -84,6 +84,7 @@ protected:
     void mousePressEvent(QMouseEvent *event) override;
     bool event(QEvent *event) override;
     void paintEvent(QPaintEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 private slots:
     //获取程序状态
     void slotapplicationStateChanged(Qt::ApplicationState state);
@@ -156,6 +157,7 @@ private:
     CMyScheduleView *m_dlg = Q_NULLPTR;
 
     bool m_firstPaintDone = false;
+    bool m_clientShowSyncScheduled = false;
     bool m_deferredViewDataInitDone = false;
     bool m_hasInit = false;
 };

--- a/src/calendar-service/src/caldav/dcaldavaccountregistrar.cpp
+++ b/src/calendar-service/src/caldav/dcaldavaccountregistrar.cpp
@@ -142,8 +142,10 @@ void DCalDavAccountRegistrar::start(const Request &request, const Callback &call
                    DCalDavTransport::Response(), DCalDavErrorCode::Unknown);
             return;
         }
-        m_request.jobManager->requestSync(
-            m_request.account.accountId, DCalDavSyncStateMachine::StartupTrigger);
+        if (m_request.triggerInitialSync) {
+            m_request.jobManager->requestSync(
+                m_request.account.accountId, DCalDavSyncStateMachine::StartupTrigger);
+        }
         finish(true);
     });
 }

--- a/src/calendar-service/src/caldav/dcaldavaccountregistrar.h
+++ b/src/calendar-service/src/caldav/dcaldavaccountregistrar.h
@@ -27,6 +27,9 @@ public:
         DAccountDataBase *localDatabase = nullptr;
         DAccountManagerDataBase *accountManagerDatabase = nullptr;
         DCalDavSyncJobManager *jobManager = nullptr;
+        // Existing accounts are registered at service startup and synced after
+        // the client reports that its window is shown.
+        bool triggerInitialSync = true;
     };
 
     struct Result {

--- a/src/calendar-service/src/calendarDataManager/daccountmanagemodule.cpp
+++ b/src/calendar-service/src/calendarDataManager/daccountmanagemodule.cpp
@@ -285,8 +285,6 @@ DAccountManageModule::DAccountManageModule(QObject *parent)
 
     connect(&m_timer, &QTimer::timeout, this, &DAccountManageModule::slotClientIsOpen);
     m_timer.start(2000);
-    QTimer::singleShot(0, this, &DAccountManageModule::registerCalDavAccounts);
-
     connect(&m_calDavDailyTimer, &QTimer::timeout,
             this, &DAccountManageModule::slotCalDavDailySync);
     scheduleNextCalDavDailySync();
@@ -1081,14 +1079,21 @@ void DAccountManageModule::slotCalDavOnlineStateChanged(bool isOnline)
 
 void DAccountManageModule::registerCalDavAccounts()
 {
+    if (m_calDavAccountsRegistrationStarted) {
+        return;
+    }
+    m_calDavAccountsRegistrationStarted = true;
+
+    qCDebug(ServiceLogger) << "Registering existing CalDAV accounts after client open.";
     for (const DAccount::Ptr &account : m_accountList) {
         if (account->accountType() == DAccount::Account_CalDav) {
-            registerCalDavAccount(account);
+            registerCalDavAccount(account, false);
         }
     }
 }
 
-void DAccountManageModule::registerCalDavAccount(const DAccount::Ptr &account)
+void DAccountManageModule::registerCalDavAccount(const DAccount::Ptr &account,
+                                                 bool triggerInitialSync)
 {
     if (account.isNull() || account->accountID().isEmpty()
         || !m_accountModuleMap.contains(account->accountID())
@@ -1117,17 +1122,22 @@ void DAccountManageModule::registerCalDavAccount(const DAccount::Ptr &account)
     request.localDatabase = accountModule->accountDatabase();
     request.accountManagerDatabase = m_accountManagerDB.data();
     request.jobManager = &m_calDavSyncJobManager;
+    request.triggerInitialSync = triggerInitialSync;
 
     const QString accountID = account->accountID();
     DCalDavAccountRegistrar *registrar = new DCalDavAccountRegistrar(this);
     m_calDavRegistrars.insert(accountID, registrar);
-    registrar->start(request, [this, accountID, registrar](
+    registrar->start(request, [this, accountID, registrar, triggerInitialSync](
                          const DCalDavAccountRegistrar::Result &result) {
         m_calDavRegistrars.remove(accountID);
         if (result.success) {
             const DAccountModule::Ptr accountModule = m_accountModuleMap.value(accountID);
             if (!accountModule.isNull()) {
                 accountModule->notifyScheduleDataChanged();
+            }
+            if (!triggerInitialSync && m_clientIsOpen) {
+                m_calDavSyncJobManager.requestSync(
+                    accountID, DCalDavSyncStateMachine::ForegroundTrigger);
             }
         } else {
             DCalDavAccountInfo accountInfo;
@@ -1191,8 +1201,14 @@ bool DAccountManageModule::isSupportUid()
 void DAccountManageModule::calendarOpen(bool isOpen)
 {
     qCDebug(ServiceLogger) << "Calendar open status changed:" << isOpen;
+    m_clientIsOpen = isOpen;
     //每次开启日历时需要同步数据
     if (isOpen) {
+        // Defer CalDAV discovery until the client window is visible. Service
+        // startup should only initialize local account data and not access the
+        // credential store or remote CalDAV servers.
+        registerCalDavAccounts();
+
         QMap<QString, DAccountModule::Ptr>::iterator iter = m_accountModuleMap.begin();
         for (; iter != m_accountModuleMap.end(); ++iter) {
             if (iter.value()->account()->accountType() == DAccount::Account_CalDav) {

--- a/src/calendar-service/src/calendarDataManager/daccountmanagemodule.h
+++ b/src/calendar-service/src/calendarDataManager/daccountmanagemodule.h
@@ -121,7 +121,7 @@ private:
     // 保存通用配置
     void setGeneralSettings(const DCalendarGeneralSettings::Ptr &cgSet);
     void registerCalDavAccounts();
-    void registerCalDavAccount(const DAccount::Ptr &account);
+    void registerCalDavAccount(const DAccount::Ptr &account, bool triggerInitialSync = true);
     void scheduleNextCalDavDailySync();
     void scheduleNextCalDavRetry();
     bool migrateCalDavSchedulesToLocal(const DAccountModule::Ptr &calDavModule,
@@ -172,6 +172,8 @@ private:
     DTK_CORE_NAMESPACE::DConfig *m_reginFormatConfig;
     QTimer m_timer;
     bool m_isSupportUid = false;
+    bool m_clientIsOpen = false;
+    bool m_calDavAccountsRegistrationStarted = false;
     QSettings m_settings;
     DBusTimedate m_timeDateDbus;
     DCalDavSyncJobManager m_calDavSyncJobManager;

--- a/src/calendar-service/src/calendarDataManager/daccountmodule.cpp
+++ b/src/calendar-service/src/calendarDataManager/daccountmodule.cpp
@@ -1138,8 +1138,8 @@ void DAccountModule::accountDownload()
     qCDebug(ServiceLogger) << "Account download triggered for account:" << m_account->accountID();
     if (m_dataSync != nullptr) {
         qCInfo(ServiceLogger) << "Starting data download for account:" << m_account->accountID();
-        m_dataSync->syncData(this->account()->accountID(), this->account()->accountName(), 
-                            (int)this->account()->accountState(), 
+        m_dataSync->syncData(this->account()->accountID(), m_accountDB->getConnectionName(),
+                            (int)this->account()->accountState(),
                             DDataSyncBase::Sync_Upload | DDataSyncBase::Sync_Download);
     } else {
         qCWarning(ServiceLogger) << "Cannot download data - sync not available for account:" 
@@ -1152,8 +1152,8 @@ void DAccountModule::uploadNetWorkAccountData()
     qCDebug(ServiceLogger) << "Upload network account data triggered for account:" << m_account->accountID();
     if (m_dataSync != nullptr) {
         qCInfo(ServiceLogger) << "Starting data upload for account:" << m_account->accountID();
-        m_dataSync->syncData(this->account()->accountID(), this->account()->accountName(), 
-                            (int)this->account()->accountState(), 
+        m_dataSync->syncData(this->account()->accountID(), m_accountDB->getConnectionName(),
+                            (int)this->account()->accountState(),
                             DDataSyncBase::Sync_Upload);
     } else {
         qCWarning(ServiceLogger) << "Cannot upload data - sync not available for account:" 


### PR DESCRIPTION
Defer existing CalDAV account discovery until the client window is visible. Keep credential access and remote discovery out of service startup to reduce initial UI contention.

客户端窗口显示后再执行已有 CalDAV 账户发现。
避免在服务启动阶段读取凭据和访问远程服务，减少启动时的界面资源竞争。

Log: 优化 CalDAV 账户启动发现时机
PMS: TASK-393989
Influence: 将 CalDAV 凭据读取、远程发现和首次同步从服务启动阶段移出，
降低启动阶段的网络、数据库和界面刷新竞争，提升日历首屏显示速度。

## Summary by Sourcery

Defer CalDAV startup discovery and synchronization until after the calendar window opens to reduce initial UI, database, credential, and network contention.

Bug Fixes:
- Defer existing CalDAV account discovery, credential access, remote registration, and initial synchronization until the calendar client is visible.
- Preserve CalDAV status-change notifications received while initial status data is loading.
- Ensure manual UnionID synchronization results remain visible while suppressing successful automatic-sync notifications.

Enhancements:
- Add a short post-display delay before notifying the service that the client is open, reducing startup contention and improving initial calendar rendering.
- Use the account database connection name for network account data synchronization.