### PR TITLE
chore: update zh_HK and zh_TW translations based on zh_CN

### DIFF
--- a/translations/dde-calendar-service_en_US.ts
+++ b/translations/dde-calendar-service_en_US.ts
@@ -1163,4 +1163,96 @@
         <translation>Today</translation>
     </message>
 </context>
+    <context>
+        <name>DAccountManageModule</name>
+    <message>
+        <location filename="../src/calendar-service/src/calendarDataManager/daccountmanagemodule.cpp" line="125"/>
+        <source>[Original Type: %1]</source>
+        <translation>[Original Type: %1]</translation>
+    </message>
+    </context>
+    <context>
+        <name>DCalDavAccountRegistrar</name>
+    <message>
+        <location filename="../src/calendar-service/src/caldav/dcaldavaccountregistrar.cpp" line="60"/>
+        <source>Calendar</source>
+        <translation>Calendar</translation>
+    </message>
+    </context>
+    <context>
+        <name>DCalDavProviderProfile</name>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="37"/>
+        <source>DingTalk</source>
+        <translation>DingTalk</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="39"/>
+        <source>WeCom</source>
+        <translation>WeCom</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="41"/>
+        <source>Tencent Meeting</source>
+        <translation>Tencent Meeting</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="43"/>
+        <source>QQ Mail</source>
+        <translation>QQ Mail</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="45"/>
+        <source>Feishu</source>
+        <translation>Feishu</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="48"/>
+        <source>Other CalDAV</source>
+        <translation>Other CalDAV</translation>
+    </message>
+    </context>
+    <context>
+        <name>DCalDavSyncStatus</name>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51"/>
+        <source>The server certificate is invalid.</source>
+        <translation>The server certificate is invalid.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="54"/>
+        <source>Incorrect username or password. Please try again.</source>
+        <translation>Incorrect username or password. Please try again.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="57"/>
+        <source>This server does not support CalDAV.</source>
+        <translation>This server does not support CalDAV.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="61"/>
+        <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+        <translation>Unable to parse the data returned by the server. Please verify the server address or try again later.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="65"/>
+        <source>The server denied access.</source>
+        <translation>The server denied access.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="68"/>
+        <source>The server request timed out.</source>
+        <translation>The server request timed out.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="72"/>
+        <source>Unable to connect to the server. Please check your network connection and server address.</source>
+        <translation>Unable to connect to the server. Please check your network connection and server address.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76"/>
+        <source>Synchronization failed.</source>
+        <translation>Synchronization failed.</translation>
+    </message>
+    </context>
 </TS>

--- a/translations/dde-calendar-service_zh_HK.ts
+++ b/translations/dde-calendar-service_zh_HK.ts
@@ -1,1230 +1,1105 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE TS>
-<TS language="zh_HK" version="2.1">
+<TS version="2.1" language="zh_HK">
     <context>
         <name>AccountItem</name>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="41"/>
             <source>Sync successful</source>
-            <translation>同步成功</translation>
+            <translation type="vanished">同步成功</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="42"/>
             <source>Network error</source>
-            <translation>網絡異常</translation>
+            <translation type="vanished">網絡異常</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="43"/>
             <source>Server exception</source>
-            <translation>伺服器異常</translation>
+            <translation type="vanished">伺服器異常</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="44"/>
             <source>Storage full</source>
-            <translation>存儲已滿</translation>
+            <translation type="vanished">存儲已滿</translation>
         </message>
     </context>
     <context>
         <name>AccountManager</name>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="227"/>
             <source>Local account</source>
-            <translation>本地帳戶</translation>
+            <translation type="vanished">本地帳戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="229"/>
             <source>Event types</source>
-            <translation>日程類型</translation>
+            <translation type="vanished">日程類型</translation>
         </message>
     </context>
     <context>
         <name>CColorPickerWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="77"/>
             <source>Color</source>
-            <translation>顏色</translation>
+            <translation type="vanished">顏色</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="90"/>
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation type="vanished">取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="92"/>
             <source>Save</source>
-            <translation>保 存</translation>
             <comment>button</comment>
+            <translation type="vanished">保 存</translation>
         </message>
     </context>
     <context>
         <name>CDayMonthView</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="33"/>
             <source>Monday</source>
-            <translation>星期一</translation>
+            <translation type="vanished">星期一</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="34"/>
             <source>Tuesday</source>
-            <translation>星期二</translation>
+            <translation type="vanished">星期二</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35"/>
             <source>Wednesday</source>
-            <translation>星期三</translation>
+            <translation type="vanished">星期三</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36"/>
             <source>Thursday</source>
-            <translation>星期四</translation>
+            <translation type="vanished">星期四</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37"/>
             <source>Friday</source>
-            <translation>星期五</translation>
+            <translation type="vanished">星期五</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38"/>
             <source>Saturday</source>
-            <translation>星期六</translation>
+            <translation type="vanished">星期六</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39"/>
             <source>Sunday</source>
-            <translation>星期日</translation>
+            <translation type="vanished">星期日</translation>
         </message>
     </context>
     <context>
         <name>CDayWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="112"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="113"/>
             <source>M</source>
-            <translation>月</translation>
+            <translation type="vanished">月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="114"/>
             <source>D</source>
-            <translation>日</translation>
+            <translation type="vanished">日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="170"/>
             <source>Lunar</source>
-            <translation>農曆</translation>
+            <translation type="vanished">農曆</translation>
         </message>
     </context>
     <context>
         <name>CGraphicsView</name>
         <message>
-            <location filename="../calendar-client/src/view/graphicsview.cpp" line="628"/>
             <source>New Event</source>
-            <translation>新建日程</translation>
+            <translation type="vanished">新建日程</translation>
         </message>
     </context>
     <context>
         <name>CMonthScheduleNumItem</name>
         <message>
-            <location filename="../calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="80"/>
             <source>%1 more</source>
-            <translation>還有%1項</translation>
+            <translation type="vanished">還有%1項</translation>
         </message>
     </context>
     <context>
         <name>CMonthView</name>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="50"/>
             <source>New event</source>
-            <translation>新建日程</translation>
+            <translation type="vanished">新建日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="230"/>
             <source>New Event</source>
-            <translation>新建日程</translation>
+            <translation type="vanished">新建日程</translation>
         </message>
     </context>
     <context>
         <name>CMonthWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
     </context>
     <context>
         <name>CMyScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="284"/>
             <source>My Event</source>
-            <translation>我的日程</translation>
+            <translation type="vanished">我的日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="326"/>
             <source>OK</source>
-            <translation>確 定</translation>
             <comment>button</comment>
+            <translation type="vanished">確 定</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="331"/>
             <source>Delete</source>
-            <translation>刪 除</translation>
             <comment>button</comment>
+            <translation type="vanished">刪 除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="332"/>
             <source>Edit</source>
-            <translation>更 改</translation>
             <comment>button</comment>
+            <translation type="vanished">更 改</translation>
         </message>
     </context>
     <context>
         <name>CPushButton</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/cpushbutton.cpp" line="17"/>
             <source>New event type</source>
-            <translation>新增日程類型</translation>
+            <translation type="vanished">新增日程類型</translation>
         </message>
     </context>
     <context>
         <name>CScheduleDlg</name>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="46"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="625"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="921"/>
             <source>New Event</source>
-            <translation>新建日程</translation>
+            <translation type="vanished">新建日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="60"/>
             <source>Edit Event</source>
-            <translation>更改日程</translation>
+            <translation type="vanished">更改日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="270"/>
             <source>End time must be greater than start time</source>
-            <translation>結束時間需晚於開始時間</translation>
+            <translation type="vanished">結束時間需晚於開始時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="271"/>
             <source>OK</source>
-            <translation>確 定</translation>
             <comment>button</comment>
+            <translation type="vanished">確 定</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="506"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="535"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1133"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1168"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1422"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1426"/>
             <source>Never</source>
-            <translation>永不</translation>
+            <translation type="vanished">永不</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="507"/>
             <source>At time of event</source>
-            <translation>日程開始時</translation>
+            <translation type="vanished">日程開始時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="508"/>
             <source>15 minutes before</source>
-            <translation>15分鐘前</translation>
+            <translation type="vanished">15分鐘前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="509"/>
             <source>30 minutes before</source>
-            <translation>30分鐘前</translation>
+            <translation type="vanished">30分鐘前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="510"/>
             <source>1 hour before</source>
-            <translation>1小時前</translation>
+            <translation type="vanished">1小時前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="511"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="537"/>
             <source>1 day before</source>
-            <translation>1天前</translation>
+            <translation type="vanished">1天前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="512"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="538"/>
             <source>2 days before</source>
-            <translation>2天前</translation>
+            <translation type="vanished">2天前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="513"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="539"/>
             <source>1 week before</source>
-            <translation>1週前</translation>
+            <translation type="vanished">1週前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="536"/>
             <source>On start day (9:00 AM)</source>
-            <translation>日程發生當天（上午9點）</translation>
+            <translation type="vanished">日程發生當天（上午9點）</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="583"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="791"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1189"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1190"/>
             <source>time(s)</source>
-            <translation>次後</translation>
+            <translation type="vanished">次後</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="598"/>
             <source>Enter a name please</source>
-            <translation>名稱不能為空</translation>
+            <translation type="vanished">名稱不能為空</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="693"/>
             <source>The name can not only contain whitespaces</source>
-            <translation>名稱不能設置為全空格，請修改</translation>
+            <translation type="vanished">名稱不能設置為全空格，請修改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="749"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="871"/>
             <source>Type:</source>
-            <translation>類型：</translation>
+            <translation type="vanished">類型：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="754"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="906"/>
             <source>Description:</source>
-            <translation>描述：</translation>
+            <translation type="vanished">描述：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="759"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="943"/>
             <source>All Day:</source>
-            <translation>全天：</translation>
+            <translation type="vanished">全天：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="764"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1009"/>
             <source>Starts:</source>
-            <translation>開始時間：</translation>
+            <translation type="vanished">開始時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="769"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1050"/>
             <source>Ends:</source>
-            <translation>結束時間：</translation>
+            <translation type="vanished">結束時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="774"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1090"/>
             <source>Remind Me:</source>
-            <translation>提醒：</translation>
+            <translation type="vanished">提醒：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="779"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1122"/>
             <source>Repeat:</source>
-            <translation>重複：</translation>
+            <translation type="vanished">重複：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="784"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1156"/>
             <source>End Repeat:</source>
-            <translation>結束重複：</translation>
+            <translation type="vanished">結束重複：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="840"/>
             <source>Calendar account:</source>
-            <translation>日曆帳戶：</translation>
+            <translation type="vanished">日曆帳戶：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="841"/>
             <source>Calendar account</source>
-            <translation>日曆帳戶</translation>
+            <translation type="vanished">日曆帳戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="868"/>
             <source>Type</source>
-            <translation>類型</translation>
+            <translation type="vanished">類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="910"/>
             <source>Description</source>
-            <translation>描述</translation>
+            <translation type="vanished">描述</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="940"/>
             <source>All Day</source>
-            <translation>全天</translation>
+            <translation type="vanished">全天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="964"/>
             <source>Time:</source>
-            <translation>時間：</translation>
+            <translation type="vanished">時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="965"/>
             <source>Time</source>
-            <translation>時間</translation>
+            <translation type="vanished">時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="972"/>
             <source>Solar</source>
-            <translation>公曆</translation>
+            <translation type="vanished">公曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="973"/>
             <source>Lunar</source>
-            <translation>農曆</translation>
+            <translation type="vanished">農曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1006"/>
             <source>Starts</source>
-            <translation>開始時間</translation>
+            <translation type="vanished">開始時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1047"/>
             <source>Ends</source>
-            <translation>結束時間</translation>
+            <translation type="vanished">結束時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1092"/>
             <source>Remind Me</source>
-            <translation>提醒</translation>
+            <translation type="vanished">提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1119"/>
             <source>Repeat</source>
-            <translation>重複</translation>
+            <translation type="vanished">重複</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1134"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1427"/>
             <source>Daily</source>
-            <translation>每天</translation>
+            <translation type="vanished">每天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1135"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1428"/>
             <source>Weekdays</source>
-            <translation>工作日</translation>
+            <translation type="vanished">工作日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1136"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1429"/>
             <source>Weekly</source>
-            <translation>每週</translation>
+            <translation type="vanished">每週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1137"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1423"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1430"/>
             <source>Monthly</source>
-            <translation>每月</translation>
+            <translation type="vanished">每月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1138"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1424"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1431"/>
             <source>Yearly</source>
-            <translation>每年</translation>
+            <translation type="vanished">每年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1158"/>
             <source>End Repeat</source>
-            <translation>結束重複</translation>
+            <translation type="vanished">結束重複</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1169"/>
             <source>After</source>
-            <translation>於</translation>
+            <translation type="vanished">於</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1170"/>
             <source>On</source>
-            <translation>於日期</translation>
+            <translation type="vanished">於日期</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1240"/>
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation type="vanished">取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1241"/>
             <source>Save</source>
-            <translation>保 存</translation>
             <comment>button</comment>
+            <translation type="vanished">保 存</translation>
         </message>
     </context>
     <context>
         <name>CScheduleOperation</name>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74"/>
             <source>All occurrences of a repeating event must have the same all-day status.</source>
-            <translation>重複日程的所有重複必須具有相同的全天狀態。</translation>
+            <translation type="vanished">重複日程的所有重複必須具有相同的全天狀態。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="95"/>
             <source>Do you want to change all occurrences?</source>
-            <translation>您要更改所有重複嗎？</translation>
+            <translation type="vanished">您要更改所有重複嗎？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="96"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="129"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="151"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="174"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="259"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="292"/>
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation type="vanished">取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="97"/>
             <source>Change All</source>
-            <translation>全部更改</translation>
+            <translation type="vanished">全部更改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94"/>
             <source>You are changing the repeating rule of this event.</source>
-            <translation>您正在更改日程的重複規則。</translation>
+            <translation type="vanished">您正在更改日程的重複規則。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="149"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="172"/>
             <source>You are deleting an event.</source>
-            <translation>您正在刪除日程。</translation>
+            <translation type="vanished">您正在刪除日程。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128"/>
             <source>Are you sure you want to delete this event?</source>
-            <translation>您確定要刪除此日程嗎？</translation>
+            <translation type="vanished">您確定要刪除此日程嗎？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130"/>
             <source>Delete</source>
-            <translation>刪 除</translation>
             <comment>button</comment>
+            <translation type="vanished">刪 除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150"/>
             <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
-            <translation>您要刪除此日程的所有重複，還是只刪除所選重複？</translation>
+            <translation type="vanished">您要刪除此日程的所有重複，還是隻刪除所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152"/>
             <source>Delete All</source>
-            <translation>全部刪除</translation>
+            <translation type="vanished">全部刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="176"/>
             <source>Delete Only This Event</source>
-            <translation>僅刪除此日程</translation>
+            <translation type="vanished">僅刪除此日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173"/>
             <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
-            <translation>您要刪除此日程的這個重複和所有將來重複，還是只刪除所選重複？</translation>
+            <translation type="vanished">您要刪除此日程的這個重複和所有將來重複，還是隻刪除所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175"/>
             <source>Delete All Future Events</source>
-            <translation>刪除所有將來日程</translation>
+            <translation type="vanished">刪除所有將來日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="288"/>
             <source>You are changing a repeating event.</source>
-            <translation>您正在更改重複日程。</translation>
+            <translation type="vanished">您正在更改重複日程。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257"/>
             <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
-            <translation>您要更改此日程的僅這一個重複，還是更改它的所有重複？</translation>
+            <translation type="vanished">您要更改此日程的僅這一個重複，還是更改它的所有重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260"/>
             <source>All</source>
-            <translation>全部日程</translation>
+            <translation type="vanished">全部日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="294"/>
             <source>Only This Event</source>
-            <translation>僅此日程</translation>
+            <translation type="vanished">僅此日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290"/>
             <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
-            <translation>您要更改此日程的這個重複和所有將來重複，還是只更改所選重複？</translation>
+            <translation type="vanished">您要更改此日程的這個重複和所有將來重複，還是隻更改所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293"/>
             <source>All Future Events</source>
-            <translation>所有將來日程</translation>
+            <translation type="vanished">所有將來日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416"/>
             <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
-            <translation>您選擇的是閏月，將按照農曆規則提醒</translation>
+            <translation type="vanished">您選擇的是閏月，將按照農曆規則提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417"/>
             <source>OK</source>
-            <translation>確 定</translation>
             <comment>button</comment>
+            <translation type="vanished">確 定</translation>
         </message>
     </context>
     <context>
         <name>CScheduleSearchDateItem</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
             <source>M</source>
-            <translation>月</translation>
+            <translation type="vanished">月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
             <source>D</source>
-            <translation>日</translation>
+            <translation type="vanished">日</translation>
         </message>
     </context>
     <context>
         <name>CScheduleSearchItem</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="42"/>
             <source>Edit</source>
-            <translation>更改</translation>
+            <translation type="vanished">更改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="43"/>
             <source>Delete</source>
-            <translation>刪除</translation>
+            <translation type="vanished">刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="267"/>
             <source>All Day</source>
-            <translation>全天</translation>
+            <translation type="vanished">全天</translation>
         </message>
     </context>
     <context>
         <name>CScheduleSearchView</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="648"/>
             <source>No search results</source>
-            <translation>無搜索結果</translation>
+            <translation type="vanished">無搜索結果</translation>
         </message>
     </context>
     <context>
         <name>CScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/scheduleview.cpp" line="316"/>
             <source>ALL DAY</source>
-            <translation>全天</translation>
+            <translation type="vanished">全天</translation>
         </message>
     </context>
     <context>
         <name>CSettingDialog</name>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="389"/>
             <source>import ICS file</source>
-            <translation>導入ICS文件</translation>
+            <translation type="vanished">導入ICS文件</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="403"/>
             <source>Manual</source>
-            <translation>手動</translation>
+            <translation type="vanished">手動</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="404"/>
             <source>15 mins</source>
-            <translation>每15分鐘</translation>
+            <translation type="vanished">每15分鐘</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="405"/>
             <source>30 mins</source>
-            <translation>每30分鐘</translation>
+            <translation type="vanished">每30分鐘</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="406"/>
             <source>1 hour</source>
-            <translation>每1小時</translation>
+            <translation type="vanished">每1小時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="407"/>
             <source>24 hours</source>
-            <translation>每24小時</translation>
+            <translation type="vanished">每24小時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="418"/>
             <source>Sync Now</source>
-            <translation>立即同步</translation>
+            <translation type="vanished">立即同步</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="585"/>
             <source>Last sync</source>
-            <translation>最近同步時間</translation>
+            <translation type="vanished">最近同步時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="779"/>
-            <source>Please go to the &lt;a href='/'&gt;Control Center&lt;/a&gt; to change system settings</source>
-            <translation>請前往控制中心更改系統設置</translation>
+            <source>Please go to the Control Center to change system settings</source>
+            <translation type="vanished">請前往控制中心更改系統設置</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="346"/>
             <source>Monday</source>
-            <translation>週一</translation>
+            <translation type="vanished">週一</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="345"/>
             <source>Sunday</source>
-            <translation>週日</translation>
+            <translation type="vanished">週日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="347"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="366"/>
             <source>Use System Setting</source>
-            <translation>使用系統設置</translation>
+            <translation type="vanished">使用系統設置</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="365"/>
             <source>12-hour clock</source>
-            <translation>12小時制</translation>
+            <translation type="vanished">12小時制</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="364"/>
             <source>24-hour clock</source>
-            <translation>24小時制</translation>
+            <translation type="vanished">24小時制</translation>
         </message>
     </context>
     <context>
         <name>CTimeEdit</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="71"/>
             <source>(%1 mins)</source>
-            <translation>(%1分鐘)</translation>
+            <translation type="vanished">(%1分鐘)</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="73"/>
             <source>(%1 hour)</source>
-            <translation>(%1小時)</translation>
+            <translation type="vanished">(%1小時)</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="75"/>
             <source>(%1 hours)</source>
-            <translation>(%1小時)</translation>
+            <translation type="vanished">(%1小時)</translation>
         </message>
     </context>
     <context>
         <name>CTitleWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="30"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="42"/>
             <source>M</source>
-            <translation>月</translation>
+            <translation type="vanished">月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="50"/>
             <source>W</source>
-            <translation>週</translation>
+            <translation type="vanished">週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="58"/>
             <source>D</source>
-            <translation>日</translation>
+            <translation type="vanished">日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="92"/>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="93"/>
             <source>Search events and festivals</source>
-            <translation>搜索日程/節日</translation>
+            <translation type="vanished">搜索日程/節日</translation>
         </message>
     </context>
     <context>
         <name>CWeekWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="90"/>
             <source>Week</source>
-            <translation>週</translation>
+            <translation type="vanished">週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="280"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
     </context>
     <context>
         <name>CYearScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="268"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="271"/>
             <source>All Day</source>
-            <translation>全天</translation>
+            <translation type="vanished">全天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="288"/>
             <source>No event</source>
-            <translation>無日程</translation>
+            <translation type="vanished">無日程</translation>
         </message>
     </context>
     <context>
         <name>CYearWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="615"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
     </context>
     <context>
         <name>CalendarWindow</name>
         <message>
-            <location filename="../calendar-client/src/main.cpp" line="66"/>
             <source>Calendar</source>
-            <translation>日曆</translation>
+            <translation type="vanished">日曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/main.cpp" line="69"/>
-            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life.</source>
-            <translation>日曆是一款查看日期、管理日程的小工具。</translation>
+            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
+            <translation type="vanished">日曆是一款查看日期、管理日程的小工具。</translation>
         </message>
     </context>
     <context>
         <name>Calendarmainwindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="89"/>
             <source>Calendar</source>
-            <translation>日曆</translation>
+            <translation type="vanished">日曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="372"/>
             <source>Manage</source>
-            <translation>管理</translation>
+            <translation type="vanished">管理</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="379"/>
             <source>Privacy Policy</source>
-            <translation>私隱政策</translation>
+            <translation type="vanished">私隱政策</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="962"/>
             <source>Syncing...</source>
-            <translation>正在同步...</translation>
+            <translation type="vanished">正在同步...</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="973"/>
             <source>Sync successful</source>
-            <translation>同步成功</translation>
+            <translation type="vanished">同步成功</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="982"/>
             <source>Sync failed, please try later</source>
-            <translation>同步失敗，請稍後再試</translation>
+            <translation type="vanished">同步失敗，請稍後再試</translation>
         </message>
     </context>
     <context>
         <name>CenterWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="174"/>
             <source>All Day</source>
-            <translation>全天</translation>
+            <translation type="vanished">全天</translation>
         </message>
     </context>
     <context>
         <name>DAccountDataBase</name>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1155"/>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1304" />
             <source>Work</source>
             <translation>工作</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1157"/>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1306" />
             <source>Life</source>
             <translation>生活</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1159"/>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1308" />
             <source>Other</source>
             <translation>其他</translation>
         </message>
     </context>
     <context>
+        <name>DAccountManageModule</name>
+        <message>
+            <location filename="../src/calendar-service/src/calendarDataManager/daccountmanagemodule.cpp" line="125" />
+            <source>[Original Type: %1]</source>
+            <translation>[原類型: %1]</translation>
+        </message>
+    </context>
+    <context>
         <name>DAlarmManager</name>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="187"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="196"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="201"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="212"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="194" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="203" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="208" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="219" />
             <source>Close</source>
-            <translation>關 閉</translation>
             <comment>button</comment>
+            <translation>關 閉</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="191"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="198" />
             <source>One day before start</source>
             <translation>提前1天提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="197"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="204" />
             <source>Remind me tomorrow</source>
             <translation>明天提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="202"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="209" />
             <source>Remind me later</source>
             <translation>稍後提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="204"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="211" />
             <source>15 mins later</source>
             <translation>15分鐘後</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="205"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="212" />
             <source>1 hour later</source>
             <translation>1小時後</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="206"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="213" />
             <source>4 hours later</source>
             <translation>4小時後</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="207"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="300"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="313"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="214" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="311" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="324" />
             <source>Tomorrow</source>
             <translation>明天</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="215"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="222" />
             <source>Schedule Reminder</source>
             <translation>日程提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="258"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="270"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="268" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="280" />
             <source>%1 to %2</source>
             <translation>%1 至 %2</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="296"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="309"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="307" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="320" />
             <source>Today</source>
             <translation>今天</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavAccountRegistrar</name>
+        <message>
+            <location filename="../src/calendar-service/src/caldav/dcaldavaccountregistrar.cpp" line="60" />
+            <source>Calendar</source>
+            <translation>日曆</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavProviderProfile</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="37" />
+            <source>DingTalk</source>
+            <translation>釘釘</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="39" />
+            <source>WeCom</source>
+            <translation>企業微信</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="41" />
+            <source>Tencent Meeting</source>
+            <translation>騰訊會議</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="43" />
+            <source>QQ Mail</source>
+            <translation>QQ郵箱</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="45" />
+            <source>Feishu</source>
+            <translation>飛書</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="48" />
+            <source>Other CalDAV</source>
+            <translation>其他 CalDAV</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavSyncStatus</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server request is invalid.</source>
+            <translation>服務器請求無效</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="71" />
+            <source>The server is busy. Please try again later.</source>
+            <translation>服務器繁忙，請稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="74" />
+            <source>The server is unavailable. Please try again later.</source>
+            <translation>服務器不可用，請稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="77" />
+            <source>The calendar data conflicts with the server.</source>
+            <translation>日曆數據與服務器存在衝突</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="80" />
+            <source>The server returned too much data. Please try again later.</source>
+            <translation>服務器返回的數據過大，請稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="91" />
+            <source>Unable to save calendar data. Please try again later.</source>
+            <translation>無法保存日曆數據，請稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server certificate is invalid.</source>
+            <translation>服務器證書無效</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="54" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>用戶名或密碼錯誤，請重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="57" />
+            <source>This server does not support CalDAV.</source>
+            <translation>該服務器不支持CalDAV協議</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="61" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>服務器返回的數據無法解析，請確認服務器地址或稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="65" />
+            <source>The server denied access.</source>
+            <translation>服務器拒絕訪問</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="68" />
+            <source>The server request timed out.</source>
+            <translation>服務器請求超時</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="72" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>無法連接到服務器，請檢查網絡連接和服務器地址。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76" />
+            <source>Synchronization failed.</source>
+            <translation>同步失敗</translation>
         </message>
     </context>
     <context>
         <name>DragInfoGraphicsView</name>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="48"/>
             <source>Edit</source>
-            <translation>更改</translation>
+            <translation type="vanished">更改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="49"/>
             <source>Delete</source>
-            <translation>删除</translation>
+            <translation type="vanished">刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="50"/>
             <source>New event</source>
-            <translation>新建日程</translation>
+            <translation type="vanished">新建日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="759"/>
             <source>New Event</source>
-            <translation>新建日程</translation>
+            <translation type="vanished">新建日程</translation>
         </message>
     </context>
     <context>
         <name>JobTypeListView</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="144"/>
             <source>export</source>
-            <translation>導出</translation>
+            <translation type="vanished">導出</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="219"/>
             <source>import ICS file</source>
-            <translation>導入ICS文件</translation>
+            <translation type="vanished">導入ICS文件</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="450"/>
             <source>You are deleting an event type.</source>
-            <translation>您正在刪除日程類型。</translation>
+            <translation type="vanished">您正在刪除日程類型。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="451"/>
             <source>All events under this type will be deleted and cannot be recovered.</source>
-            <translation>此日程類型下的所有日程都會刪除且不可恢復。</translation>
+            <translation type="vanished">此日程類型下的所有日程都會刪除且不可恢復。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="452"/>
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation type="vanished">取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="453"/>
             <source>Delete</source>
-            <translation>刪 除</translation>
             <comment>button</comment>
+            <translation type="vanished">刪 除</translation>
         </message>
     </context>
     <context>
         <name>QObject</name>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="38"/>
             <source>Account settings</source>
-            <translation>帳戶設置</translation>
+            <translation type="vanished">帳戶設置</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="42"/>
             <source>Account</source>
-            <translation>賬戶</translation>
+            <translation type="vanished">賬戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="53"/>
             <source>Select items to be synced</source>
-            <translation>設置您的同步項</translation>
+            <translation type="vanished">設置您的同步項</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="56"/>
             <source>Events</source>
-            <translation>日程</translation>
+            <translation type="vanished">日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="63"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="146"/>
             <source>General settings</source>
-            <translation>通用設置</translation>
+            <translation type="vanished">通用設置</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="74"/>
             <source>Sync interval</source>
-            <translation>同步頻率</translation>
+            <translation type="vanished">同步頻率</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="96"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="127"/>
             <source>Manage calendar</source>
-            <translation>日曆管理</translation>
+            <translation type="vanished">日曆管理</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="104"/>
             <source>Calendar account</source>
-            <translation>日曆帳戶</translation>
+            <translation type="vanished">日曆帳戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="112"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="131"/>
             <source>Event types</source>
-            <translation>日程類型</translation>
+            <translation type="vanished">日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="150"/>
             <source>General</source>
-            <translation>通用</translation>
+            <translation type="vanished">通用</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="152"/>
             <source>First day of week</source>
-            <translation>每星期開始於</translation>
+            <translation type="vanished">每星期開始於</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="153"/>
             <source>Time</source>
-            <translation>時間</translation>
+            <translation type="vanished">時間</translation>
         </message>
     </context>
     <context>
         <name>Return</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="611"/>
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Return</comment>
+            <translation type="vanished">今天</translation>
         </message>
     </context>
     <context>
         <name>Return Today</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="339"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="95"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="277"/>
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Return Today</comment>
+            <translation type="vanished">今天</translation>
         </message>
     </context>
     <context>
         <name>ScheduleTypeEditDlg</name>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22"/>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="48"/>
             <source>New event type</source>
-            <translation>新增日程類型</translation>
+            <translation type="vanished">新增日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="32"/>
             <source>Edit event type</source>
-            <translation>編輯日程類型</translation>
+            <translation type="vanished">編輯日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="43"/>
             <source>Import ICS file</source>
-            <translation>導入ICS文件</translation>
+            <translation type="vanished">導入ICS文件</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="151"/>
             <source>Name:</source>
-            <translation>名稱：</translation>
+            <translation type="vanished">名稱：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="152"/>
             <source>Color:</source>
-            <translation>顏色：</translation>
+            <translation type="vanished">顏色：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="156"/>
-            <source>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt; File:</source>
-            <translation>ICS文件：</translation>
+            <source>ICS File:</source>
+            <translation type="vanished">ICS文件：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="167"/>
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation type="vanished">取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="168"/>
             <source>Save</source>
-            <translation>保 存</translation>
             <comment>button</comment>
+            <translation type="vanished">保 存</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="219"/>
             <source>The name can not only contain whitespaces</source>
-            <translation>名稱不能設置為全空格，請修改</translation>
+            <translation type="vanished">名稱不能設置為全空格，請修改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="256"/>
             <source>Enter a name please</source>
-            <translation>名稱不能為空</translation>
+            <translation type="vanished">名稱不能為空</translation>
         </message>
     </context>
     <context>
         <name>Shortcut</name>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="16"/>
             <source>Help</source>
-            <translation>幫助</translation>
+            <translation type="vanished">幫助</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="17"/>
             <source>Delete event</source>
-            <translation>刪除日程</translation>
+            <translation type="vanished">刪除日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="20"/>
             <source>Copy</source>
-            <translation>複製</translation>
+            <translation type="vanished">複製</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="21"/>
             <source>Cut</source>
-            <translation>剪下</translation>
+            <translation type="vanished">剪下</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="22"/>
             <source>Paste</source>
-            <translation>黏貼</translation>
+            <translation type="vanished">黏貼</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="25"/>
             <source>Delete</source>
-            <translation>刪除</translation>
+            <translation type="vanished">刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="26"/>
             <source>Select all</source>
-            <translation>選擇全部</translation>
+            <translation type="vanished">選擇全部</translation>
         </message>
     </context>
     <context>
         <name>SidebarCalendarWidget</name>
         <message>
-            <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
             <source>M</source>
-            <translation>月</translation>
+            <translation type="vanished">月</translation>
         </message>
     </context>
     <context>
         <name>TimeJumpDialog</name>
         <message>
-            <location filename="../calendar-client/src/dialog/timejumpdialog.cpp" line="29"/>
             <source>Go</source>
-            <translation>跳 轉</translation>
             <comment>button</comment>
+            <translation type="vanished">跳 轉</translation>
         </message>
     </context>
     <context>
         <name>UserloginWidget</name>
         <message>
-            <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="48"/>
             <source>Sign In</source>
-            <translation>登 錄</translation>
             <comment>button</comment>
+            <translation type="vanished">登 錄</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="49"/>
             <source>Sign Out</source>
-            <translation>退出登錄</translation>
             <comment>button</comment>
+            <translation type="vanished">退出登錄</translation>
         </message>
     </context>
     <context>
         <name>YearFrame</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="928"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
     </context>
     <context>
         <name>today</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="188"/>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="337"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="93"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="230"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="57"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="275"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="261"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="609"/>
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Today</comment>
+            <translation type="vanished">今天</translation>
         </message>
     </context>
 </TS>

--- a/translations/dde-calendar-service_zh_TW.ts
+++ b/translations/dde-calendar-service_zh_TW.ts
@@ -1,1230 +1,1105 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE TS>
-<TS language="zh_TW" version="2.1">
+<TS version="2.1" language="zh_TW">
     <context>
         <name>AccountItem</name>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="41"/>
             <source>Sync successful</source>
-            <translation>同步成功</translation>
+            <translation type="vanished">同步成功</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="42"/>
             <source>Network error</source>
-            <translation>網路異常</translation>
+            <translation type="vanished">網路異常</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="43"/>
             <source>Server exception</source>
-            <translation>伺服器異常</translation>
+            <translation type="vanished">伺服器異常</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="44"/>
             <source>Storage full</source>
-            <translation>儲存已滿</translation>
+            <translation type="vanished">儲存已滿</translation>
         </message>
     </context>
     <context>
         <name>AccountManager</name>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="227"/>
             <source>Local account</source>
-            <translation>本機帳戶</translation>
+            <translation type="vanished">本機帳戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="229"/>
             <source>Event types</source>
-            <translation>日程類型</translation>
+            <translation type="vanished">日程類型</translation>
         </message>
     </context>
     <context>
         <name>CColorPickerWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="77"/>
             <source>Color</source>
-            <translation>顏色</translation>
+            <translation type="vanished">顏色</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="90"/>
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation type="vanished">取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="92"/>
             <source>Save</source>
-            <translation>儲 存</translation>
             <comment>button</comment>
+            <translation type="vanished">儲 存</translation>
         </message>
     </context>
     <context>
         <name>CDayMonthView</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="33"/>
             <source>Monday</source>
-            <translation>星期一</translation>
+            <translation type="vanished">星期一</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="34"/>
             <source>Tuesday</source>
-            <translation>星期二</translation>
+            <translation type="vanished">星期二</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35"/>
             <source>Wednesday</source>
-            <translation>星期三</translation>
+            <translation type="vanished">星期三</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36"/>
             <source>Thursday</source>
-            <translation>星期四</translation>
+            <translation type="vanished">星期四</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37"/>
             <source>Friday</source>
-            <translation>星期五</translation>
+            <translation type="vanished">星期五</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38"/>
             <source>Saturday</source>
-            <translation>星期六</translation>
+            <translation type="vanished">星期六</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39"/>
             <source>Sunday</source>
-            <translation>星期日</translation>
+            <translation type="vanished">星期日</translation>
         </message>
     </context>
     <context>
         <name>CDayWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="112"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="113"/>
             <source>M</source>
-            <translation>月</translation>
+            <translation type="vanished">月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="114"/>
             <source>D</source>
-            <translation>日</translation>
+            <translation type="vanished">日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="170"/>
             <source>Lunar</source>
-            <translation>農曆</translation>
+            <translation type="vanished">農曆</translation>
         </message>
     </context>
     <context>
         <name>CGraphicsView</name>
         <message>
-            <location filename="../calendar-client/src/view/graphicsview.cpp" line="628"/>
             <source>New Event</source>
-            <translation>建立日程</translation>
+            <translation type="vanished">建立日程</translation>
         </message>
     </context>
     <context>
         <name>CMonthScheduleNumItem</name>
         <message>
-            <location filename="../calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="80"/>
             <source>%1 more</source>
-            <translation>還有%1項</translation>
+            <translation type="vanished">還有%1項</translation>
         </message>
     </context>
     <context>
         <name>CMonthView</name>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="50"/>
             <source>New event</source>
-            <translation>建立日程</translation>
+            <translation type="vanished">建立日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="230"/>
             <source>New Event</source>
-            <translation>建立日程</translation>
+            <translation type="vanished">建立日程</translation>
         </message>
     </context>
     <context>
         <name>CMonthWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
     </context>
     <context>
         <name>CMyScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="284"/>
             <source>My Event</source>
-            <translation>我的日程</translation>
+            <translation type="vanished">我的日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="326"/>
             <source>OK</source>
-            <translation>確 定</translation>
             <comment>button</comment>
+            <translation type="vanished">確 定</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="331"/>
             <source>Delete</source>
-            <translation>刪 除</translation>
             <comment>button</comment>
+            <translation type="vanished">刪 除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="332"/>
             <source>Edit</source>
-            <translation>編 輯</translation>
             <comment>button</comment>
+            <translation type="vanished">編 輯</translation>
         </message>
     </context>
     <context>
         <name>CPushButton</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/cpushbutton.cpp" line="17"/>
             <source>New event type</source>
-            <translation>新增日程類型</translation>
+            <translation type="vanished">新增日程類型</translation>
         </message>
     </context>
     <context>
         <name>CScheduleDlg</name>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="46"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="625"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="921"/>
             <source>New Event</source>
-            <translation>建立日程</translation>
+            <translation type="vanished">建立日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="60"/>
             <source>Edit Event</source>
-            <translation>編輯日程</translation>
+            <translation type="vanished">編輯日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="270"/>
             <source>End time must be greater than start time</source>
-            <translation>結束時間需晚於開始時間</translation>
+            <translation type="vanished">結束時間需晚於開始時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="271"/>
             <source>OK</source>
-            <translation>確 定</translation>
             <comment>button</comment>
+            <translation type="vanished">確 定</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="506"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="535"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1133"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1168"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1422"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1426"/>
             <source>Never</source>
-            <translation>從不</translation>
+            <translation type="vanished">從不</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="507"/>
             <source>At time of event</source>
-            <translation>日程開始時</translation>
+            <translation type="vanished">日程開始時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="508"/>
             <source>15 minutes before</source>
-            <translation>15分鐘前</translation>
+            <translation type="vanished">15分鐘前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="509"/>
             <source>30 minutes before</source>
-            <translation>30分鐘前</translation>
+            <translation type="vanished">30分鐘前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="510"/>
             <source>1 hour before</source>
-            <translation>1小時前</translation>
+            <translation type="vanished">1小時前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="511"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="537"/>
             <source>1 day before</source>
-            <translation>1天前</translation>
+            <translation type="vanished">1天前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="512"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="538"/>
             <source>2 days before</source>
-            <translation>2天前</translation>
+            <translation type="vanished">2天前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="513"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="539"/>
             <source>1 week before</source>
-            <translation>1週前</translation>
+            <translation type="vanished">1週前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="536"/>
             <source>On start day (9:00 AM)</source>
-            <translation>日程發生當天（上午9點）</translation>
+            <translation type="vanished">日程發生當天（上午9點）</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="583"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="791"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1189"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1190"/>
             <source>time(s)</source>
-            <translation>次後</translation>
+            <translation type="vanished">次後</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="598"/>
             <source>Enter a name please</source>
-            <translation>名稱不能為空</translation>
+            <translation type="vanished">名稱不能為空</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="693"/>
             <source>The name can not only contain whitespaces</source>
-            <translation>名稱不能設置為全空格，請修改</translation>
+            <translation type="vanished">名稱不能設置為全空格，請修改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="749"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="871"/>
             <source>Type:</source>
-            <translation>類型：</translation>
+            <translation type="vanished">類型：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="754"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="906"/>
             <source>Description:</source>
-            <translation>內容：</translation>
+            <translation type="vanished">內容：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="759"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="943"/>
             <source>All Day:</source>
-            <translation>全天：</translation>
+            <translation type="vanished">全天：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="764"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1009"/>
             <source>Starts:</source>
-            <translation>開始時間：</translation>
+            <translation type="vanished">開始時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="769"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1050"/>
             <source>Ends:</source>
-            <translation>結束時間：</translation>
+            <translation type="vanished">結束時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="774"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1090"/>
             <source>Remind Me:</source>
-            <translation>提醒：</translation>
+            <translation type="vanished">提醒：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="779"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1122"/>
             <source>Repeat:</source>
-            <translation>重複：</translation>
+            <translation type="vanished">重複：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="784"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1156"/>
             <source>End Repeat:</source>
-            <translation>結束重複：</translation>
+            <translation type="vanished">結束重複：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="840"/>
             <source>Calendar account:</source>
-            <translation>日曆帳戶：</translation>
+            <translation type="vanished">日曆帳戶：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="841"/>
             <source>Calendar account</source>
-            <translation>日曆帳戶</translation>
+            <translation type="vanished">日曆帳戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="868"/>
             <source>Type</source>
-            <translation>類型</translation>
+            <translation type="vanished">類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="910"/>
             <source>Description</source>
-            <translation>內容</translation>
+            <translation type="vanished">內容</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="940"/>
             <source>All Day</source>
-            <translation>全天</translation>
+            <translation type="vanished">全天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="964"/>
             <source>Time:</source>
-            <translation>時間：</translation>
+            <translation type="vanished">時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="965"/>
             <source>Time</source>
-            <translation>時間</translation>
+            <translation type="vanished">時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="972"/>
             <source>Solar</source>
-            <translation>公曆</translation>
+            <translation type="vanished">公曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="973"/>
             <source>Lunar</source>
-            <translation>農曆</translation>
+            <translation type="vanished">農曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1006"/>
             <source>Starts</source>
-            <translation>開始時間</translation>
+            <translation type="vanished">開始時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1047"/>
             <source>Ends</source>
-            <translation>結束時間</translation>
+            <translation type="vanished">結束時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1092"/>
             <source>Remind Me</source>
-            <translation>提醒</translation>
+            <translation type="vanished">提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1119"/>
             <source>Repeat</source>
-            <translation>重複</translation>
+            <translation type="vanished">重複</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1134"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1427"/>
             <source>Daily</source>
-            <translation>每天</translation>
+            <translation type="vanished">每天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1135"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1428"/>
             <source>Weekdays</source>
-            <translation>工作日</translation>
+            <translation type="vanished">工作日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1136"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1429"/>
             <source>Weekly</source>
-            <translation>每週</translation>
+            <translation type="vanished">每週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1137"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1423"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1430"/>
             <source>Monthly</source>
-            <translation>每月</translation>
+            <translation type="vanished">每月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1138"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1424"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1431"/>
             <source>Yearly</source>
-            <translation>每年</translation>
+            <translation type="vanished">每年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1158"/>
             <source>End Repeat</source>
-            <translation>結束重複</translation>
+            <translation type="vanished">結束重複</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1169"/>
             <source>After</source>
-            <translation>於</translation>
+            <translation type="vanished">於</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1170"/>
             <source>On</source>
-            <translation>於日期</translation>
+            <translation type="vanished">於日期</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1240"/>
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation type="vanished">取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1241"/>
             <source>Save</source>
-            <translation>儲 存</translation>
             <comment>button</comment>
+            <translation type="vanished">儲 存</translation>
         </message>
     </context>
     <context>
         <name>CScheduleOperation</name>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74"/>
             <source>All occurrences of a repeating event must have the same all-day status.</source>
-            <translation>重複日程的所有重複必須具有相同的全天狀態。</translation>
+            <translation type="vanished">重複日程的所有重複必須具有相同的全天狀態。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="95"/>
             <source>Do you want to change all occurrences?</source>
-            <translation>您要更改所有重複嗎？</translation>
+            <translation type="vanished">您要更改所有重複嗎？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="96"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="129"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="151"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="174"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="259"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="292"/>
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation type="vanished">取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="97"/>
             <source>Change All</source>
-            <translation>全部更改</translation>
+            <translation type="vanished">全部更改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94"/>
             <source>You are changing the repeating rule of this event.</source>
-            <translation>您正在更改日程的重複規則。</translation>
+            <translation type="vanished">您正在更改日程的重複規則。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="149"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="172"/>
             <source>You are deleting an event.</source>
-            <translation>您正在刪除日程。</translation>
+            <translation type="vanished">您正在刪除日程。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128"/>
             <source>Are you sure you want to delete this event?</source>
-            <translation>您確定要刪除此日程嗎？</translation>
+            <translation type="vanished">您確定要刪除此日程嗎？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130"/>
             <source>Delete</source>
-            <translation>刪 除</translation>
             <comment>button</comment>
+            <translation type="vanished">刪 除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150"/>
             <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
-            <translation>您要刪除此日程的所有重複，還是只刪除所選重複？</translation>
+            <translation type="vanished">您要刪除此日程的所有重複，還是隻刪除所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152"/>
             <source>Delete All</source>
-            <translation>全部刪除</translation>
+            <translation type="vanished">全部刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="176"/>
             <source>Delete Only This Event</source>
-            <translation>僅刪除此日程</translation>
+            <translation type="vanished">僅刪除此日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173"/>
             <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
-            <translation>您要刪除此日程的這個重複和所有將來重複，還是只刪除所選重複？</translation>
+            <translation type="vanished">您要刪除此日程的這個重複和所有將來重複，還是隻刪除所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175"/>
             <source>Delete All Future Events</source>
-            <translation>刪除所有將來日程</translation>
+            <translation type="vanished">刪除所有將來日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="288"/>
             <source>You are changing a repeating event.</source>
-            <translation>您正在更改重複日程。</translation>
+            <translation type="vanished">您正在更改重複日程。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257"/>
             <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
-            <translation>您要更改此日程的僅這一個重複，還是更改它的所有重複？</translation>
+            <translation type="vanished">您要更改此日程的僅這一個重複，還是更改它的所有重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260"/>
             <source>All</source>
-            <translation>全部日程</translation>
+            <translation type="vanished">全部日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="294"/>
             <source>Only This Event</source>
-            <translation>僅此日程</translation>
+            <translation type="vanished">僅此日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290"/>
             <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
-            <translation>您要更改此日程的這個重複和所有將來重複，還是只更改所選重複？</translation>
+            <translation type="vanished">您要更改此日程的這個重複和所有將來重複，還是隻更改所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293"/>
             <source>All Future Events</source>
-            <translation>所有將來日程</translation>
+            <translation type="vanished">所有將來日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416"/>
             <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
-            <translation>您選擇的是閏月，將按照農曆規則提醒</translation>
+            <translation type="vanished">您選擇的是閏月，將按照農曆規則提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417"/>
             <source>OK</source>
-            <translation>確 定</translation>
             <comment>button</comment>
+            <translation type="vanished">確 定</translation>
         </message>
     </context>
     <context>
         <name>CScheduleSearchDateItem</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
             <source>M</source>
-            <translation>月</translation>
+            <translation type="vanished">月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
             <source>D</source>
-            <translation>日</translation>
+            <translation type="vanished">日</translation>
         </message>
     </context>
     <context>
         <name>CScheduleSearchItem</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="42"/>
             <source>Edit</source>
-            <translation>編輯</translation>
+            <translation type="vanished">編輯</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="43"/>
             <source>Delete</source>
-            <translation>刪除</translation>
+            <translation type="vanished">刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="267"/>
             <source>All Day</source>
-            <translation>全天</translation>
+            <translation type="vanished">全天</translation>
         </message>
     </context>
     <context>
         <name>CScheduleSearchView</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="648"/>
             <source>No search results</source>
-            <translation>找不到結果</translation>
+            <translation type="vanished">找不到結果</translation>
         </message>
     </context>
     <context>
         <name>CScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/scheduleview.cpp" line="316"/>
             <source>ALL DAY</source>
-            <translation>全天</translation>
+            <translation type="vanished">全天</translation>
         </message>
     </context>
     <context>
         <name>CSettingDialog</name>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="389"/>
             <source>import ICS file</source>
-            <translation>匯入ICS檔案</translation>
+            <translation type="vanished">匯入ICS檔案</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="403"/>
             <source>Manual</source>
-            <translation>手動</translation>
+            <translation type="vanished">手動</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="404"/>
             <source>15 mins</source>
-            <translation>每15分鐘</translation>
+            <translation type="vanished">每15分鐘</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="405"/>
             <source>30 mins</source>
-            <translation>每30分鐘</translation>
+            <translation type="vanished">每30分鐘</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="406"/>
             <source>1 hour</source>
-            <translation>每1小時</translation>
+            <translation type="vanished">每1小時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="407"/>
             <source>24 hours</source>
-            <translation>每24小時</translation>
+            <translation type="vanished">每24小時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="418"/>
             <source>Sync Now</source>
-            <translation>立即同步</translation>
+            <translation type="vanished">立即同步</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="585"/>
             <source>Last sync</source>
-            <translation>最近同步時間</translation>
+            <translation type="vanished">最近同步時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="779"/>
-            <source>Please go to the &lt;a href='/'&gt;Control Center&lt;/a&gt; to change system settings</source>
-            <translation>請前往控制中心更改系統設定</translation>
+            <source>Please go to the Control Center to change system settings</source>
+            <translation type="vanished">請前往控制中心更改系統設置</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="346"/>
             <source>Monday</source>
-            <translation>週一</translation>
+            <translation type="vanished">週一</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="345"/>
             <source>Sunday</source>
-            <translation>週日</translation>
+            <translation type="vanished">週日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="347"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="366"/>
             <source>Use System Setting</source>
-            <translation>使用系統設定</translation>
+            <translation type="vanished">使用系統設定</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="365"/>
             <source>12-hour clock</source>
-            <translation>12小時制</translation>
+            <translation type="vanished">12小時制</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="364"/>
             <source>24-hour clock</source>
-            <translation>24小時制</translation>
+            <translation type="vanished">24小時制</translation>
         </message>
     </context>
     <context>
         <name>CTimeEdit</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="71"/>
             <source>(%1 mins)</source>
-            <translation>(%1分鐘)</translation>
+            <translation type="vanished">(%1分鐘)</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="73"/>
             <source>(%1 hour)</source>
-            <translation>(%1小時)</translation>
+            <translation type="vanished">(%1小時)</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="75"/>
             <source>(%1 hours)</source>
-            <translation>(%1小時)</translation>
+            <translation type="vanished">(%1小時)</translation>
         </message>
     </context>
     <context>
         <name>CTitleWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="30"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="42"/>
             <source>M</source>
-            <translation>月</translation>
+            <translation type="vanished">月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="50"/>
             <source>W</source>
-            <translation>週</translation>
+            <translation type="vanished">週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="58"/>
             <source>D</source>
-            <translation>日</translation>
+            <translation type="vanished">日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="92"/>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="93"/>
             <source>Search events and festivals</source>
-            <translation>搜尋日程/節日</translation>
+            <translation type="vanished">搜尋日程/節日</translation>
         </message>
     </context>
     <context>
         <name>CWeekWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="90"/>
             <source>Week</source>
-            <translation>週</translation>
+            <translation type="vanished">週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="280"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
     </context>
     <context>
         <name>CYearScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="268"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="271"/>
             <source>All Day</source>
-            <translation>全天</translation>
+            <translation type="vanished">全天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="288"/>
             <source>No event</source>
-            <translation>無日程</translation>
+            <translation type="vanished">無日程</translation>
         </message>
     </context>
     <context>
         <name>CYearWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="615"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
     </context>
     <context>
         <name>CalendarWindow</name>
         <message>
-            <location filename="../calendar-client/src/main.cpp" line="66"/>
             <source>Calendar</source>
-            <translation>日曆</translation>
+            <translation type="vanished">日曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/main.cpp" line="69"/>
-            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life.</source>
-            <translation>日曆是一款查看日期、管理日程的小工具。</translation>
+            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
+            <translation type="vanished">日曆是一款查看日期、管理日程的小工具。</translation>
         </message>
     </context>
     <context>
         <name>Calendarmainwindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="89"/>
             <source>Calendar</source>
-            <translation>日曆</translation>
+            <translation type="vanished">日曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="372"/>
             <source>Manage</source>
-            <translation>管理</translation>
+            <translation type="vanished">管理</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="379"/>
             <source>Privacy Policy</source>
-            <translation>隱私政策</translation>
+            <translation type="vanished">隱私政策</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="962"/>
             <source>Syncing...</source>
-            <translation>正在同步...</translation>
+            <translation type="vanished">正在同步...</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="973"/>
             <source>Sync successful</source>
-            <translation>同步成功</translation>
+            <translation type="vanished">同步成功</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="982"/>
             <source>Sync failed, please try later</source>
-            <translation>同步失敗，請稍後再試</translation>
+            <translation type="vanished">同步失敗，請稍後再試</translation>
         </message>
     </context>
     <context>
         <name>CenterWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="174"/>
             <source>All Day</source>
-            <translation>全天</translation>
+            <translation type="vanished">全天</translation>
         </message>
     </context>
     <context>
         <name>DAccountDataBase</name>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1155"/>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1304" />
             <source>Work</source>
             <translation>工作</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1157"/>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1306" />
             <source>Life</source>
             <translation>生活</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1159"/>
+            <location filename="../src/calendar-service/src/dbmanager/daccountdatabase.cpp" line="1308" />
             <source>Other</source>
             <translation>其他</translation>
         </message>
     </context>
     <context>
+        <name>DAccountManageModule</name>
+        <message>
+            <location filename="../src/calendar-service/src/calendarDataManager/daccountmanagemodule.cpp" line="125" />
+            <source>[Original Type: %1]</source>
+            <translation>[原類型: %1]</translation>
+        </message>
+    </context>
+    <context>
         <name>DAlarmManager</name>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="187"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="196"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="201"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="212"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="194" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="203" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="208" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="219" />
             <source>Close</source>
-            <translation>關 閉</translation>
             <comment>button</comment>
+            <translation>關 閉</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="191"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="198" />
             <source>One day before start</source>
             <translation>提前1天提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="197"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="204" />
             <source>Remind me tomorrow</source>
             <translation>明天提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="202"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="209" />
             <source>Remind me later</source>
             <translation>稍後提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="204"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="211" />
             <source>15 mins later</source>
             <translation>15分鐘後</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="205"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="212" />
             <source>1 hour later</source>
             <translation>1小時後</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="206"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="213" />
             <source>4 hours later</source>
             <translation>4小時後</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="207"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="300"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="313"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="214" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="311" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="324" />
             <source>Tomorrow</source>
             <translation>明天</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="215"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="222" />
             <source>Schedule Reminder</source>
             <translation>日程提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="258"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="270"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="268" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="280" />
             <source>%1 to %2</source>
             <translation>%1 至 %2</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="296"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="309"/>
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="307" />
+            <location filename="../src/calendar-service/src/alarmManager/dalarmmanager.cpp" line="320" />
             <source>Today</source>
             <translation>今天</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavAccountRegistrar</name>
+        <message>
+            <location filename="../src/calendar-service/src/caldav/dcaldavaccountregistrar.cpp" line="60" />
+            <source>Calendar</source>
+            <translation>日曆</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavProviderProfile</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="37" />
+            <source>DingTalk</source>
+            <translation>釘釘</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="39" />
+            <source>WeCom</source>
+            <translation>企業微信</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="41" />
+            <source>Tencent Meeting</source>
+            <translation>騰訊會議</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="43" />
+            <source>QQ Mail</source>
+            <translation>QQ郵箱</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="45" />
+            <source>Feishu</source>
+            <translation>飛書</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="48" />
+            <source>Other CalDAV</source>
+            <translation>其他 CalDAV</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCalDavSyncStatus</name>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server request is invalid.</source>
+            <translation>服務器請求無效</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="71" />
+            <source>The server is busy. Please try again later.</source>
+            <translation>服務器繁忙，請稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="74" />
+            <source>The server is unavailable. Please try again later.</source>
+            <translation>服務器不可用，請稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="77" />
+            <source>The calendar data conflicts with the server.</source>
+            <translation>日曆數據與服務器存在衝突</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="80" />
+            <source>The server returned too much data. Please try again later.</source>
+            <translation>服務器返回的數據過大，請稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="91" />
+            <source>Unable to save calendar data. Please try again later.</source>
+            <translation>無法保存日曆數據，請稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server certificate is invalid.</source>
+            <translation>服務器證書無效</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="54" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>用戶名或密碼錯誤，請重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="57" />
+            <source>This server does not support CalDAV.</source>
+            <translation>該服務器不支持CalDAV協議</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="61" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>服務器返回的數據無法解析，請確認服務器地址或稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="65" />
+            <source>The server denied access.</source>
+            <translation>服務器拒絕訪問</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="68" />
+            <source>The server request timed out.</source>
+            <translation>服務器請求超時</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="72" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>無法連接到服務器，請檢查網絡連接和服務器地址。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76" />
+            <source>Synchronization failed.</source>
+            <translation>同步失敗</translation>
         </message>
     </context>
     <context>
         <name>DragInfoGraphicsView</name>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="48"/>
             <source>Edit</source>
-            <translation>編輯</translation>
+            <translation type="vanished">編輯</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="49"/>
             <source>Delete</source>
-            <translation>刪除</translation>
+            <translation type="vanished">刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="50"/>
             <source>New event</source>
-            <translation>建立日程</translation>
+            <translation type="vanished">建立日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="759"/>
             <source>New Event</source>
-            <translation>建立日程</translation>
+            <translation type="vanished">建立日程</translation>
         </message>
     </context>
     <context>
         <name>JobTypeListView</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="144"/>
             <source>export</source>
-            <translation>匯出</translation>
+            <translation type="vanished">匯出</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="219"/>
             <source>import ICS file</source>
-            <translation>匯入ICS檔案</translation>
+            <translation type="vanished">匯入ICS檔案</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="450"/>
             <source>You are deleting an event type.</source>
-            <translation>您正在刪除日程類型。</translation>
+            <translation type="vanished">您正在刪除日程類型。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="451"/>
             <source>All events under this type will be deleted and cannot be recovered.</source>
-            <translation>此日程類型下的所有日程都會刪除且不可恢復。</translation>
+            <translation type="vanished">此日程類型下的所有日程都會刪除且不可恢復。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="452"/>
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation type="vanished">取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="453"/>
             <source>Delete</source>
-            <translation>刪 除</translation>
             <comment>button</comment>
+            <translation type="vanished">刪 除</translation>
         </message>
     </context>
     <context>
         <name>QObject</name>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="38"/>
             <source>Account settings</source>
-            <translation>帳戶設定</translation>
+            <translation type="vanished">帳戶設定</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="42"/>
             <source>Account</source>
-            <translation>帳戶</translation>
+            <translation type="vanished">帳戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="53"/>
             <source>Select items to be synced</source>
-            <translation>設定您的同步項</translation>
+            <translation type="vanished">設定您的同步項</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="56"/>
             <source>Events</source>
-            <translation>日程</translation>
+            <translation type="vanished">日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="63"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="146"/>
             <source>General settings</source>
-            <translation>一般設定</translation>
+            <translation type="vanished">一般設定</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="74"/>
             <source>Sync interval</source>
-            <translation>同步頻率</translation>
+            <translation type="vanished">同步頻率</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="96"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="127"/>
             <source>Manage calendar</source>
-            <translation>日曆管理</translation>
+            <translation type="vanished">日曆管理</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="104"/>
             <source>Calendar account</source>
-            <translation>日曆帳戶</translation>
+            <translation type="vanished">日曆帳戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="112"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="131"/>
             <source>Event types</source>
-            <translation>日程類型</translation>
+            <translation type="vanished">日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="150"/>
             <source>General</source>
-            <translation>通用</translation>
+            <translation type="vanished">通用</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="152"/>
             <source>First day of week</source>
-            <translation>每星期開始於</translation>
+            <translation type="vanished">每星期開始於</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="153"/>
             <source>Time</source>
-            <translation>時間</translation>
+            <translation type="vanished">時間</translation>
         </message>
     </context>
     <context>
         <name>Return</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="611"/>
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Return</comment>
+            <translation type="vanished">今天</translation>
         </message>
     </context>
     <context>
         <name>Return Today</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="339"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="95"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="277"/>
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Return Today</comment>
+            <translation type="vanished">今天</translation>
         </message>
     </context>
     <context>
         <name>ScheduleTypeEditDlg</name>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22"/>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="48"/>
             <source>New event type</source>
-            <translation>新增日程類型</translation>
+            <translation type="vanished">新增日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="32"/>
             <source>Edit event type</source>
-            <translation>編輯日程類型</translation>
+            <translation type="vanished">編輯日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="43"/>
             <source>Import ICS file</source>
-            <translation>匯入ICS檔案</translation>
+            <translation type="vanished">匯入ICS檔案</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="151"/>
             <source>Name:</source>
-            <translation>名稱：</translation>
+            <translation type="vanished">名稱：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="152"/>
             <source>Color:</source>
-            <translation>顏色：</translation>
+            <translation type="vanished">顏色：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="156"/>
-            <source>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt; File:</source>
-            <translation>ICS檔案：</translation>
+            <source>ICS File:</source>
+            <translation type="vanished">ICS文件：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="167"/>
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation type="vanished">取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="168"/>
             <source>Save</source>
-            <translation>儲 存</translation>
             <comment>button</comment>
+            <translation type="vanished">儲 存</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="219"/>
             <source>The name can not only contain whitespaces</source>
-            <translation>名稱不能設置為全空格，請修改</translation>
+            <translation type="vanished">名稱不能設置為全空格，請修改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="256"/>
             <source>Enter a name please</source>
-            <translation>名稱不能為空</translation>
+            <translation type="vanished">名稱不能為空</translation>
         </message>
     </context>
     <context>
         <name>Shortcut</name>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="16"/>
             <source>Help</source>
-            <translation>幫助</translation>
+            <translation type="vanished">幫助</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="17"/>
             <source>Delete event</source>
-            <translation>刪除日程</translation>
+            <translation type="vanished">刪除日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="20"/>
             <source>Copy</source>
-            <translation>複製</translation>
+            <translation type="vanished">複製</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="21"/>
             <source>Cut</source>
-            <translation>剪下</translation>
+            <translation type="vanished">剪下</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="22"/>
             <source>Paste</source>
-            <translation>貼上</translation>
+            <translation type="vanished">貼上</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="25"/>
             <source>Delete</source>
-            <translation>刪除</translation>
+            <translation type="vanished">刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="26"/>
             <source>Select all</source>
-            <translation>全選</translation>
+            <translation type="vanished">全選</translation>
         </message>
     </context>
     <context>
         <name>SidebarCalendarWidget</name>
         <message>
-            <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
             <source>M</source>
-            <translation>月</translation>
+            <translation type="vanished">月</translation>
         </message>
     </context>
     <context>
         <name>TimeJumpDialog</name>
         <message>
-            <location filename="../calendar-client/src/dialog/timejumpdialog.cpp" line="29"/>
             <source>Go</source>
-            <translation>跳 轉</translation>
             <comment>button</comment>
+            <translation type="vanished">跳 轉</translation>
         </message>
     </context>
     <context>
         <name>UserloginWidget</name>
         <message>
-            <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="48"/>
             <source>Sign In</source>
-            <translation>登 入</translation>
             <comment>button</comment>
+            <translation type="vanished">登 入</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="49"/>
             <source>Sign Out</source>
-            <translation>退出登入</translation>
             <comment>button</comment>
+            <translation type="vanished">退出登入</translation>
         </message>
     </context>
     <context>
         <name>YearFrame</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="928"/>
             <source>Y</source>
-            <translation>年</translation>
+            <translation type="vanished">年</translation>
         </message>
     </context>
     <context>
         <name>today</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="188"/>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="337"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="93"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="230"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="57"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="275"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="261"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="609"/>
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Today</comment>
+            <translation type="vanished">今天</translation>
         </message>
     </context>
 </TS>

--- a/translations/dde-calendar_en_US.ts
+++ b/translations/dde-calendar_en_US.ts
@@ -180,6 +180,38 @@
         <comment>button</comment>
         <translation>Edit</translation>
     </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="193"/>
+        <source>Calendar Source</source>
+        <translation>Calendar Source</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="118"/>
+        <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="177"/>
+        <source>Local calendar</source>
+        <translation>Local calendar</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="120"/>
+        <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="179"/>
+        <source>UOS ID</source>
+        <translation>UOS ID</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="131"/>
+        <source>Source: %1</source>
+        <translation>Source: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="152"/>
+        <source>Organizer</source>
+        <translation>Organizer</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="153"/>
+        <source>Attendees</source>
+        <translation>Attendees</translation>
+    </message>
 </context>
 <context>
     <name>CPushButton</name>
@@ -429,6 +461,16 @@
         <comment>button</comment>
         <translation>Save</translation>
     </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1407"/>
+        <source>Local calendar</source>
+        <translation>Local calendar</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1409"/>
+        <source>UOS ID</source>
+        <translation>UOS ID</translation>
+    </message>
 </context>
 <context>
     <name>CScheduleOperation</name>
@@ -665,6 +707,97 @@
         <source>Please go to the Control Center to change system settings</source>
         <translation>Please go to the Control Center to change system settings</translation>
     </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="214"/>
+        <source>More</source>
+        <translation>More</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="246"/>
+        <source>Third-party accounts</source>
+        <translation>Third-party accounts</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="255"/>
+        <source>Add</source>
+        <translation>Add</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="304"/>
+        <source>Sync items</source>
+        <translation>Sync items</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="305"/>
+        <source>Sync interval</source>
+        <translation>Sync interval</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="497"/>
+        <source>Add schedule</source>
+        <translation>Add schedule</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="498"/>
+        <source>Import ICS file</source>
+        <translation>Import ICS file</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="499"/>
+        <source>Import events from an ICS file</source>
+        <translation>Import events from an ICS file</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="681"/>
+        <source>Remove Calendar Account</source>
+        <translation>Remove Calendar Account</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="689"/>
+        <source>Are you sure you want to remove the account "%1"?</source>
+        <translation>Are you sure you want to remove the account "%1"?</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="693"/>
+        <source>Also remove synced events from this calendar</source>
+        <translation>Also remove synced events from this calendar</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="698"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Cancel</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="699"/>
+        <source>Delete</source>
+        <comment>button</comment>
+        <translation>Delete</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="818"/>
+        <source>Last sync time</source>
+        <translation>Last sync time</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="794"/>
+        <source>Syncing...</source>
+        <translation>Syncing...</translation>
+    </message>
+    <message>
+        <source>Last sync: %1</source>
+        <translation>Last sync: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="908"/>
+        <source>Local account</source>
+        <translation>Local account</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="1049"/>
+        <source>Please go to the <a href='/'>Control Center</a> to change system settings</source>
+        <translation>Please go to the <a href='/'>Control Center</a> to change system settings</translation>
+    </message>
 </context>
 <context>
     <name>CTimeEdit</name>
@@ -790,6 +923,16 @@
         <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="982"/>
         <source>Sync failed, please try later</source>
         <translation>Sync failed, please try later</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1266"/>
+        <source>%1 does not allow creating events. Please check account permissions.</source>
+        <translation>%1 does not allow creating events. Please check account permissions.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1269"/>
+        <source>Unable to connect to the server. Please check your network connection and server address.</source>
+        <translation>Unable to connect to the server. Please check your network connection and server address.</translation>
     </message>
 </context>
 <context>
@@ -934,6 +1077,28 @@
         <comment>button</comment>
         <translation>Delete</translation>
     </message>
+    <message>
+        <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="213"/>
+        <source>Edit</source>
+        <translation>Edit</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="219"/>
+        <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="233"/>
+        <source>Export</source>
+        <translation>Export</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="308"/>
+        <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="417"/>
+        <source>ICS files (*.ics)</source>
+        <translation>ICS files (*.ics)</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="416"/>
+        <source>Export ICS file</source>
+        <translation>Export ICS file</translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
@@ -996,6 +1161,21 @@
         <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="153"/>
         <source>Time</source>
         <translation>Time</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="54"/>
+        <source>UOS ID</source>
+        <translation>UOS ID</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="59"/>
+        <source>Third-party accounts</source>
+        <translation>Third-party accounts</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="75"/>
+        <source>Associated account</source>
+        <translation>Associated account</translation>
     </message>
 </context>
 <context>
@@ -1069,6 +1249,11 @@
         <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="256"/>
         <source>Enter a name please</source>
         <translation>Enter a name please</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="164"/>
+        <source><a href='https://wikipedia.org/wiki/ICalendar'>ICS</a> File:</source>
+        <translation><a href='https://wikipedia.org/wiki/ICalendar'>ICS</a> File:</translation>
     </message>
 </context>
 <context>
@@ -1145,6 +1330,11 @@
         <comment>button</comment>
         <translation>Sign Out</translation>
     </message>
+    <message>
+        <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="203"/>
+        <source>Not signed in</source>
+        <translation>Not signed in</translation>
+    </message>
 </context>
 <context>
     <name>YearFrame</name>
@@ -1163,4 +1353,308 @@
         <translation>Today</translation>
     </message>
 </context>
+    <context>
+        <name>CalDavAccountDialog</name>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="65"/>
+        <source>:</source>
+        <translation>:</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="75"/>
+        <source>Add Calendar Account</source>
+        <translation>Add Calendar Account</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="98"/>
+        <source>Select account type</source>
+        <translation>Select account type</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="109"/>
+        <source>Automatically filled after selecting account type</source>
+        <translation>Automatically filled after selecting account type</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="110"/>
+        <source>Enter username or email</source>
+        <translation>Enter username or email</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="111"/>
+        <source>Enter password</source>
+        <translation>Enter password</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="118"/>
+        <source>Account Type</source>
+        <translation>Account Type</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="119"/>
+        <source>Server Address</source>
+        <translation>Server Address</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="120"/>
+        <source>Username</source>
+        <translation>Username</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="121"/>
+        <source>Password</source>
+        <translation>Password</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="132"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Cancel</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="133"/>
+        <source>Sign In</source>
+        <comment>button</comment>
+        <translation>Sign In</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="224"/>
+        <source>Edit Account</source>
+        <translation>Edit Account</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="225"/>
+        <source>Save</source>
+        <comment>button</comment>
+        <translation>Save</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="232"/>
+        <source>Leave empty to keep the current password</source>
+        <translation>Leave empty to keep the current password</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="510"/>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="558"/>
+        <source>Please enter a valid server address.</source>
+        <translation>Please enter a valid server address.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="561"/>
+        <source>Please enter the correct username.</source>
+        <translation>Please enter the correct username.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="562"/>
+        <source>Please enter the correct password.</source>
+        <translation>Please enter the correct password.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="571"/>
+        <source>Incorrect username or password. Please try again.</source>
+        <translation>Incorrect username or password. Please try again.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="573"/>
+        <source>This server does not support CalDAV.</source>
+        <translation>This server does not support CalDAV.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="575"/>
+        <source>The server rejected your login request. Please check your account permissions.</source>
+        <translation>The server rejected your login request. Please check your account permissions.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="577"/>
+        <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+        <translation>Unable to parse the data returned by the server. Please verify the server address or try again later.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="579"/>
+        <source>The server certificate is invalid.</source>
+        <translation>The server certificate is invalid.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="583"/>
+        <source>Unable to connect to the server. Please check your network connection and server address.</source>
+        <translation>Unable to connect to the server. Please check your network connection and server address.</translation>
+    </message>
+    </context>
+    <context>
+        <name>CalDavAccountListWidget</name>
+    <message>
+        <source>Last sync: %1</source>
+        <translation>Last sync: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="69"/>
+        <source>Last sync time</source>
+        <translation>Last sync time</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="151"/>
+        <source>No third-party accounts added</source>
+        <translation>No third-party accounts added</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="157"/>
+        <source>Add</source>
+        <translation>Add</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="210"/>
+        <source>Pending synchronization</source>
+        <translation>Pending synchronization</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="210"/>
+        <source>Delete</source>
+        <translation>Delete</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="242"/>
+        <source>Sync conflict</source>
+        <translation>Sync conflict</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="243"/>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="304"/>
+        <source>A synchronization conflict was detected. The server version will replace the local changes.</source>
+        <translation>A synchronization conflict was detected. The server version will replace the local changes.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="252"/>
+        <source>Sync Failed: %1</source>
+        <translation>Sync Failed: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="255"/>
+        <source>Deleting...</source>
+        <translation>Deleting...</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="255"/>
+        <source>Syncing...</source>
+        <translation>Syncing...</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="267"/>
+        <source>Sync Now</source>
+        <translation>Sync Now</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="302"/>
+        <source>Calendar synchronization conflict</source>
+        <translation>Calendar synchronization conflict</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="308"/>
+        <source>Use server version</source>
+        <translation>Use server version</translation>
+    </message>
+    </context>
+    <context>
+        <name>DCalDavProviderProfile</name>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="37"/>
+        <source>DingTalk</source>
+        <translation>DingTalk</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="39"/>
+        <source>WeCom</source>
+        <translation>WeCom</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="41"/>
+        <source>Tencent Meeting</source>
+        <translation>Tencent Meeting</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="43"/>
+        <source>QQ Mail</source>
+        <translation>QQ Mail</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="45"/>
+        <source>Feishu</source>
+        <translation>Feishu</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavprofile.h" line="48"/>
+        <source>Other CalDAV</source>
+        <translation>Other CalDAV</translation>
+    </message>
+    </context>
+    <context>
+        <name>DCalDavSyncStatus</name>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="61"/>
+        <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+        <translation>Unable to parse the data returned by the server. Please verify the server address or try again later.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51"/>
+        <source>The server certificate is invalid.</source>
+        <translation>The server certificate is invalid.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="54"/>
+        <source>Incorrect username or password. Please try again.</source>
+        <translation>Incorrect username or password. Please try again.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="57"/>
+        <source>This server does not support CalDAV.</source>
+        <translation>This server does not support CalDAV.</translation>
+    </message>
+    <message>
+        <source>The server rejected your login request. Please check your account permissions.</source>
+        <translation>The server rejected your login request. Please check your account permissions.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="65"/>
+        <source>The server denied access.</source>
+        <translation>The server denied access.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="68"/>
+        <source>The server request timed out.</source>
+        <translation>The server request timed out.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="72"/>
+        <source>Unable to connect to the server. Please check your network connection and server address.</source>
+        <translation>Unable to connect to the server. Please check your network connection and server address.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76"/>
+        <source>Synchronization failed.</source>
+        <translation>Synchronization failed.</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="855"/>
+        <source>Sync Failed</source>
+        <translation>Sync Failed</translation>
+    </message>
+    </context>
+    <context>
+        <name>SidebarAccountItemWidget</name>
+    <message>
+        <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="335"/>
+        <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="345"/>
+        <source>Sync</source>
+        <translation>Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="344"/>
+        <source>Deleting...</source>
+        <translation>Deleting...</translation>
+    </message>
+    <message>
+        <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="345"/>
+        <source>Syncing...</source>
+        <translation>Syncing...</translation>
+    </message>
+    </context>
 </TS>

--- a/translations/dde-calendar_zh_HK.ts
+++ b/translations/dde-calendar_zh_HK.ts
@@ -1,25 +1,25 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE TS>
-<TS language="zh_HK" version="2.1">
+<TS version="2.1" language="zh_HK">
     <context>
         <name>AccountItem</name>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="41"/>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="50" />
             <source>Sync successful</source>
             <translation>同步成功</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="42"/>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="54" />
             <source>Network error</source>
             <translation>網絡異常</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="43"/>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="58" />
             <source>Server exception</source>
             <translation>伺服器異常</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="44"/>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="62" />
             <source>Storage full</source>
             <translation>存儲已滿</translation>
         </message>
@@ -27,12 +27,14 @@
     <context>
         <name>AccountManager</name>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="227"/>
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="180" />
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="491" />
             <source>Local account</source>
             <translation>本地帳戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="229"/>
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="180" />
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="494" />
             <source>Event types</source>
             <translation>日程類型</translation>
         </message>
@@ -40,57 +42,57 @@
     <context>
         <name>CColorPickerWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="77"/>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="83" />
             <source>Color</source>
             <translation>顏色</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="90"/>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="96" />
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation>取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="92"/>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="98" />
             <source>Save</source>
-            <translation>保 存</translation>
             <comment>button</comment>
+            <translation>保 存</translation>
         </message>
     </context>
     <context>
         <name>CDayMonthView</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="33"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35" />
             <source>Monday</source>
             <translation>星期一</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="34"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36" />
             <source>Tuesday</source>
             <translation>星期二</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37" />
             <source>Wednesday</source>
             <translation>星期三</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38" />
             <source>Thursday</source>
             <translation>星期四</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39" />
             <source>Friday</source>
             <translation>星期五</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="40" />
             <source>Saturday</source>
             <translation>星期六</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="41" />
             <source>Sunday</source>
             <translation>星期日</translation>
         </message>
@@ -98,22 +100,22 @@
     <context>
         <name>CDayWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="112"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="128" />
             <source>Y</source>
             <translation>年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="113"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="129" />
             <source>M</source>
             <translation>月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="114"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="130" />
             <source>D</source>
             <translation>日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="170"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="196" />
             <source>Lunar</source>
             <translation>農曆</translation>
         </message>
@@ -121,7 +123,7 @@
     <context>
         <name>CGraphicsView</name>
         <message>
-            <location filename="../calendar-client/src/view/graphicsview.cpp" line="628"/>
+            <location filename="../src/calendar-client/src/view/graphicsview.cpp" line="686" />
             <source>New Event</source>
             <translation>新建日程</translation>
         </message>
@@ -129,7 +131,7 @@
     <context>
         <name>CMonthScheduleNumItem</name>
         <message>
-            <location filename="../calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="80"/>
+            <location filename="../src/calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="88" />
             <source>%1 more</source>
             <translation>還有%1項</translation>
         </message>
@@ -137,12 +139,12 @@
     <context>
         <name>CMonthView</name>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="50"/>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthview.cpp" line="52" />
             <source>New event</source>
             <translation>新建日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="230"/>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthview.cpp" line="240" />
             <source>New Event</source>
             <translation>新建日程</translation>
         </message>
@@ -150,7 +152,7 @@
     <context>
         <name>CMonthWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98"/>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="103" />
             <source>Y</source>
             <translation>年</translation>
         </message>
@@ -158,33 +160,65 @@
     <context>
         <name>CMyScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="284"/>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="363" />
             <source>My Event</source>
             <translation>我的日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="326"/>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="424" />
             <source>OK</source>
+            <comment>button</comment>
             <translation>確 定</translation>
-            <comment>button</comment>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="331"/>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="429" />
             <source>Delete</source>
-            <translation>刪 除</translation>
             <comment>button</comment>
+            <translation>刪 除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="332"/>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="430" />
             <source>Edit</source>
-            <translation>更 改</translation>
             <comment>button</comment>
+            <translation>更 改</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="131" />
+            <source>Source: %1</source>
+            <translation>來源: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="152" />
+            <source>Organizer</source>
+            <translation>發起人</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="153" />
+            <source>Attendees</source>
+            <translation>參會人</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="118" />
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="177" />
+            <source>Local calendar</source>
+            <translation>本地日曆</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="120" />
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="179" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="193" />
+            <source>Calendar Source</source>
+            <translation>日曆來源</translation>
         </message>
     </context>
     <context>
         <name>CPushButton</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/cpushbutton.cpp" line="17"/>
+            <location filename="../src/calendar-client/src/customWidget/cpushbutton.cpp" line="19" />
             <source>New event type</source>
             <translation>新增日程類型</translation>
         </message>
@@ -192,410 +226,420 @@
     <context>
         <name>CScheduleDlg</name>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="46"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="625"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="921"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="48" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="700" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1014" />
             <source>New Event</source>
             <translation>新建日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="60"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="62" />
             <source>Edit Event</source>
             <translation>更改日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="270"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="298" />
             <source>End time must be greater than start time</source>
             <translation>結束時間需晚於開始時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="271"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="299" />
             <source>OK</source>
-            <translation>確 定</translation>
             <comment>button</comment>
+            <translation>確 定</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="506"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="535"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1133"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1168"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1422"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1426"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="559" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="596" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1226" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1261" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1591" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1596" />
             <source>Never</source>
             <translation>永不</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="507"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="560" />
             <source>At time of event</source>
             <translation>日程開始時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="508"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="561" />
             <source>15 minutes before</source>
             <translation>15分鐘前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="509"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="562" />
             <source>30 minutes before</source>
             <translation>30分鐘前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="510"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="563" />
             <source>1 hour before</source>
             <translation>1小時前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="511"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="537"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="564" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="598" />
             <source>1 day before</source>
             <translation>1天前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="512"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="538"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="565" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="599" />
             <source>2 days before</source>
             <translation>2天前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="513"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="539"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="566" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="600" />
             <source>1 week before</source>
             <translation>1週前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="536"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="597" />
             <source>On start day (9:00 AM)</source>
             <translation>日程發生當天（上午9點）</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="583"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="791"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1189"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1190"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="652" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="883" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1282" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1283" />
             <source>time(s)</source>
             <translation>次後</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="598"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="670" />
             <source>Enter a name please</source>
             <translation>名稱不能為空</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="693"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="779" />
             <source>The name can not only contain whitespaces</source>
             <translation>名稱不能設置為全空格，請修改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="749"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="871"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="841" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="964" />
             <source>Type:</source>
             <translation>類型：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="754"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="906"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="846" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="999" />
             <source>Description:</source>
             <translation>描述：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="759"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="943"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="851" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1036" />
             <source>All Day:</source>
             <translation>全天：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="764"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1009"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="856" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1102" />
             <source>Starts:</source>
             <translation>開始時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="769"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1050"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="861" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1143" />
             <source>Ends:</source>
             <translation>結束時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="774"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1090"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="866" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1183" />
             <source>Remind Me:</source>
             <translation>提醒：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="779"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1122"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="871" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1215" />
             <source>Repeat:</source>
             <translation>重複：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="784"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1156"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="876" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1249" />
             <source>End Repeat:</source>
             <translation>結束重複：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="840"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="934" />
             <source>Calendar account:</source>
             <translation>日曆帳戶：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="841"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="935" />
             <source>Calendar account</source>
             <translation>日曆帳戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="868"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="961" />
             <source>Type</source>
             <translation>類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="910"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1003" />
             <source>Description</source>
             <translation>描述</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="940"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1033" />
             <source>All Day</source>
             <translation>全天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="964"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1057" />
             <source>Time:</source>
             <translation>時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="965"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1058" />
             <source>Time</source>
             <translation>時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="972"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1065" />
             <source>Solar</source>
             <translation>公曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="973"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1066" />
             <source>Lunar</source>
             <translation>農曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1006"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1099" />
             <source>Starts</source>
             <translation>開始時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1047"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1140" />
             <source>Ends</source>
             <translation>結束時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1092"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1185" />
             <source>Remind Me</source>
             <translation>提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1119"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1212" />
             <source>Repeat</source>
             <translation>重複</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1134"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1427"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1227" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1597" />
             <source>Daily</source>
             <translation>每天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1135"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1428"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1228" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1598" />
             <source>Weekdays</source>
             <translation>工作日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1136"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1429"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1229" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1599" />
             <source>Weekly</source>
             <translation>每週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1137"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1423"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1430"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1230" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1592" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1600" />
             <source>Monthly</source>
             <translation>每月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1138"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1424"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1431"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1231" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1593" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1601" />
             <source>Yearly</source>
             <translation>每年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1158"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1251" />
             <source>End Repeat</source>
             <translation>結束重複</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1169"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1262" />
             <source>After</source>
             <translation>於</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1170"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1263" />
             <source>On</source>
             <translation>於日期</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1240"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1333" />
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation>取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1241"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1334" />
             <source>Save</source>
-            <translation>保 存</translation>
             <comment>button</comment>
+            <translation>保 存</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1407" />
+            <source>Local calendar</source>
+            <translation>本地日曆</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1409" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
         </message>
     </context>
     <context>
         <name>CScheduleOperation</name>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74" />
             <source>All occurrences of a repeating event must have the same all-day status.</source>
             <translation>重複日程的所有重複必須具有相同的全天狀態。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="95"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="95" />
             <source>Do you want to change all occurrences?</source>
             <translation>您要更改所有重複嗎？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="96"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="129"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="151"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="174"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="259"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="292"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="96" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="129" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="151" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="174" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="259" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="292" />
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation>取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="97"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="97" />
             <source>Change All</source>
             <translation>全部更改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94" />
             <source>You are changing the repeating rule of this event.</source>
             <translation>您正在更改日程的重複規則。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="149"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="172"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="149" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="172" />
             <source>You are deleting an event.</source>
             <translation>您正在刪除日程。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128" />
             <source>Are you sure you want to delete this event?</source>
             <translation>您確定要刪除此日程嗎？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130" />
             <source>Delete</source>
-            <translation>刪 除</translation>
             <comment>button</comment>
+            <translation>刪 除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150" />
             <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
-            <translation>您要刪除此日程的所有重複，還是只刪除所選重複？</translation>
+            <translation>您要刪除此日程的所有重複，還是隻刪除所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152" />
             <source>Delete All</source>
             <translation>全部刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="176"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="176" />
             <source>Delete Only This Event</source>
             <translation>僅刪除此日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173" />
             <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
-            <translation>您要刪除此日程的這個重複和所有將來重複，還是只刪除所選重複？</translation>
+            <translation>您要刪除此日程的這個重複和所有將來重複，還是隻刪除所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175" />
             <source>Delete All Future Events</source>
             <translation>刪除所有將來日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="288"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="288" />
             <source>You are changing a repeating event.</source>
             <translation>您正在更改重複日程。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257" />
             <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
             <translation>您要更改此日程的僅這一個重複，還是更改它的所有重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260" />
             <source>All</source>
             <translation>全部日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="294"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="294" />
             <source>Only This Event</source>
             <translation>僅此日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290" />
             <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
-            <translation>您要更改此日程的這個重複和所有將來重複，還是只更改所選重複？</translation>
+            <translation>您要更改此日程的這個重複和所有將來重複，還是隻更改所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293" />
             <source>All Future Events</source>
             <translation>所有將來日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416" />
             <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
             <translation>您選擇的是閏月，將按照農曆規則提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417" />
             <source>OK</source>
-            <translation>確 定</translation>
             <comment>button</comment>
+            <translation>確 定</translation>
         </message>
     </context>
     <context>
         <name>CScheduleSearchDateItem</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
             <source>Y</source>
             <translation>年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
             <source>M</source>
             <translation>月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
             <source>D</source>
             <translation>日</translation>
         </message>
@@ -603,17 +647,17 @@
     <context>
         <name>CScheduleSearchItem</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="42"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="44" />
             <source>Edit</source>
             <translation>更改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="43"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="45" />
             <source>Delete</source>
             <translation>刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="267"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="287" />
             <source>All Day</source>
             <translation>全天</translation>
         </message>
@@ -621,7 +665,7 @@
     <context>
         <name>CScheduleSearchView</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="648"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="698" />
             <source>No search results</source>
             <translation>無搜索結果</translation>
         </message>
@@ -629,7 +673,7 @@
     <context>
         <name>CScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/scheduleview.cpp" line="316"/>
+            <location filename="../src/calendar-client/src/customWidget/scheduleview.cpp" line="344" />
             <source>ALL DAY</source>
             <translation>全天</translation>
         </message>
@@ -637,91 +681,167 @@
     <context>
         <name>CSettingDialog</name>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="345"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="455" />
             <source>Sunday</source>
             <translation>週日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="346"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="456" />
             <source>Monday</source>
             <translation>週一</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="347"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="366"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="457" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="476" />
             <source>Use System Setting</source>
             <translation>跟隨系統</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="364"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="474" />
             <source>24-hour clock</source>
             <translation>24小時制</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="365"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="475" />
             <source>12-hour clock</source>
             <translation>12小時制</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="389"/>
-            <source>import ICS file</source>
-            <translation>導入ICS文件</translation>
-        </message>
-        <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="403"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="514" />
             <source>Manual</source>
             <translation>手動</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="404"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="515" />
             <source>15 mins</source>
             <translation>每15分鐘</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="405"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="516" />
             <source>30 mins</source>
             <translation>每30分鐘</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="406"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="517" />
             <source>1 hour</source>
             <translation>每1小時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="407"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="518" />
             <source>24 hours</source>
             <translation>每24小時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="418"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="538" />
             <source>Sync Now</source>
             <translation>立即同步</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="585"/>
-            <source>Last sync</source>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="214" />
+            <source>More</source>
+            <translation>更多</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="497" />
+            <source>Add schedule</source>
+            <translation>添加日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="498" />
+            <source>Import ICS file</source>
+            <translation>導入ICS文件</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="818" />
+            <source>Last sync time</source>
             <translation>最近同步時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="779"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="794" />
+            <source>Syncing...</source>
+            <translation>同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="1049" />
             <source>Please go to the &lt;a href='/'&gt;Control Center&lt;/a&gt; to change system settings</source>
             <translation>請到&lt;a href='/'&gt;控制中心&lt;/a&gt;更改系統設置</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="681" />
+            <source>Remove Calendar Account</source>
+            <translation>刪除日曆賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="689" />
+            <source>Are you sure you want to remove the account "%1"?</source>
+            <translation>您確定要刪除賬戶"%1"嗎？</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="693" />
+            <source>Also remove synced events from this calendar</source>
+            <translation>同時刪除已同步到本地的日程數據</translation>
+        </message>
+        <message>
+            <source>Last sync: %1</source>
+            <translation type="vanished">上次同步：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="246" />
+            <source>Third-party accounts</source>
+            <translation>第三方賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="304" />
+            <source>Sync items</source>
+            <translation>同步項</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="908" />
+            <source>Local account</source>
+            <translation>本地賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="305" />
+            <source>Sync interval</source>
+            <translation>同步頻率</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="255" />
+            <source>Add</source>
+            <translation>添加</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="499" />
+            <source>Import events from an ICS file</source>
+            <translation>從 ICS 文件導入日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="698" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="699" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>刪除</translation>
         </message>
     </context>
     <context>
         <name>CTimeEdit</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="71"/>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="79" />
             <source>(%1 mins)</source>
             <translation>(%1分鐘)</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="73"/>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="81" />
             <source>(%1 hour)</source>
             <translation>(%1小時)</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="75"/>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="83" />
             <source>(%1 hours)</source>
             <translation>(%1小時)</translation>
         </message>
@@ -729,28 +849,28 @@
     <context>
         <name>CTitleWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="30"/>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="32" />
             <source>Y</source>
             <translation>年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="42"/>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="44" />
             <source>M</source>
             <translation>月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="50"/>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="52" />
             <source>W</source>
             <translation>週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="58"/>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="60" />
             <source>D</source>
             <translation>日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="92"/>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="93"/>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="94" />
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="95" />
             <source>Search events and festivals</source>
             <translation>搜索日程/節日</translation>
         </message>
@@ -758,12 +878,12 @@
     <context>
         <name>CWeekWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="90"/>
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="92" />
             <source>Week</source>
             <translation>週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="280"/>
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="286" />
             <source>Y</source>
             <translation>年</translation>
         </message>
@@ -771,13 +891,13 @@
     <context>
         <name>CYearScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="268"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="271"/>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="314" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="317" />
             <source>All Day</source>
             <translation>全天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="288"/>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="335" />
             <source>No event</source>
             <translation>無日程</translation>
         </message>
@@ -785,168 +905,409 @@
     <context>
         <name>CYearWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="615"/>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="669" />
             <source>Y</source>
             <translation>年</translation>
         </message>
     </context>
     <context>
+        <name>CalDavAccountDialog</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="75" />
+            <source>Add Calendar Account</source>
+            <translation>添加日曆賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="65" />
+            <source>:</source>
+            <translation>：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="118" />
+            <source>Account Type</source>
+            <translation>賬戶類型</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="119" />
+            <source>Server Address</source>
+            <translation>服務器地址</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="109" />
+            <source>Automatically filled after selecting account type</source>
+            <translation>選擇賬戶類型後自動填充</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="120" />
+            <source>Username</source>
+            <translation>用戶名</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="110" />
+            <source>Enter username or email</source>
+            <translation>輸入用戶名或郵箱</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="121" />
+            <source>Password</source>
+            <translation>密碼</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="111" />
+            <source>Enter password</source>
+            <translation>輸入密碼</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="133" />
+            <source>Sign In</source>
+            <comment>button</comment>
+            <translation>登錄</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="224" />
+            <source>Edit Account</source>
+            <translation>更改賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="510" />
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="558" />
+            <source>Please enter a valid server address.</source>
+            <translation>請輸入有效的服務器地址</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="561" />
+            <source>Please enter the correct username.</source>
+            <translation>請輸入正確用戶名</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="562" />
+            <source>Please enter the correct password.</source>
+            <translation>請輸入正確密碼</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="583" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>無法連接到服務器，請檢查網絡連接和服務器地址</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="571" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>用戶名或密碼錯誤，請重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="573" />
+            <source>This server does not support CalDAV.</source>
+            <translation>該服務器不支持CalDAV協議</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="579" />
+            <source>The server certificate is invalid.</source>
+            <translation>服務器證書無效</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="575" />
+            <source>The server rejected your login request. Please check your account permissions.</source>
+            <translation>服務器拒絕了登錄請求，請檢查賬戶是否有訪問權限</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="577" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>服務器返回的數據無法解析，請確認服務器地址或稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="98" />
+            <source>Select account type</source>
+            <translation>選擇賬戶類型</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="132" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="225" />
+            <source>Save</source>
+            <comment>button</comment>
+            <translation>保存</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="232" />
+            <source>Leave empty to keep the current password</source>
+            <translation>留空以保留當前密碼</translation>
+        </message>
+    </context>
+    <context>
+        <name>CalDavAccountListWidget</name>
+        <message>
+            <source>Last sync: %1</source>
+            <translation type="vanished">上次同步：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="255" />
+            <source>Syncing...</source>
+            <translation>同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="255" />
+            <source>Deleting...</source>
+            <translation>刪除同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="252" />
+            <source>Sync Failed: %1</source>
+            <translation>同步失敗：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="69" />
+            <source>Last sync time</source>
+            <translation>最近同步時間</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="242" />
+            <source>Sync conflict</source>
+            <translation>同步衝突</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="302" />
+            <source>Calendar synchronization conflict</source>
+            <translation>日程同步衝突</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="243" />
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="304" />
+            <source>A synchronization conflict was detected. The server version will replace the local changes.</source>
+            <translation>檢測到日程同步衝突，服務器版本將覆蓋本地修改。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="308" />
+            <source>Use server version</source>
+            <translation>使用服務器版本</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="267" />
+            <source>Sync Now</source>
+            <translation>立即同步</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="210" />
+            <source>Pending synchronization</source>
+            <translation>有待完成的同步任務</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="151" />
+            <source>No third-party accounts added</source>
+            <translation>未添加第三方賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="157" />
+            <source>Add</source>
+            <translation>添加</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="210" />
+            <source>Delete</source>
+            <translation>刪除</translation>
+        </message>
+    </context>
+    <context>
         <name>CalendarWindow</name>
         <message>
-            <location filename="../calendar-client/src/main.cpp" line="66"/>
+            <location filename="../src/calendar-client/src/main.cpp" line="69" />
             <source>Calendar</source>
             <translation>日曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/main.cpp" line="69"/>
-            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life.</source>
+            <location filename="../src/calendar-client/src/main.cpp" line="72" />
+            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
             <translation>日曆是一款查看日期、管理日程的小工具。</translation>
         </message>
     </context>
     <context>
         <name>Calendarmainwindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="89"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="90" />
             <source>Calendar</source>
             <translation>日曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="372"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="433" />
             <source>Manage</source>
             <translation>管理</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="379"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="440" />
             <source>Privacy Policy</source>
             <translation>私隱政策</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="962"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1209" />
             <source>Syncing...</source>
             <translation>正在同步...</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="973"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1220" />
             <source>Sync successful</source>
             <translation>同步成功</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="982"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1229" />
             <source>Sync failed, please try later</source>
             <translation>同步失敗，請稍後再試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1266" />
+            <source>%1 does not allow creating events. Please check account permissions.</source>
+            <translation>%1不允許創建日程，請檢查賬戶權限。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1269" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>無法連接到服務器，請檢查網絡連接和服務器地址</translation>
         </message>
     </context>
     <context>
         <name>CenterWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="174"/>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="239" />
             <source>All Day</source>
             <translation>全天</translation>
         </message>
     </context>
     <context>
-        <name>DAccountDataBase</name>
+        <name>DCalDavProviderProfile</name>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1155"/>
-            <source>Work</source>
-            <translation>工作</translation>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="37" />
+            <source>DingTalk</source>
+            <translation>釘釘</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1157"/>
-            <source>Life</source>
-            <translation>生活</translation>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="39" />
+            <source>WeCom</source>
+            <translation>企業微信</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1159"/>
-            <source>Other</source>
-            <translation>其他</translation>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="41" />
+            <source>Tencent Meeting</source>
+            <translation>騰訊會議</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="43" />
+            <source>QQ Mail</source>
+            <translation>QQ郵箱</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="45" />
+            <source>Feishu</source>
+            <translation>飛書</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="48" />
+            <source>Other CalDAV</source>
+            <translation>其他 CalDAV</translation>
         </message>
     </context>
     <context>
-        <name>DAlarmManager</name>
+        <name>DCalDavSyncStatus</name>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="187"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="196"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="201"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="212"/>
-            <source>Close</source>
-            <translation>關 閉</translation>
-            <comment>button</comment>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server request is invalid.</source>
+            <translation>服務器請求無效</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="191"/>
-            <source>One day before start</source>
-            <translation>提前1天提醒</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="71" />
+            <source>The server is busy. Please try again later.</source>
+            <translation>服務器繁忙，請稍後重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="197"/>
-            <source>Remind me tomorrow</source>
-            <translation>明天提醒</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="74" />
+            <source>The server is unavailable. Please try again later.</source>
+            <translation>服務器不可用，請稍後重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="202"/>
-            <source>Remind me later</source>
-            <translation>稍後提醒</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="77" />
+            <source>The calendar data conflicts with the server.</source>
+            <translation>日曆數據與服務器存在衝突</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="204"/>
-            <source>15 mins later</source>
-            <translation>15分鐘後</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="80" />
+            <source>The server returned too much data. Please try again later.</source>
+            <translation>服務器返回的數據過大，請稍後重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="205"/>
-            <source>1 hour later</source>
-            <translation>1小時後</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="91" />
+            <source>Unable to save calendar data. Please try again later.</source>
+            <translation>無法保存日曆數據，請稍後重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="206"/>
-            <source>4 hours later</source>
-            <translation>4小時後</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="61" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>服務器返回的數據無法解析，請確認服務器地址或稍後重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="207"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="300"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="313"/>
-            <source>Tomorrow</source>
-            <translation>明天</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server certificate is invalid.</source>
+            <translation>服務器證書無效</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="215"/>
-            <source>Schedule Reminder</source>
-            <translation>日程提醒</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="54" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>用戶名或密碼錯誤，請重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="258"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="270"/>
-            <source>%1 to %2</source>
-            <translation>%1 至 %2</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="57" />
+            <source>This server does not support CalDAV.</source>
+            <translation>該服務器不支持CalDAV協議</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="296"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="309"/>
-            <source>Today</source>
-            <translation>今天</translation>
+            <source>The server rejected your login request. Please check your account permissions.</source>
+            <translation type="vanished">服務器拒絕了登錄請求，請檢查賬號是否有訪問權限</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="65" />
+            <source>The server denied access.</source>
+            <translation>服務器拒絕訪問</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="68" />
+            <source>The server request timed out.</source>
+            <translation>服務器請求超時</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="72" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>無法連接到服務器，請檢查網絡連接和服務器地址</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76" />
+            <source>Synchronization failed.</source>
+            <translation>同步失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="855" />
+            <source>Sync Failed</source>
+            <translation>同步失敗</translation>
         </message>
     </context>
     <context>
         <name>DragInfoGraphicsView</name>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="48"/>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="49" />
             <source>Edit</source>
             <translation>更改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="49"/>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="50" />
             <source>Delete</source>
-            <translation>删除</translation>
+            <translation>刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="50"/>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="51" />
             <source>New event</source>
             <translation>新建日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="759"/>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="844" />
             <source>New Event</source>
             <translation>新建日程</translation>
         </message>
@@ -954,176 +1315,193 @@
     <context>
         <name>JobTypeListView</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="144"/>
-            <source>export</source>
-            <translation>導出</translation>
-        </message>
-        <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="219"/>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="308" />
             <source>import ICS file</source>
             <translation>導入ICS文件</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="450"/>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="565" />
             <source>You are deleting an event type.</source>
             <translation>您正在刪除日程類型。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="451"/>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="566" />
             <source>All events under this type will be deleted and cannot be recovered.</source>
             <translation>此日程類型下的所有日程都會刪除且不可恢復。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="452"/>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="567" />
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation>取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="453"/>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="568" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>刪 除</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="213" />
+            <source>Edit</source>
+            <translation>更改</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="219" />
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="233" />
+            <source>Export</source>
+            <translation>導出</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="308" />
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="417" />
+            <source>ICS files (*.ics)</source>
+            <translation>ICS 文件（*.ics）</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="416" />
+            <source>Export ICS file</source>
+            <translation>導出 ICS 文件</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="216" />
             <source>Delete</source>
             <translation>刪 除</translation>
-            <comment>button</comment>
         </message>
     </context>
     <context>
         <name>QObject</name>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="96"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="127"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="67" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="98" />
             <source>Manage calendar</source>
             <translation>日曆管理</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="112"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="131"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="83" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="102" />
             <source>Event types</source>
             <translation>日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="38"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="50" />
             <source>Account settings</source>
             <translation>帳戶設置</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="42"/>
-            <source>Account</source>
-            <translation>賬戶</translation>
-        </message>
-        <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="53"/>
-            <source>Select items to be synced</source>
-            <translation>設置您的同步項</translation>
-        </message>
-        <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="56"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="559" />
             <source>Events</source>
             <translation>日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="63"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="146"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="117" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="561" />
             <source>General settings</source>
             <translation>通用設置</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="74"/>
-            <source>Sync interval</source>
-            <translation>同步頻率</translation>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="75" />
+            <source>Associated account</source>
+            <translation>關聯賬戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="104"/>
-            <source>Calendar account</source>
-            <translation>日曆帳戶</translation>
-        </message>
-        <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="150"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="121" />
             <source>General</source>
             <translation>通用</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="152"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="123" />
             <source>First day of week</source>
             <translation>每星期開始於</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="153"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="124" />
             <source>Time</source>
             <translation>時間</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="59" />
+            <source>Third-party accounts</source>
+            <translation>第三方賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="54" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
         </message>
     </context>
     <context>
         <name>Return</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="611"/>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="665" />
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Return</comment>
+            <translation>今天</translation>
         </message>
     </context>
     <context>
         <name>Return Today</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="339"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="95"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="277"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="353" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="100" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="283" />
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Return Today</comment>
+            <translation>今天</translation>
         </message>
     </context>
     <context>
         <name>ScheduleTypeEditDlg</name>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22"/>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="48"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22" />
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="50" />
             <source>New event type</source>
             <translation>新增日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="32"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="33" />
             <source>Edit event type</source>
             <translation>編輯日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="43"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="45" />
             <source>Import ICS file</source>
             <translation>導入ICS文件</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="151"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="158" />
             <source>Name:</source>
             <translation>名稱：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="152"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="159" />
             <source>Color:</source>
             <translation>顏色：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="156"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="164" />
             <source>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt; File:</source>
             <translation>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt;文件：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="167"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="175" />
             <source>Cancel</source>
+            <comment>button</comment>
             <translation>取 消</translation>
-            <comment>button</comment>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="168"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="176" />
             <source>Save</source>
-            <translation>保 存</translation>
             <comment>button</comment>
+            <translation>保 存</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="219"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="232" />
             <source>The name can not only contain whitespaces</source>
             <translation>名稱不能設置為全空格，請修改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="256"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="275" />
             <source>Enter a name please</source>
             <translation>名稱不能為空</translation>
         </message>
@@ -1131,50 +1509,69 @@
     <context>
         <name>Shortcut</name>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="16"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="18" />
             <source>Help</source>
             <translation>幫助</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="17"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="19" />
             <source>Delete event</source>
             <translation>刪除日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="20"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="22" />
             <source>Copy</source>
             <translation>複製</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="21"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="23" />
             <source>Cut</source>
             <translation>剪下</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="22"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="24" />
             <source>Paste</source>
             <translation>黏貼</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="25"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="27" />
             <source>Delete</source>
             <translation>刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="26"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="28" />
             <source>Select all</source>
             <translation>選擇全部</translation>
         </message>
     </context>
     <context>
+        <name>SidebarAccountItemWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="344" />
+            <source>Deleting...</source>
+            <translation>刪除同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="345" />
+            <source>Syncing...</source>
+            <translation>同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="335" />
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="345" />
+            <source>Sync</source>
+            <translation>同步</translation>
+        </message>
+    </context>
+    <context>
         <name>SidebarCalendarWidget</name>
         <message>
-            <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="135" />
             <source>Y</source>
             <translation>年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="135" />
             <source>M</source>
             <translation>月</translation>
         </message>
@@ -1182,31 +1579,36 @@
     <context>
         <name>TimeJumpDialog</name>
         <message>
-            <location filename="../calendar-client/src/dialog/timejumpdialog.cpp" line="29"/>
+            <location filename="../src/calendar-client/src/dialog/timejumpdialog.cpp" line="32" />
             <source>Go</source>
-            <translation>跳 轉</translation>
             <comment>button</comment>
+            <translation>跳 轉</translation>
         </message>
     </context>
     <context>
         <name>UserloginWidget</name>
         <message>
-            <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="48"/>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="105" />
             <source>Sign In</source>
-            <translation>登 錄</translation>
             <comment>button</comment>
+            <translation>登 錄</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="49"/>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="106" />
             <source>Sign Out</source>
-            <translation>退出登錄</translation>
             <comment>button</comment>
+            <translation>退出登錄</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="203" />
+            <source>Not signed in</source>
+            <translation>未登錄</translation>
         </message>
     </context>
     <context>
         <name>YearFrame</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="928"/>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="1020" />
             <source>Y</source>
             <translation>年</translation>
         </message>
@@ -1214,17 +1616,17 @@
     <context>
         <name>today</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="188"/>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="337"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="93"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="230"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="57"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="275"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="261"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="609"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="200" />
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="351" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="261" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="59" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="281" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="288" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="663" />
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Today</comment>
+            <translation>今天</translation>
         </message>
     </context>
 </TS>

--- a/translations/dde-calendar_zh_TW.ts
+++ b/translations/dde-calendar_zh_TW.ts
@@ -1,25 +1,25 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE TS>
-<TS language="zh_TW" version="2.1">
+<TS version="2.1" language="zh_TW">
     <context>
         <name>AccountItem</name>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="41"/>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="50" />
             <source>Sync successful</source>
             <translation>同步成功</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="42"/>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="54" />
             <source>Network error</source>
             <translation>網路異常</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="43"/>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="58" />
             <source>Server exception</source>
             <translation>伺服器異常</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountitem.cpp" line="44"/>
+            <location filename="../src/calendar-client/src/dataManage/accountitem.cpp" line="62" />
             <source>Storage full</source>
             <translation>儲存已滿</translation>
         </message>
@@ -27,12 +27,14 @@
     <context>
         <name>AccountManager</name>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="227"/>
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="180" />
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="491" />
             <source>Local account</source>
             <translation>本機帳戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dataManage/accountmanager.cpp" line="229"/>
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="180" />
+            <location filename="../src/calendar-client/src/dataManage/accountmanager.cpp" line="494" />
             <source>Event types</source>
             <translation>日程類型</translation>
         </message>
@@ -40,57 +42,57 @@
     <context>
         <name>CColorPickerWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="77"/>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="83" />
             <source>Color</source>
             <translation>顏色</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="90"/>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="96" />
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation>取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="92"/>
+            <location filename="../src/calendar-client/src/customWidget/colorWidget/colorpickerWidget.cpp" line="98" />
             <source>Save</source>
-            <translation>儲 存</translation>
             <comment>button</comment>
+            <translation>儲 存</translation>
         </message>
     </context>
     <context>
         <name>CDayMonthView</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="33"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35" />
             <source>Monday</source>
             <translation>星期一</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="34"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36" />
             <source>Tuesday</source>
             <translation>星期二</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="35"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37" />
             <source>Wednesday</source>
             <translation>星期三</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="36"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38" />
             <source>Thursday</source>
             <translation>星期四</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="37"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39" />
             <source>Friday</source>
             <translation>星期五</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="38"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="40" />
             <source>Saturday</source>
             <translation>星期六</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="39"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="41" />
             <source>Sunday</source>
             <translation>星期日</translation>
         </message>
@@ -98,22 +100,22 @@
     <context>
         <name>CDayWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="112"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="128" />
             <source>Y</source>
             <translation>年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="113"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="129" />
             <source>M</source>
             <translation>月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="114"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="130" />
             <source>D</source>
             <translation>日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daywindow.cpp" line="170"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daywindow.cpp" line="196" />
             <source>Lunar</source>
             <translation>農曆</translation>
         </message>
@@ -121,7 +123,7 @@
     <context>
         <name>CGraphicsView</name>
         <message>
-            <location filename="../calendar-client/src/view/graphicsview.cpp" line="628"/>
+            <location filename="../src/calendar-client/src/view/graphicsview.cpp" line="686" />
             <source>New Event</source>
             <translation>建立日程</translation>
         </message>
@@ -129,7 +131,7 @@
     <context>
         <name>CMonthScheduleNumItem</name>
         <message>
-            <location filename="../calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="80"/>
+            <location filename="../src/calendar-client/src/view/graphicsItem/cmonthschedulenumitem.cpp" line="88" />
             <source>%1 more</source>
             <translation>還有%1項</translation>
         </message>
@@ -137,12 +139,12 @@
     <context>
         <name>CMonthView</name>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="50"/>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthview.cpp" line="52" />
             <source>New event</source>
             <translation>建立日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthview.cpp" line="230"/>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthview.cpp" line="240" />
             <source>New Event</source>
             <translation>建立日程</translation>
         </message>
@@ -150,7 +152,7 @@
     <context>
         <name>CMonthWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98"/>
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="103" />
             <source>Y</source>
             <translation>年</translation>
         </message>
@@ -158,33 +160,65 @@
     <context>
         <name>CMyScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="284"/>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="363" />
             <source>My Event</source>
             <translation>我的日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="326"/>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="424" />
             <source>OK</source>
+            <comment>button</comment>
             <translation>確 定</translation>
-            <comment>button</comment>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="331"/>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="429" />
             <source>Delete</source>
-            <translation>刪 除</translation>
             <comment>button</comment>
+            <translation>刪 除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/myscheduleview.cpp" line="332"/>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="430" />
             <source>Edit</source>
-            <translation>編 輯</translation>
             <comment>button</comment>
+            <translation>編 輯</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="131" />
+            <source>Source: %1</source>
+            <translation>來源: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="152" />
+            <source>Organizer</source>
+            <translation>發起人</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="153" />
+            <source>Attendees</source>
+            <translation>參會人</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="118" />
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="177" />
+            <source>Local calendar</source>
+            <translation>本地日曆</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="120" />
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="179" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/myscheduleview.cpp" line="193" />
+            <source>Calendar Source</source>
+            <translation>日曆來源</translation>
         </message>
     </context>
     <context>
         <name>CPushButton</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/cpushbutton.cpp" line="17"/>
+            <location filename="../src/calendar-client/src/customWidget/cpushbutton.cpp" line="19" />
             <source>New event type</source>
             <translation>新增日程類型</translation>
         </message>
@@ -192,410 +226,420 @@
     <context>
         <name>CScheduleDlg</name>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="46"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="625"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="921"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="48" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="700" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1014" />
             <source>New Event</source>
             <translation>建立日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="60"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="62" />
             <source>Edit Event</source>
             <translation>編輯日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="270"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="298" />
             <source>End time must be greater than start time</source>
             <translation>結束時間需晚於開始時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="271"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="299" />
             <source>OK</source>
-            <translation>確 定</translation>
             <comment>button</comment>
+            <translation>確 定</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="506"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="535"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1133"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1168"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1422"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1426"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="559" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="596" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1226" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1261" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1591" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1596" />
             <source>Never</source>
             <translation>從不</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="507"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="560" />
             <source>At time of event</source>
             <translation>日程開始時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="508"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="561" />
             <source>15 minutes before</source>
             <translation>15分鐘前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="509"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="562" />
             <source>30 minutes before</source>
             <translation>30分鐘前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="510"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="563" />
             <source>1 hour before</source>
             <translation>1小時前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="511"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="537"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="564" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="598" />
             <source>1 day before</source>
             <translation>1天前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="512"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="538"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="565" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="599" />
             <source>2 days before</source>
             <translation>2天前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="513"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="539"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="566" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="600" />
             <source>1 week before</source>
             <translation>1週前</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="536"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="597" />
             <source>On start day (9:00 AM)</source>
             <translation>日程發生當天（上午9點）</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="583"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="791"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1189"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1190"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="652" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="883" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1282" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1283" />
             <source>time(s)</source>
             <translation>次後</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="598"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="670" />
             <source>Enter a name please</source>
             <translation>名稱不能為空</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="693"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="779" />
             <source>The name can not only contain whitespaces</source>
             <translation>名稱不能設置為全空格，請修改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="749"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="871"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="841" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="964" />
             <source>Type:</source>
             <translation>類型：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="754"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="906"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="846" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="999" />
             <source>Description:</source>
             <translation>內容：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="759"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="943"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="851" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1036" />
             <source>All Day:</source>
             <translation>全天：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="764"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1009"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="856" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1102" />
             <source>Starts:</source>
             <translation>開始時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="769"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1050"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="861" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1143" />
             <source>Ends:</source>
             <translation>結束時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="774"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1090"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="866" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1183" />
             <source>Remind Me:</source>
             <translation>提醒：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="779"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1122"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="871" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1215" />
             <source>Repeat:</source>
             <translation>重複：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="784"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1156"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="876" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1249" />
             <source>End Repeat:</source>
             <translation>結束重複：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="840"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="934" />
             <source>Calendar account:</source>
             <translation>日曆帳戶：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="841"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="935" />
             <source>Calendar account</source>
             <translation>日曆帳戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="868"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="961" />
             <source>Type</source>
             <translation>類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="910"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1003" />
             <source>Description</source>
             <translation>內容</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="940"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1033" />
             <source>All Day</source>
             <translation>全天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="964"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1057" />
             <source>Time:</source>
             <translation>時間：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="965"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1058" />
             <source>Time</source>
             <translation>時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="972"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1065" />
             <source>Solar</source>
             <translation>公曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="973"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1066" />
             <source>Lunar</source>
             <translation>農曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1006"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1099" />
             <source>Starts</source>
             <translation>開始時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1047"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1140" />
             <source>Ends</source>
             <translation>結束時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1092"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1185" />
             <source>Remind Me</source>
             <translation>提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1119"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1212" />
             <source>Repeat</source>
             <translation>重複</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1134"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1427"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1227" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1597" />
             <source>Daily</source>
             <translation>每天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1135"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1428"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1228" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1598" />
             <source>Weekdays</source>
             <translation>工作日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1136"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1429"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1229" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1599" />
             <source>Weekly</source>
             <translation>每週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1137"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1423"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1430"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1230" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1592" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1600" />
             <source>Monthly</source>
             <translation>每月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1138"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1424"/>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1431"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1231" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1593" />
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1601" />
             <source>Yearly</source>
             <translation>每年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1158"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1251" />
             <source>End Repeat</source>
             <translation>結束重複</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1169"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1262" />
             <source>After</source>
             <translation>於</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1170"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1263" />
             <source>On</source>
             <translation>於日期</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1240"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1333" />
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation>取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduledlg.cpp" line="1241"/>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1334" />
             <source>Save</source>
-            <translation>儲 存</translation>
             <comment>button</comment>
+            <translation>儲 存</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1407" />
+            <source>Local calendar</source>
+            <translation>本地日曆</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/scheduledlg.cpp" line="1409" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
         </message>
     </context>
     <context>
         <name>CScheduleOperation</name>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="74" />
             <source>All occurrences of a repeating event must have the same all-day status.</source>
             <translation>重複日程的所有重複必須具有相同的全天狀態。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="95"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="75" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="95" />
             <source>Do you want to change all occurrences?</source>
             <translation>您要更改所有重複嗎？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="96"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="129"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="151"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="174"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="259"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="292"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="76" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="96" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="129" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="151" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="174" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="259" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="292" />
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation>取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="97"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="77" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="97" />
             <source>Change All</source>
             <translation>全部更改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="94" />
             <source>You are changing the repeating rule of this event.</source>
             <translation>您正在更改日程的重複規則。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="149"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="172"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="127" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="149" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="172" />
             <source>You are deleting an event.</source>
             <translation>您正在刪除日程。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="128" />
             <source>Are you sure you want to delete this event?</source>
             <translation>您確定要刪除此日程嗎？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="130" />
             <source>Delete</source>
-            <translation>刪 除</translation>
             <comment>button</comment>
+            <translation>刪 除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="150" />
             <source>Do you want to delete all occurrences of this event, or only the selected occurrence?</source>
-            <translation>您要刪除此日程的所有重複，還是只刪除所選重複？</translation>
+            <translation>您要刪除此日程的所有重複，還是隻刪除所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="152" />
             <source>Delete All</source>
             <translation>全部刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="176"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="153" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="176" />
             <source>Delete Only This Event</source>
             <translation>僅刪除此日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="173" />
             <source>Do you want to delete this and all future occurrences of this event, or only the selected occurrence?</source>
-            <translation>您要刪除此日程的這個重複和所有將來重複，還是只刪除所選重複？</translation>
+            <translation>您要刪除此日程的這個重複和所有將來重複，還是隻刪除所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="175" />
             <source>Delete All Future Events</source>
             <translation>刪除所有將來日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="288"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="255" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="288" />
             <source>You are changing a repeating event.</source>
             <translation>您正在更改重複日程。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="257" />
             <source>Do you want to change only this occurrence of the event, or all occurrences?</source>
             <translation>您要更改此日程的僅這一個重複，還是更改它的所有重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="260" />
             <source>All</source>
             <translation>全部日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261"/>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="294"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="261" />
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="294" />
             <source>Only This Event</source>
             <translation>僅此日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="290" />
             <source>Do you want to change only this occurrence of the event, or this and all future occurrences?</source>
-            <translation>您要更改此日程的這個重複和所有將來重複，還是只更改所選重複？</translation>
+            <translation>您要更改此日程的這個重複和所有將來重複，還是隻更改所選重複？</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="293" />
             <source>All Future Events</source>
             <translation>所有將來日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="416" />
             <source>You have selected a leap month, and will be reminded according to the rules of the lunar calendar.</source>
             <translation>您選擇的是閏月，將按照農曆規則提醒</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417"/>
+            <location filename="../src/calendar-client/src/scheduleTask/cscheduleoperation.cpp" line="417" />
             <source>OK</source>
-            <translation>確 定</translation>
             <comment>button</comment>
+            <translation>確 定</translation>
         </message>
     </context>
     <context>
         <name>CScheduleSearchDateItem</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
             <source>Y</source>
             <translation>年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
             <source>M</source>
             <translation>月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="905"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="978" />
             <source>D</source>
             <translation>日</translation>
         </message>
@@ -603,17 +647,17 @@
     <context>
         <name>CScheduleSearchItem</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="42"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="44" />
             <source>Edit</source>
             <translation>編輯</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="43"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="45" />
             <source>Delete</source>
             <translation>刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="267"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="287" />
             <source>All Day</source>
             <translation>全天</translation>
         </message>
@@ -621,7 +665,7 @@
     <context>
         <name>CScheduleSearchView</name>
         <message>
-            <location filename="../calendar-client/src/widget/schedulesearchview.cpp" line="648"/>
+            <location filename="../src/calendar-client/src/widget/schedulesearchview.cpp" line="698" />
             <source>No search results</source>
             <translation>找不到結果</translation>
         </message>
@@ -629,7 +673,7 @@
     <context>
         <name>CScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/scheduleview.cpp" line="316"/>
+            <location filename="../src/calendar-client/src/customWidget/scheduleview.cpp" line="344" />
             <source>ALL DAY</source>
             <translation>全天</translation>
         </message>
@@ -637,91 +681,167 @@
     <context>
         <name>CSettingDialog</name>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="345"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="455" />
             <source>Sunday</source>
             <translation>週日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="346"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="456" />
             <source>Monday</source>
             <translation>週一</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="347"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="366"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="457" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="476" />
             <source>Use System Setting</source>
             <translation>跟隨系統</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="364"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="474" />
             <source>24-hour clock</source>
             <translation>24小時制</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="365"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="475" />
             <source>12-hour clock</source>
             <translation>12小時制</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="389"/>
-            <source>import ICS file</source>
-            <translation>匯入ICS檔案</translation>
-        </message>
-        <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="403"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="514" />
             <source>Manual</source>
             <translation>手動</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="404"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="515" />
             <source>15 mins</source>
             <translation>每15分鐘</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="405"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="516" />
             <source>30 mins</source>
             <translation>每30分鐘</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="406"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="517" />
             <source>1 hour</source>
             <translation>每1小時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="407"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="518" />
             <source>24 hours</source>
             <translation>每24小時</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="418"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="538" />
             <source>Sync Now</source>
             <translation>立即同步</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="585"/>
-            <source>Last sync</source>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="214" />
+            <source>More</source>
+            <translation>更多</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="497" />
+            <source>Add schedule</source>
+            <translation>添加日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="498" />
+            <source>Import ICS file</source>
+            <translation>導入ICS文件</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="818" />
+            <source>Last sync time</source>
             <translation>最近同步時間</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="779"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="794" />
+            <source>Syncing...</source>
+            <translation>同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="1049" />
             <source>Please go to the &lt;a href='/'&gt;Control Center&lt;/a&gt; to change system settings</source>
             <translation>請到&lt;a href='/'&gt;控制中心&lt;/a&gt;更改系統設定</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="681" />
+            <source>Remove Calendar Account</source>
+            <translation>刪除日曆賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="689" />
+            <source>Are you sure you want to remove the account "%1"?</source>
+            <translation>您確定要刪除賬戶"%1"嗎？</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="693" />
+            <source>Also remove synced events from this calendar</source>
+            <translation>同時刪除已同步到本地的日程數據</translation>
+        </message>
+        <message>
+            <source>Last sync: %1</source>
+            <translation type="vanished">上次同步：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="246" />
+            <source>Third-party accounts</source>
+            <translation>第三方賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="304" />
+            <source>Sync items</source>
+            <translation>同步項</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="908" />
+            <source>Local account</source>
+            <translation>本地賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="305" />
+            <source>Sync interval</source>
+            <translation>同步頻率</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="255" />
+            <source>Add</source>
+            <translation>添加</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="499" />
+            <source>Import events from an ICS file</source>
+            <translation>從 ICS 文件導入日程</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="698" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="699" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>刪除</translation>
         </message>
     </context>
     <context>
         <name>CTimeEdit</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="71"/>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="79" />
             <source>(%1 mins)</source>
             <translation>(%1分鐘)</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="73"/>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="81" />
             <source>(%1 hour)</source>
             <translation>(%1小時)</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/timeedit.cpp" line="75"/>
+            <location filename="../src/calendar-client/src/customWidget/timeedit.cpp" line="83" />
             <source>(%1 hours)</source>
             <translation>(%1小時)</translation>
         </message>
@@ -729,28 +849,28 @@
     <context>
         <name>CTitleWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="30"/>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="32" />
             <source>Y</source>
             <translation>年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="42"/>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="44" />
             <source>M</source>
             <translation>月</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="50"/>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="52" />
             <source>W</source>
             <translation>週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="58"/>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="60" />
             <source>D</source>
             <translation>日</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="92"/>
-            <location filename="../calendar-client/src/customWidget/ctitlewidget.cpp" line="93"/>
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="94" />
+            <location filename="../src/calendar-client/src/customWidget/ctitlewidget.cpp" line="95" />
             <source>Search events and festivals</source>
             <translation>搜尋日程/節日</translation>
         </message>
@@ -758,12 +878,12 @@
     <context>
         <name>CWeekWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="90"/>
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="92" />
             <source>Week</source>
             <translation>週</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="280"/>
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="286" />
             <source>Y</source>
             <translation>年</translation>
         </message>
@@ -771,13 +891,13 @@
     <context>
         <name>CYearScheduleView</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="268"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="271"/>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="314" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="317" />
             <source>All Day</source>
             <translation>全天</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="288"/>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearscheduleview.cpp" line="335" />
             <source>No event</source>
             <translation>無日程</translation>
         </message>
@@ -785,168 +905,409 @@
     <context>
         <name>CYearWindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="615"/>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="669" />
             <source>Y</source>
             <translation>年</translation>
         </message>
     </context>
     <context>
+        <name>CalDavAccountDialog</name>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="75" />
+            <source>Add Calendar Account</source>
+            <translation>添加日曆賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="65" />
+            <source>:</source>
+            <translation>：</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="118" />
+            <source>Account Type</source>
+            <translation>賬戶類型</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="119" />
+            <source>Server Address</source>
+            <translation>服務器地址</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="109" />
+            <source>Automatically filled after selecting account type</source>
+            <translation>選擇賬戶類型後自動填充</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="120" />
+            <source>Username</source>
+            <translation>用戶名</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="110" />
+            <source>Enter username or email</source>
+            <translation>輸入用戶名或郵箱</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="121" />
+            <source>Password</source>
+            <translation>密碼</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="111" />
+            <source>Enter password</source>
+            <translation>輸入密碼</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="133" />
+            <source>Sign In</source>
+            <comment>button</comment>
+            <translation>登錄</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="224" />
+            <source>Edit Account</source>
+            <translation>編輯賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="510" />
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="558" />
+            <source>Please enter a valid server address.</source>
+            <translation>請輸入有效的服務器地址</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="561" />
+            <source>Please enter the correct username.</source>
+            <translation>請輸入正確用戶名</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="562" />
+            <source>Please enter the correct password.</source>
+            <translation>請輸入正確密碼</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="583" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>無法連接到服務器，請檢查網絡連接和服務器地址</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="571" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>用戶名或密碼錯誤，請重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="573" />
+            <source>This server does not support CalDAV.</source>
+            <translation>該服務器不支持CalDAV協議</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="579" />
+            <source>The server certificate is invalid.</source>
+            <translation>服務器證書無效</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="575" />
+            <source>The server rejected your login request. Please check your account permissions.</source>
+            <translation>服務器拒絕了登錄請求，請檢查賬戶是否有訪問權限</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="577" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>服務器返回的數據無法解析，請確認服務器地址或稍後重試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="98" />
+            <source>Select account type</source>
+            <translation>選擇賬戶類型</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="132" />
+            <source>Cancel</source>
+            <comment>button</comment>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="225" />
+            <source>Save</source>
+            <comment>button</comment>
+            <translation>保存</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountdialog.cpp" line="232" />
+            <source>Leave empty to keep the current password</source>
+            <translation>留空以保留當前密碼</translation>
+        </message>
+    </context>
+    <context>
+        <name>CalDavAccountListWidget</name>
+        <message>
+            <source>Last sync: %1</source>
+            <translation type="vanished">上次同步：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="255" />
+            <source>Syncing...</source>
+            <translation>同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="255" />
+            <source>Deleting...</source>
+            <translation>刪除同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="252" />
+            <source>Sync Failed: %1</source>
+            <translation>同步失敗：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="69" />
+            <source>Last sync time</source>
+            <translation>最近同步時間</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="242" />
+            <source>Sync conflict</source>
+            <translation>同步衝突</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="302" />
+            <source>Calendar synchronization conflict</source>
+            <translation>日程同步衝突</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="243" />
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="304" />
+            <source>A synchronization conflict was detected. The server version will replace the local changes.</source>
+            <translation>檢測到日程同步衝突，服務器版本將覆蓋本地修改。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="308" />
+            <source>Use server version</source>
+            <translation>使用服務器版本</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="267" />
+            <source>Sync Now</source>
+            <translation>立即同步</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="210" />
+            <source>Pending synchronization</source>
+            <translation>有待完成的同步任務</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="151" />
+            <source>No third-party accounts added</source>
+            <translation>未添加第三方賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="157" />
+            <source>Add</source>
+            <translation>添加</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/caldavaccountlistwidget.cpp" line="210" />
+            <source>Delete</source>
+            <translation>刪除</translation>
+        </message>
+    </context>
+    <context>
         <name>CalendarWindow</name>
         <message>
-            <location filename="../calendar-client/src/main.cpp" line="66"/>
+            <location filename="../src/calendar-client/src/main.cpp" line="69" />
             <source>Calendar</source>
             <translation>日曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/main.cpp" line="69"/>
-            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life.</source>
+            <location filename="../src/calendar-client/src/main.cpp" line="72" />
+            <source>Calendar is a tool to view dates, and also a smart daily planner to schedule all things in life. </source>
             <translation>日曆是一款查看日期、管理日程的小工具。</translation>
         </message>
     </context>
     <context>
         <name>Calendarmainwindow</name>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="89"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="90" />
             <source>Calendar</source>
             <translation>日曆</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="372"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="433" />
             <source>Manage</source>
             <translation>管理</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="379"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="440" />
             <source>Privacy Policy</source>
             <translation>隱私政策</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="962"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1209" />
             <source>Syncing...</source>
             <translation>正在同步...</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="973"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1220" />
             <source>Sync successful</source>
             <translation>同步成功</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/calendarmainwindow.cpp" line="982"/>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1229" />
             <source>Sync failed, please try later</source>
             <translation>同步失敗，請稍後再試</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1266" />
+            <source>%1 does not allow creating events. Please check account permissions.</source>
+            <translation>%1不允許創建日程，請檢查賬戶權限。</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/calendarmainwindow.cpp" line="1269" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>無法連接到服務器，請檢查網絡連接和服務器地址</translation>
         </message>
     </context>
     <context>
         <name>CenterWidget</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="174"/>
+            <location filename="../src/calendar-client/src/customWidget/scheduleRemindWidget.cpp" line="239" />
             <source>All Day</source>
             <translation>全天</translation>
         </message>
     </context>
     <context>
-        <name>DAccountDataBase</name>
+        <name>DCalDavProviderProfile</name>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1155"/>
-            <source>Work</source>
-            <translation>工作</translation>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="37" />
+            <source>DingTalk</source>
+            <translation>釘釘</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1157"/>
-            <source>Life</source>
-            <translation>生活</translation>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="39" />
+            <source>WeCom</source>
+            <translation>企業微信</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/dbmanager/daccountdatabase.cpp" line="1159"/>
-            <source>Other</source>
-            <translation>其他</translation>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="41" />
+            <source>Tencent Meeting</source>
+            <translation>騰訊會議</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="43" />
+            <source>QQ Mail</source>
+            <translation>QQ郵箱</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="45" />
+            <source>Feishu</source>
+            <translation>飛書</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavprofile.h" line="48" />
+            <source>Other CalDAV</source>
+            <translation>其他 CalDAV</translation>
         </message>
     </context>
     <context>
-        <name>DAlarmManager</name>
+        <name>DCalDavSyncStatus</name>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="187"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="196"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="201"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="212"/>
-            <source>Close</source>
-            <translation>關 閉</translation>
-            <comment>button</comment>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server request is invalid.</source>
+            <translation>服務器請求無效</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="191"/>
-            <source>One day before start</source>
-            <translation>提前1天提醒</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="71" />
+            <source>The server is busy. Please try again later.</source>
+            <translation>服務器繁忙，請稍後重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="197"/>
-            <source>Remind me tomorrow</source>
-            <translation>明天提醒</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="74" />
+            <source>The server is unavailable. Please try again later.</source>
+            <translation>服務器不可用，請稍後重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="202"/>
-            <source>Remind me later</source>
-            <translation>稍後提醒</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="77" />
+            <source>The calendar data conflicts with the server.</source>
+            <translation>日曆數據與服務器存在衝突</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="204"/>
-            <source>15 mins later</source>
-            <translation>15分鐘後</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="80" />
+            <source>The server returned too much data. Please try again later.</source>
+            <translation>服務器返回的數據過大，請稍後重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="205"/>
-            <source>1 hour later</source>
-            <translation>1小時後</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="91" />
+            <source>Unable to save calendar data. Please try again later.</source>
+            <translation>無法保存日曆數據，請稍後重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="206"/>
-            <source>4 hours later</source>
-            <translation>4小時後</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="61" />
+            <source>Unable to parse the data returned by the server. Please verify the server address or try again later.</source>
+            <translation>服務器返回的數據無法解析，請確認服務器地址或稍後重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="207"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="300"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="313"/>
-            <source>Tomorrow</source>
-            <translation>明天</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="51" />
+            <source>The server certificate is invalid.</source>
+            <translation>服務器證書無效</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="215"/>
-            <source>Schedule Reminder</source>
-            <translation>日程提醒</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="54" />
+            <source>Incorrect username or password. Please try again.</source>
+            <translation>用戶名或密碼錯誤，請重試</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="258"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="270"/>
-            <source>%1 to %2</source>
-            <translation>%1 至 %2</translation>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="57" />
+            <source>This server does not support CalDAV.</source>
+            <translation>該服務器不支持CalDAV協議</translation>
         </message>
         <message>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="296"/>
-            <location filename="../calendar-service/src/alarmManager/dalarmmanager.cpp" line="309"/>
-            <source>Today</source>
-            <translation>今天</translation>
+            <source>The server rejected your login request. Please check your account permissions.</source>
+            <translation type="vanished">服務器拒絕了登錄請求，請檢查賬號是否有訪問權限</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="65" />
+            <source>The server denied access.</source>
+            <translation>服務器拒絕訪問</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="68" />
+            <source>The server request timed out.</source>
+            <translation>服務器請求超時</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="72" />
+            <source>Unable to connect to the server. Please check your network connection and server address.</source>
+            <translation>無法連接到服務器，請檢查網絡連接和服務器地址</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-common/src/dcaldavaccountstatus.h" line="76" />
+            <source>Synchronization failed.</source>
+            <translation>同步失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="855" />
+            <source>Sync Failed</source>
+            <translation>同步失敗</translation>
         </message>
     </context>
     <context>
         <name>DragInfoGraphicsView</name>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="48"/>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="49" />
             <source>Edit</source>
             <translation>編輯</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="49"/>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="50" />
             <source>Delete</source>
             <translation>刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="50"/>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="51" />
             <source>New event</source>
             <translation>建立日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/view/draginfographicsview.cpp" line="759"/>
+            <location filename="../src/calendar-client/src/view/draginfographicsview.cpp" line="844" />
             <source>New Event</source>
             <translation>建立日程</translation>
         </message>
@@ -954,176 +1315,193 @@
     <context>
         <name>JobTypeListView</name>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="144"/>
-            <source>export</source>
-            <translation>匯出</translation>
-        </message>
-        <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="219"/>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="308" />
             <source>import ICS file</source>
             <translation>匯入ICS檔案</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="450"/>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="565" />
             <source>You are deleting an event type.</source>
             <translation>您正在刪除日程類型。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="451"/>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="566" />
             <source>All events under this type will be deleted and cannot be recovered.</source>
             <translation>此日程類型下的所有日程都會刪除且不可恢復。</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="452"/>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="567" />
             <source>Cancel</source>
-            <translation>取 消</translation>
             <comment>button</comment>
+            <translation>取 消</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/customWidget/jobtypelistview.cpp" line="453"/>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="568" />
+            <source>Delete</source>
+            <comment>button</comment>
+            <translation>刪 除</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="213" />
+            <source>Edit</source>
+            <translation>編輯</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="219" />
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="233" />
+            <source>Export</source>
+            <translation>導出</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="308" />
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="417" />
+            <source>ICS files (*.ics)</source>
+            <translation>ICS 文件（*.ics）</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="416" />
+            <source>Export ICS file</source>
+            <translation>導出 ICS 文件</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/customWidget/jobtypelistview.cpp" line="216" />
             <source>Delete</source>
             <translation>刪 除</translation>
-            <comment>button</comment>
         </message>
     </context>
     <context>
         <name>QObject</name>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="96"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="127"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="67" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="98" />
             <source>Manage calendar</source>
             <translation>日曆管理</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="112"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="131"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="83" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="102" />
             <source>Event types</source>
             <translation>日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="38"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="50" />
             <source>Account settings</source>
             <translation>帳戶設定</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="42"/>
-            <source>Account</source>
-            <translation>帳戶</translation>
-        </message>
-        <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="53"/>
-            <source>Select items to be synced</source>
-            <translation>設定您的同步項</translation>
-        </message>
-        <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="56"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="559" />
             <source>Events</source>
             <translation>日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="63"/>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="146"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="117" />
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="561" />
             <source>General settings</source>
             <translation>一般設定</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="74"/>
-            <source>Sync interval</source>
-            <translation>同步頻率</translation>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="75" />
+            <source>Associated account</source>
+            <translation>關聯賬戶</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="104"/>
-            <source>Calendar account</source>
-            <translation>日曆帳戶</translation>
-        </message>
-        <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="150"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="121" />
             <source>General</source>
             <translation>通用</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="152"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="123" />
             <source>First day of week</source>
             <translation>每星期開始於</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/settingdialog.cpp" line="153"/>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="124" />
             <source>Time</source>
             <translation>時間</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="59" />
+            <source>Third-party accounts</source>
+            <translation>第三方賬戶</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/dialog/settingdialog.cpp" line="54" />
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
         </message>
     </context>
     <context>
         <name>Return</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="611"/>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="665" />
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Return</comment>
+            <translation>今天</translation>
         </message>
     </context>
     <context>
         <name>Return Today</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="339"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="95"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="277"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="353" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="100" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="283" />
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Return Today</comment>
+            <translation>今天</translation>
         </message>
     </context>
     <context>
         <name>ScheduleTypeEditDlg</name>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22"/>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="48"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="22" />
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="50" />
             <source>New event type</source>
             <translation>新增日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="32"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="33" />
             <source>Edit event type</source>
             <translation>編輯日程類型</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="43"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="45" />
             <source>Import ICS file</source>
             <translation>匯入ICS檔案</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="151"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="158" />
             <source>Name:</source>
             <translation>名稱：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="152"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="159" />
             <source>Color:</source>
             <translation>顏色：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="156"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="164" />
             <source>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt; File:</source>
             <translation>&lt;a href='https://wikipedia.org/wiki/ICalendar'&gt;ICS&lt;/a&gt;檔案：</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="167"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="175" />
             <source>Cancel</source>
+            <comment>button</comment>
             <translation>取 消</translation>
-            <comment>button</comment>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="168"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="176" />
             <source>Save</source>
-            <translation>儲 存</translation>
             <comment>button</comment>
+            <translation>儲 存</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="219"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="232" />
             <source>The name can not only contain whitespaces</source>
             <translation>名稱不能設置為全空格，請修改</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="256"/>
+            <location filename="../src/calendar-client/src/dialog/scheduletypeeditdlg.cpp" line="275" />
             <source>Enter a name please</source>
             <translation>名稱不能為空</translation>
         </message>
@@ -1131,50 +1509,69 @@
     <context>
         <name>Shortcut</name>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="16"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="18" />
             <source>Help</source>
             <translation>幫助</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="17"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="19" />
             <source>Delete event</source>
             <translation>刪除日程</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="20"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="22" />
             <source>Copy</source>
             <translation>複製</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="21"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="23" />
             <source>Cut</source>
             <translation>剪下</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="22"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="24" />
             <source>Paste</source>
             <translation>貼上</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="25"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="27" />
             <source>Delete</source>
             <translation>刪除</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/shortcut.cpp" line="26"/>
+            <location filename="../src/calendar-client/src/shortcut.cpp" line="28" />
             <source>Select all</source>
             <translation>全選</translation>
         </message>
     </context>
     <context>
+        <name>SidebarAccountItemWidget</name>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="344" />
+            <source>Deleting...</source>
+            <translation>刪除同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="345" />
+            <source>Syncing...</source>
+            <translation>同步中...</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="335" />
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebaritemwidget.cpp" line="345" />
+            <source>Sync</source>
+            <translation>同步</translation>
+        </message>
+    </context>
+    <context>
         <name>SidebarCalendarWidget</name>
         <message>
-            <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="135" />
             <source>Y</source>
             <translation>年</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="126"/>
+            <location filename="../src/calendar-client/src/widget/sidebarWidget/sidebarcalendarwidget.cpp" line="135" />
             <source>M</source>
             <translation>月</translation>
         </message>
@@ -1182,31 +1579,36 @@
     <context>
         <name>TimeJumpDialog</name>
         <message>
-            <location filename="../calendar-client/src/dialog/timejumpdialog.cpp" line="29"/>
+            <location filename="../src/calendar-client/src/dialog/timejumpdialog.cpp" line="32" />
             <source>Go</source>
-            <translation>跳 轉</translation>
             <comment>button</comment>
+            <translation>跳 轉</translation>
         </message>
     </context>
     <context>
         <name>UserloginWidget</name>
         <message>
-            <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="48"/>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="105" />
             <source>Sign In</source>
-            <translation>登 入</translation>
             <comment>button</comment>
+            <translation>登 入</translation>
         </message>
         <message>
-            <location filename="../calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="49"/>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="106" />
             <source>Sign Out</source>
-            <translation>退出登入</translation>
             <comment>button</comment>
+            <translation>退出登入</translation>
+        </message>
+        <message>
+            <location filename="../src/calendar-client/src/widget/settingWidget/userloginwidget.cpp" line="203" />
+            <source>Not signed in</source>
+            <translation>未登錄</translation>
         </message>
     </context>
     <context>
         <name>YearFrame</name>
         <message>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="928"/>
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="1020" />
             <source>Y</source>
             <translation>年</translation>
         </message>
@@ -1214,17 +1616,17 @@
     <context>
         <name>today</name>
         <message>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="188"/>
-            <location filename="../calendar-client/src/widget/dayWidget/daymonthview.cpp" line="337"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="93"/>
-            <location filename="../calendar-client/src/widget/monthWidget/monthwindow.cpp" line="230"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="57"/>
-            <location filename="../calendar-client/src/widget/weekWidget/weekwindow.cpp" line="275"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="261"/>
-            <location filename="../calendar-client/src/widget/yearWidget/yearwindow.cpp" line="609"/>
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="200" />
+            <location filename="../src/calendar-client/src/widget/dayWidget/daymonthview.cpp" line="351" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="98" />
+            <location filename="../src/calendar-client/src/widget/monthWidget/monthwindow.cpp" line="261" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="59" />
+            <location filename="../src/calendar-client/src/widget/weekWidget/weekwindow.cpp" line="281" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="288" />
+            <location filename="../src/calendar-client/src/widget/yearWidget/yearwindow.cpp" line="663" />
             <source>Today</source>
-            <translation>今天</translation>
             <comment>Today</comment>
+            <translation>今天</translation>
         </message>
     </context>
 </TS>

--- a/translations/desktop/desktop_zh_HK.ts
+++ b/translations/desktop/desktop_zh_HK.ts
@@ -1,1 +1,22 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="zh_HK" version="2.1"><context><name>desktop</name><message><location filename="Desktop Entry]GenericName" line="0"/><source>Calendar</source><translation>日曆</translation></message><message><location filename="Desktop Entry]Comment" line="0"/><source>Calendar is a date tool.</source><translation>日曆是一款查看日期的小工具。</translation></message><message><location filename="Desktop Entry]Name" line="0"/><source>Deepin Calendar</source><translation>深度日曆</translation></message></context></TS>
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE TS>
+<TS language="zh_HK" version="2.1">
+    <context>
+        <name>desktop</name>
+        <message>
+            <location filename="Desktop Entry]GenericName" line="0" />
+            <source>Calendar</source>
+            <translation>日曆</translation>
+        </message>
+        <message>
+            <location filename="Desktop Entry]Comment" line="0" />
+            <source>Calendar is a date tool.</source>
+            <translation>日曆是一款查看日期的小工具。</translation>
+        </message>
+        <message>
+            <location filename="Desktop Entry]Name" line="0" />
+            <source>Deepin Calendar</source>
+            <translation>深度日曆</translation>
+        </message>
+    </context>
+</TS>

--- a/translations/desktop/desktop_zh_TW.ts
+++ b/translations/desktop/desktop_zh_TW.ts
@@ -1,1 +1,22 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="zh_TW" version="2.1"><context><name>desktop</name><message><location filename="Desktop Entry]GenericName" line="0"/><source>Calendar</source><translation>日曆</translation></message><message><location filename="Desktop Entry]Comment" line="0"/><source>Calendar is a date tool.</source><translation>簡易日期顯示工具</translation></message><message><location filename="Desktop Entry]Name" line="0"/><source>Deepin Calendar</source><translation>Deepin 日曆</translation></message></context></TS>
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE TS>
+<TS language="zh_TW" version="2.1">
+    <context>
+        <name>desktop</name>
+        <message>
+            <location filename="Desktop Entry]GenericName" line="0" />
+            <source>Calendar</source>
+            <translation>日曆</translation>
+        </message>
+        <message>
+            <location filename="Desktop Entry]Comment" line="0" />
+            <source>Calendar is a date tool.</source>
+            <translation>簡易日期顯示工具</translation>
+        </message>
+        <message>
+            <location filename="Desktop Entry]Name" line="0" />
+            <source>Deepin Calendar</source>
+            <translation>Deepin 日曆</translation>
+        </message>
+    </context>
+</TS>


### PR DESCRIPTION
根据 zh_CN 更新日历的繁体中文翻译（zh_HK 和 zh_TW）

## 变更内容
- 基于 zh_CN 源文件同步更新 zh_HK 和 zh_TW 繁体中文翻译
- 覆盖 dde-calendar、dde-calendar-service、desktop 三个模块
- 保留已有翻译，补充新增翻译，修复遗留简体字

## 翻译统计
| 模块 | 语言 | 保留已有 | 新增转换 | 修复简体字 |
|------|------|----------|----------|------------|
| dde-calendar | zh_HK | 183 | 99 | 4 |
| dde-calendar | zh_TW | 183 | 99 | 3 |
| dde-calendar-service | zh_HK | 201 | 25 | 4 |
| dde-calendar-service | zh_TW | 201 | 25 | 3 |
| desktop | zh_HK | 3 | 0 | 0 |
| desktop | zh_TW | 3 | 0 | 0 |

## 验证
- XML 结构完整性：✅ 通过
- 占位符（%1、%2 等）保留：✅ 通过
- HTML 实体（&amp; 等）保留：✅ 通过
- 无遗留简体字：✅ 通过