### PR TITLE
fix(caldav): disable schedule type creation for third-party accounts

### DIFF
--- a/src/calendar-client/src/customWidget/jobtypecombobox.cpp
+++ b/src/calendar-client/src/customWidget/jobtypecombobox.cpp
@@ -149,6 +149,9 @@ void JobTypeComboBox::updateJobType(const AccountItem::Ptr& account)
     //保存现场
     bool isEnit = isEditable();
     QString text = currentText();
+    const bool isCalDavAccount = account->getAccount()
+        && account->getAccount()->accountType() == DAccount::Account_CalDav;
+    setAddTypeEnabled(!isCalDavAccount);
     m_lstJobType = account->getScheduleTypeList();
     clear(); //更新前先清空原有列表
     qCDebug(ClientLogger) << "Updating job types, count:" << m_lstJobType.size();
@@ -158,7 +161,7 @@ void JobTypeComboBox::updateJobType(const AccountItem::Ptr& account)
     //数据重置后hover标识重置为-1
     m_hoverSelectedIndex = -1;
     //恢复原状
-    setEditable(isEnit);
+    setEditable(isEnit && !isCalDavAccount);
     setCurrentText(text);
 
     // CalDAV accounts can expose both read-only and writable calendars. If
@@ -258,6 +261,22 @@ void JobTypeComboBox::addCustomWidget(QFrame *viewContainer)
             view()->installEventFilter(this);
             connect(m_addBtn, &CPushButton::clicked, this, &JobTypeComboBox::slotBtnAddItemClicked);
         }
+        setAddTypeEnabled(m_addTypeEnabled);
+    }
+}
+
+void JobTypeComboBox::setAddTypeEnabled(bool enabled)
+{
+    m_addTypeEnabled = enabled;
+    if (!enabled && isEditable()) {
+        setEditable(false);
+        setIconSize(QSize(16, 16));
+    }
+    if (m_addBtn) {
+        m_addBtn->setEnabled(enabled);
+        if (!enabled) {
+            m_addBtn->setHighlight(false);
+        }
     }
 }
 
@@ -293,9 +312,9 @@ void JobTypeComboBox::showPopup()
         addCustomWidget(viewContainer);
     }
 
-    if (m_customWidget && m_lstJobType.size() >= 20) {
-        qCDebug(ClientLogger) << "Hiding custom widget, too many items";
-        m_customWidget->hide();
+    if (m_customWidget) {
+        m_customWidget->setVisible(m_lstJobType.size() < 20);
+        setAddTypeEnabled(m_addTypeEnabled);
     }
 
     //设置最大高度为400
@@ -369,6 +388,10 @@ bool JobTypeComboBox::eventFilter(QObject *obj, QEvent *event)
 void JobTypeComboBox::slotBtnAddItemClicked()
 {
     qCDebug(ClientLogger) << "JobTypeComboBox::slotBtnAddItemClicked";
+    if (!m_addTypeEnabled) {
+        qCDebug(ClientLogger) << "Adding schedule type is disabled for current account";
+        return;
+    }
     JobTypeComboBox::hidePopup();
     setIconSize(QSize(0, 0));
     //设置没有选中，

--- a/src/calendar-client/src/customWidget/jobtypecombobox.h
+++ b/src/calendar-client/src/customWidget/jobtypecombobox.h
@@ -54,6 +54,7 @@ private:
     void addJobTypeItem(int idx, QString strColorHex, QString strJobType);
     void addCustomWidget(QFrame *);
     void setItemSelectable(bool status);
+    void setAddTypeEnabled(bool enabled);
 
 private:
     QWidget *m_customWidget {nullptr};
@@ -62,6 +63,7 @@ private:
     int m_hoverSelectedIndex = -1; //鼠标悬停的选项下标
     int m_itemNumIndex = 0; //item数量
     DAlertControl *m_control {nullptr};
+    bool m_addTypeEnabled = true;
     QLineEdit *m_lineEdit {nullptr};
     int m_oldPos = 0;
     int m_newPos = 0;

--- a/src/calendar-client/src/dialog/scheduledlg.cpp
+++ b/src/calendar-client/src/dialog/scheduledlg.cpp
@@ -97,7 +97,7 @@ void CScheduleDlg::setData(const DSchedule::Ptr &info)
         m_accountComBox->setEnabled(false);
     }
 
-    if (nullptr != m_accountItem) {
+    if (m_accountItem && m_accountItem->getAccount()) {
         qCDebug(ClientLogger) << "Updating account and type selection for account:" << m_accountItem->getAccount()->accountName();
         //更新帐户下拉框和类型选择框
         const int accountIndex = m_accountComBox->findData(m_accountItem->getAccount()->accountID());
@@ -206,6 +206,11 @@ bool CScheduleDlg::clickOkBtn()
 bool CScheduleDlg::selectScheduleType()
 {
     qCDebug(ClientLogger) << "CScheduleDlg::selectScheduleType";
+    if (m_typeComBox->isEditable() && m_accountItem && m_accountItem->getAccount()
+        && m_accountItem->getAccount()->accountType() == DAccount::Account_CalDav) {
+        qCWarning(ClientLogger) << "Cannot create a schedule type for a CalDAV account.";
+        return false;
+    }
     //编辑状态，需要创建日程
     if (m_typeComBox->isEditable()) {
         qCDebug(ClientLogger) << "Type combobox is editable, creating new schedule type";

--- a/src/calendar-client/src/dialog/settingdialog.cpp
+++ b/src/calendar-client/src/dialog/settingdialog.cpp
@@ -328,6 +328,7 @@ void CSettingDialog::initView()
     //首次显示JobTypeListView时，更新日程类型
     if (m_scheduleTypeWidget && m_accountComboBox) {
         m_scheduleTypeWidget->updateCalendarAccount(m_accountComboBox->currentData().toString());
+        setTypeEnable(m_accountComboBox->currentIndex());
     }
 
 
@@ -1060,23 +1061,27 @@ void CSettingDialog::setTypeEnable(int index)
     bool canExport = false;
     bool canImport = false;
     bool canManageTypes = false;
+    bool isCalDavAccount = false;
     if (account) {
         const DAccount::Type accountType = account->getAccount()->accountType();
+        isCalDavAccount = accountType == DAccount::Account_CalDav;
         canExport = accountType == DAccount::Account_Local
             || accountType == DAccount::Account_CalDav
             || (accountType == DAccount::Account_UnionID
                 && gUosAccountItem && gUosAccountItem->isCanSyncShedule());
         canManageTypes = accountType == DAccount::Account_Local
-            || (accountType == DAccount::Account_CalDav
-                && gAccountManager->canWriteCalDavAccount(accountId))
             || (accountType == DAccount::Account_UnionID
                 && gUosAccountItem && gUosAccountItem->isCanSyncShedule());
         canEdit = canManageTypes && account->getScheduleTypeList().count() < 20;
         canImport = canEdit;
     }
 
-    // CalDAV schedule types can be added when the account has a writable
-    // collection; read-only accounts keep the action visible but disabled.
+    if (DToolButton *moreButton = findChild<DToolButton *>(
+            QStringLiteral("ScheduleTypeMoreButton"))) {
+        moreButton->setEnabled(!isCalDavAccount);
+    }
+
+    // Schedule types cannot be added or imported for CalDAV accounts.
     // Existing collection/category types are not editable through the generic APIs.
     m_typeAddAction->setVisible(true);
     m_typeAddAction->setEnabled(canEdit);

--- a/translations/dde-calendar_zh_CN.ts
+++ b/translations/dde-calendar_zh_CN.ts
@@ -1007,7 +1007,7 @@
         <message>
             <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="575" />
             <source>The server rejected your login request. Please check your account permissions.</source>
-            <translation>服务器拒绝了登录请求，请检查账号是否有访问权限</translation>
+            <translation>服务器拒绝了登录请求，请检查账户是否有访问权限</translation>
         </message>
         <message>
             <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="577" />


### PR DESCRIPTION
Disable schedule type creation for CalDAV accounts in settings and new event dialogs. Keep schedule type creation available for local accounts and UOS ID accounts.

在账户设置和新建日程窗口中禁用第三方 CalDAV 账户新增日程类型。
保留本地账户和 UOS ID 账户的日程类型新增功能。

Log: 限制第三方账户新增日程类型
PMS: TASK-393989
Influence: 禁止第三方 CalDAV 账户新增日程类型，避免创建无法同步或不应修改的类型， 同时保持本地账户和 UOS ID 账户的原有功能不变。

## Summary by Sourcery

Restrict schedule type creation for CalDAV accounts while retaining existing functionality for supported local and UOS ID accounts.

Bug Fixes:
- Prevent schedule type creation for third-party CalDAV accounts in account settings and new event dialogs.

Enhancements:
- Preserve schedule type creation and management for local and eligible UOS ID accounts while disabling CalDAV add controls consistently.

Chores:
- Update the Chinese translation for the CalDAV login permission error message.